### PR TITLE
[codex] isolate DGM execution surfaces in docker

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Thank you for your interest in contributing to the Darwin Gödel Machine project
 
 ### Prerequisites
 - Python 3.8+
-- Docker is optional today. Docker-based isolation is planned but not yet wired into runtime execution; use your own container or VM for untrusted evolution runs.
+- Docker is optional. The current opt-in Docker path isolates generated benchmark test scripts only; use your own container or VM for untrusted evolution runs.
 - API keys for foundation models (Claude, Gemini, or OpenAI) are needed for live DGM runs, not for the default test suite.
 
 ### Setup
@@ -78,7 +78,7 @@ python run_dgm.py
 ### Security
 - Never commit API keys or secrets
 - Follow security guidelines in SECURITY.md
-- Treat model-written code as untrusted. Until Docker isolation lands, run untrusted experiments inside your own container or VM.
+- Treat model-written code as untrusted. The built-in Docker path does not yet isolate full agent solving, tool use, or self-modification.
 - Report security issues privately via GitHub Security tab
 
 ## 🏗️ Architecture

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Thank you for your interest in contributing to the Darwin Gödel Machine project
 
 ### Prerequisites
 - Python 3.8+
-- Docker is optional. The current opt-in Docker path isolates generated benchmark test scripts and agent bash tool commands; use your own container or VM for untrusted evolution runs.
+- Docker is optional. The current opt-in Docker path isolates generated benchmark test scripts plus agent bash and edit tool operations; use your own container or VM for untrusted evolution runs.
 - API keys for foundation models (Claude, Gemini, or OpenAI) are needed for live DGM runs, not for the default test suite.
 
 ### Setup
@@ -78,7 +78,7 @@ python run_dgm.py
 ### Security
 - Never commit API keys or secrets
 - Follow security guidelines in SECURITY.md
-- Treat model-written code as untrusted. The built-in Docker path does not yet isolate the model orchestration loop, file-edit tool, or controller/archive logic.
+- Treat model-written code as untrusted. The built-in Docker path does not yet isolate the model orchestration loop or controller/archive logic.
 - Report security issues privately via GitHub Security tab
 
 ## 🏗️ Architecture

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Thank you for your interest in contributing to the Darwin Gödel Machine project
 
 ### Prerequisites
 - Python 3.8+
-- Docker is optional. The current opt-in Docker path isolates generated benchmark test scripts only; use your own container or VM for untrusted evolution runs.
+- Docker is optional. The current opt-in Docker path isolates generated benchmark test scripts and agent bash tool commands; use your own container or VM for untrusted evolution runs.
 - API keys for foundation models (Claude, Gemini, or OpenAI) are needed for live DGM runs, not for the default test suite.
 
 ### Setup
@@ -78,7 +78,7 @@ python run_dgm.py
 ### Security
 - Never commit API keys or secrets
 - Follow security guidelines in SECURITY.md
-- Treat model-written code as untrusted. The built-in Docker path does not yet isolate full agent solving, tool use, or self-modification.
+- Treat model-written code as untrusted. The built-in Docker path does not yet isolate the model orchestration loop, file-edit tool, or controller/archive logic.
 - Report security issues privately via GitHub Security tab
 
 ## 🏗️ Architecture

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Thank you for your interest in contributing to the Darwin Gödel Machine project
 
 ### Prerequisites
 - Python 3.8+
-- Docker is optional. The current opt-in Docker path isolates generated benchmark test scripts plus agent bash and edit tool operations; use your own container or VM for untrusted evolution runs.
+- Docker is optional. The current opt-in Docker path isolates generated benchmark test scripts, agent bash/edit tool operations, and modified-agent runtime load checks; use your own container or VM for untrusted evolution runs.
 - API keys for foundation models (Claude, Gemini, or OpenAI) are needed for live DGM runs, not for the default test suite.
 
 ### Setup

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ For more details, see the [official blog post](https://sakana.ai/dgm/) from Saka
 - **🛠️ Tool-Equipped Agents**: Agents use Bash and file editing tools to solve problems
 - **🏪 Agent Archive System**: Stores successful agents with performance and novelty metrics
 - **🎯 Benchmark-Driven Evolution**: Uses custom coding challenges to measure improvement
-- **🔒 Guarded Execution**: Workspace-scoped file access, command filtering, hard timeouts, and opt-in Docker isolation for benchmark test scripts and agent bash commands
+- **🔒 Guarded Execution**: Workspace-scoped file access, command filtering, hard timeouts, and opt-in Docker isolation for benchmark test scripts plus agent bash/edit operations
 
 ## 🚀 Quick Start
 
@@ -79,7 +79,7 @@ dgm_settings:
   sandbox_timeout: 300
 
 evaluation:
-  use_sandbox: false  # set true to run benchmark tests and bash tool commands in Docker when available
+  use_sandbox: false  # set true to run benchmark tests and agent bash/edit operations in Docker when available
 
 sandbox:
   image_name: dgm-sandbox
@@ -280,12 +280,12 @@ Results are stored in the `results/` directory with detailed JSON reports.
 - **Workspace Containment**: File edits and bash redirects are resolved and confined to the agent's workspace; path-traversal escapes are rejected
 - **Command Filtering**: Dangerous commands are blocked before execution
 - **Hard Timeouts**: Benchmark and tool subprocesses are killed (entire process group) on timeout
-- **Opt-in Docker Command Isolation**: With `evaluation.use_sandbox: true`, generated benchmark test scripts and agent bash tool commands run in one-shot Docker containers with image, memory, CPU, timeout, and network settings from `sandbox`
+- **Opt-in Docker Command Isolation**: With `evaluation.use_sandbox: true`, generated benchmark test scripts plus agent bash and edit tool operations run in one-shot Docker containers with image, memory, CPU, timeout, and network settings from `sandbox`
 - **Validation Checks**: Modified agents must parse, define a working Agent class, and load before admission to the archive
 - **Human Oversight**: Optional pause points for review
 - **Comprehensive Logging**: Full audit trail of all changes
 
-> **Note**: Docker isolation currently covers generated benchmark test scripts and bash tool commands. The model orchestration loop, file-edit tool, and archive/controller logic still execute in the configured host workspace with guards and timeouts, so run untrusted evolution experiments inside your own container or VM.
+> **Note**: Docker isolation currently covers generated benchmark test scripts plus agent bash and edit tool operations. The model orchestration loop and archive/controller logic still execute in the configured host workspace with guards and timeouts, so run untrusted evolution experiments inside your own container or VM.
 
 ## 🐛 Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ For more details, see the [official blog post](https://sakana.ai/dgm/) from Saka
 - **🛠️ Tool-Equipped Agents**: Agents use Bash and file editing tools to solve problems
 - **🏪 Agent Archive System**: Stores successful agents with performance and novelty metrics
 - **🎯 Benchmark-Driven Evolution**: Uses custom coding challenges to measure improvement
-- **🔒 Guarded Execution**: Workspace-scoped file access, command filtering, hard timeouts, and opt-in Docker isolation for benchmark test scripts plus agent bash/edit operations
+- **🔒 Guarded Execution**: Workspace-scoped file access, command filtering, hard timeouts, and opt-in Docker isolation for benchmark test scripts, agent bash/edit operations, and modified-agent runtime load checks
 
 ## 🚀 Quick Start
 
@@ -79,7 +79,7 @@ dgm_settings:
   sandbox_timeout: 300
 
 evaluation:
-  use_sandbox: false  # set true to run benchmark tests and agent bash/edit operations in Docker when available
+  use_sandbox: false  # set true to run benchmark tests, agent tools, and runtime load checks in Docker when available
 
 sandbox:
   image_name: dgm-sandbox
@@ -281,11 +281,11 @@ Results are stored in the `results/` directory with detailed JSON reports.
 - **Command Filtering**: Dangerous commands are blocked before execution
 - **Hard Timeouts**: Benchmark and tool subprocesses are killed (entire process group) on timeout
 - **Opt-in Docker Command Isolation**: With `evaluation.use_sandbox: true`, generated benchmark test scripts plus agent bash and edit tool operations run in one-shot Docker containers with image, memory, CPU, timeout, and network settings from `sandbox`
-- **Validation Checks**: Modified agents must parse, define a working Agent class, and load before admission to the archive
+- **Validation Checks**: Modified agents must parse, define a working Agent class, and pass a runtime load check before admission to the archive; with sandboxing enabled, the runtime load check runs in Docker
 - **Human Oversight**: Optional pause points for review
 - **Comprehensive Logging**: Full audit trail of all changes
 
-> **Note**: Docker isolation currently covers generated benchmark test scripts plus agent bash and edit tool operations. The model orchestration loop and archive/controller logic still execute in the configured host workspace with guards and timeouts, so run untrusted evolution experiments inside your own container or VM.
+> **Note**: Docker isolation currently covers generated benchmark test scripts, agent bash/edit operations, and modified-agent runtime load checks. The model orchestration loop and archive/controller logic still execute in the configured host workspace with guards and timeouts, so run untrusted evolution experiments inside your own container or VM.
 
 ## 🐛 Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ For more details, see the [official blog post](https://sakana.ai/dgm/) from Saka
 - **🛠️ Tool-Equipped Agents**: Agents use Bash and file editing tools to solve problems
 - **🏪 Agent Archive System**: Stores successful agents with performance and novelty metrics
 - **🎯 Benchmark-Driven Evolution**: Uses custom coding challenges to measure improvement
-- **🔒 Guarded Execution**: Workspace-scoped file access, command filtering, and hard timeouts with process-group cleanup (Docker isolation is planned, not yet implemented)
+- **🔒 Guarded Execution**: Workspace-scoped file access, command filtering, hard timeouts, and opt-in Docker isolation for generated benchmark test scripts
 
 ## 🚀 Quick Start
 
@@ -77,6 +77,16 @@ dgm_settings:
   max_iterations: 100
   pause_after_iteration: true
   sandbox_timeout: 300
+
+evaluation:
+  use_sandbox: false  # set true to run benchmark test scripts in Docker when available
+
+sandbox:
+  image_name: dgm-sandbox
+  auto_build_image: true
+  memory_limit: 2g
+  cpu_limit: "1"
+  network_mode: none
 
 benchmarks:
   enabled:
@@ -270,11 +280,12 @@ Results are stored in the `results/` directory with detailed JSON reports.
 - **Workspace Containment**: File edits and bash redirects are resolved and confined to the agent's workspace; path-traversal escapes are rejected
 - **Command Filtering**: Dangerous commands are blocked before execution
 - **Hard Timeouts**: Benchmark and tool subprocesses are killed (entire process group) on timeout
+- **Opt-in Docker Benchmark Isolation**: With `evaluation.use_sandbox: true`, generated benchmark test scripts run in one-shot Docker containers with image, memory, CPU, timeout, and network settings from `sandbox`
 - **Validation Checks**: Modified agents must parse, define a working Agent class, and load before admission to the archive
 - **Human Oversight**: Optional pause points for review
 - **Comprehensive Logging**: Full audit trail of all changes
 
-> **Note**: execution is guarded but not fully isolated — Docker-based sandboxing is planned (`sandbox/` contains the stub). Run untrusted evolution experiments inside a container or VM.
+> **Note**: Docker isolation currently covers generated benchmark test scripts only. Agent solving, tool use, and self-modification still execute in the configured workspace with guards and timeouts, so run untrusted evolution experiments inside your own container or VM.
 
 ## 🐛 Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ For more details, see the [official blog post](https://sakana.ai/dgm/) from Saka
 - **🛠️ Tool-Equipped Agents**: Agents use Bash and file editing tools to solve problems
 - **🏪 Agent Archive System**: Stores successful agents with performance and novelty metrics
 - **🎯 Benchmark-Driven Evolution**: Uses custom coding challenges to measure improvement
-- **🔒 Guarded Execution**: Workspace-scoped file access, command filtering, hard timeouts, and opt-in Docker isolation for generated benchmark test scripts
+- **🔒 Guarded Execution**: Workspace-scoped file access, command filtering, hard timeouts, and opt-in Docker isolation for benchmark test scripts and agent bash commands
 
 ## 🚀 Quick Start
 
@@ -79,7 +79,7 @@ dgm_settings:
   sandbox_timeout: 300
 
 evaluation:
-  use_sandbox: false  # set true to run benchmark test scripts in Docker when available
+  use_sandbox: false  # set true to run benchmark tests and bash tool commands in Docker when available
 
 sandbox:
   image_name: dgm-sandbox
@@ -280,12 +280,12 @@ Results are stored in the `results/` directory with detailed JSON reports.
 - **Workspace Containment**: File edits and bash redirects are resolved and confined to the agent's workspace; path-traversal escapes are rejected
 - **Command Filtering**: Dangerous commands are blocked before execution
 - **Hard Timeouts**: Benchmark and tool subprocesses are killed (entire process group) on timeout
-- **Opt-in Docker Benchmark Isolation**: With `evaluation.use_sandbox: true`, generated benchmark test scripts run in one-shot Docker containers with image, memory, CPU, timeout, and network settings from `sandbox`
+- **Opt-in Docker Command Isolation**: With `evaluation.use_sandbox: true`, generated benchmark test scripts and agent bash tool commands run in one-shot Docker containers with image, memory, CPU, timeout, and network settings from `sandbox`
 - **Validation Checks**: Modified agents must parse, define a working Agent class, and load before admission to the archive
 - **Human Oversight**: Optional pause points for review
 - **Comprehensive Logging**: Full audit trail of all changes
 
-> **Note**: Docker isolation currently covers generated benchmark test scripts only. Agent solving, tool use, and self-modification still execute in the configured workspace with guards and timeouts, so run untrusted evolution experiments inside your own container or VM.
+> **Note**: Docker isolation currently covers generated benchmark test scripts and bash tool commands. The model orchestration loop, file-edit tool, and archive/controller logic still execute in the configured host workspace with guards and timeouts, so run untrusted evolution experiments inside your own container or VM.
 
 ## 🐛 Troubleshooting
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -26,14 +26,14 @@ cp .env.example .env
 - Benchmark and tool subprocesses run under hard timeouts, and the entire process group is killed on expiry
 - Agent modifications must parse, define a working Agent class, and load successfully before archive admission
 
-### Docker Benchmark Isolation (opt-in)
-- Set `evaluation.use_sandbox: true` to run generated benchmark test scripts in one-shot Docker containers when Docker is available
+### Docker Command Isolation (opt-in)
+- Set `evaluation.use_sandbox: true` to run generated benchmark test scripts and agent bash tool commands in one-shot Docker containers when Docker is available
 - Sandbox containers use the configured memory, CPU, timeout, working directory, and `network_mode: none` defaults from `config/dgm_config.yaml`
 - The sandbox image is built automatically when `sandbox.auto_build_image: true`
-- If Docker or the sandbox image is unavailable, benchmark execution falls back to the direct subprocess path rather than failing the default no-Docker workflow
+- If Docker or the sandbox image is unavailable, benchmark and bash command execution fall back to the direct subprocess path rather than failing the default no-Docker workflow
 
 ### Remaining Isolation Limits
-- Agent solving, tool use, and self-modification still execute in the configured workspace on the host
+- The model orchestration loop, file-edit tool, and archive/controller logic still execute in the configured workspace on the host
 - Treat every evolution run as executing model-written code on your machine: run inside your own container or VM if that is not acceptable
 
 ### Input Validation

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -27,11 +27,12 @@ cp .env.example .env
 - Agent modifications must parse, define a working Agent class, and load successfully before archive admission
 
 ### Docker Command Isolation (opt-in)
-- Set `evaluation.use_sandbox: true` to run generated benchmark test scripts plus agent bash and edit tool operations in one-shot Docker containers when Docker is available
+- Set `evaluation.use_sandbox: true` to run generated benchmark test scripts, agent bash/edit tool operations, and modified-agent runtime load checks in one-shot Docker containers when Docker is available
 - Sandbox containers use the configured memory, CPU, timeout, working directory, and `network_mode: none` defaults from `config/dgm_config.yaml`
 - Edit tool operations are applied to a staged workspace mounted into the sandbox and then synced back to the configured host workspace
+- Modified-agent runtime load validation stages the candidate agent code into the sandbox before importing it
 - The sandbox image is built automatically when `sandbox.auto_build_image: true`
-- If Docker or the sandbox image is unavailable, benchmark and agent tool execution fall back to the direct host path rather than failing the default no-Docker workflow
+- If Docker or the sandbox image is unavailable, benchmark execution, agent tool execution, and runtime load validation fall back to the direct host path rather than failing the default no-Docker workflow
 
 ### Remaining Isolation Limits
 - The model orchestration loop and archive/controller logic still execute in the configured workspace on the host

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -27,13 +27,14 @@ cp .env.example .env
 - Agent modifications must parse, define a working Agent class, and load successfully before archive admission
 
 ### Docker Command Isolation (opt-in)
-- Set `evaluation.use_sandbox: true` to run generated benchmark test scripts and agent bash tool commands in one-shot Docker containers when Docker is available
+- Set `evaluation.use_sandbox: true` to run generated benchmark test scripts plus agent bash and edit tool operations in one-shot Docker containers when Docker is available
 - Sandbox containers use the configured memory, CPU, timeout, working directory, and `network_mode: none` defaults from `config/dgm_config.yaml`
+- Edit tool operations are applied to a staged workspace mounted into the sandbox and then synced back to the configured host workspace
 - The sandbox image is built automatically when `sandbox.auto_build_image: true`
-- If Docker or the sandbox image is unavailable, benchmark and bash command execution fall back to the direct subprocess path rather than failing the default no-Docker workflow
+- If Docker or the sandbox image is unavailable, benchmark and agent tool execution fall back to the direct host path rather than failing the default no-Docker workflow
 
 ### Remaining Isolation Limits
-- The model orchestration loop, file-edit tool, and archive/controller logic still execute in the configured workspace on the host
+- The model orchestration loop and archive/controller logic still execute in the configured workspace on the host
 - Treat every evolution run as executing model-written code on your machine: run inside your own container or VM if that is not acceptable
 
 ### Input Validation

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -26,9 +26,15 @@ cp .env.example .env
 - Benchmark and tool subprocesses run under hard timeouts, and the entire process group is killed on expiry
 - Agent modifications must parse, define a working Agent class, and load successfully before archive admission
 
-### Isolation (planned, NOT yet implemented)
-- Docker-based container isolation is stubbed in `sandbox/` and not wired in — agent code currently executes as host subprocesses
-- Until it lands, treat every evolution run as executing model-written code on your machine: run inside a container or VM if that is not acceptable
+### Docker Benchmark Isolation (opt-in)
+- Set `evaluation.use_sandbox: true` to run generated benchmark test scripts in one-shot Docker containers when Docker is available
+- Sandbox containers use the configured memory, CPU, timeout, working directory, and `network_mode: none` defaults from `config/dgm_config.yaml`
+- The sandbox image is built automatically when `sandbox.auto_build_image: true`
+- If Docker or the sandbox image is unavailable, benchmark execution falls back to the direct subprocess path rather than failing the default no-Docker workflow
+
+### Remaining Isolation Limits
+- Agent solving, tool use, and self-modification still execute in the configured workspace on the host
+- Treat every evolution run as executing model-written code on your machine: run inside your own container or VM if that is not acceptable
 
 ### Input Validation
 - All agent modifications are validated before execution

--- a/agent/agent.py
+++ b/agent/agent.py
@@ -127,8 +127,13 @@ class Agent:
         )
         self.tool_registry.register_tool(bash_tool)
         
-        # Register edit tool (placeholder for now)
-        edit_tool = EditTool(working_directory=str(self.working_directory))
+        # Register edit tool
+        edit_tool = EditTool(
+            working_directory=str(self.working_directory),
+            sandbox_manager=self.config.sandbox_manager,
+            use_sandbox=self.config.use_sandbox,
+            timeout=self.config.tool_timeout,
+        )
         self.tool_registry.register_tool(edit_tool)
     
     async def solve_task(self, task: Task) -> Dict[str, Any]:

--- a/agent/agent.py
+++ b/agent/agent.py
@@ -51,6 +51,8 @@ class AgentConfig:
     tool_timeout: int = 30
     max_iterations: int = 10
     memory_limit: Optional[int] = None
+    sandbox_manager: Optional[Any] = None
+    use_sandbox: bool = False
 
 
 class Agent:
@@ -119,7 +121,9 @@ class Agent:
         # Register bash tool
         bash_tool = BashTool(
             working_directory=str(self.working_directory),
-            timeout=self.config.tool_timeout
+            timeout=self.config.tool_timeout,
+            sandbox_manager=self.config.sandbox_manager,
+            use_sandbox=self.config.use_sandbox,
         )
         self.tool_registry.register_tool(bash_tool)
         

--- a/agent/tools/bash_tool.py
+++ b/agent/tools/bash_tool.py
@@ -82,10 +82,21 @@ class BashTool(BaseTool):
         """Return True when sandboxed command execution is configured."""
         if not self.use_sandbox or self.sandbox_manager is None:
             return False
+        readiness_check = getattr(self.sandbox_manager, "is_sandbox_ready", None)
+        if readiness_check is not None:
+            return bool(readiness_check())
         availability_check = getattr(self.sandbox_manager, "is_docker_available", None)
         if availability_check is None:
             return True
-        return bool(availability_check())
+        if not bool(availability_check()):
+            return False
+        ensure_image = getattr(self.sandbox_manager, "ensure_sandbox_image", None)
+        if ensure_image is not None:
+            try:
+                ensure_image()
+            except Exception:
+                return False
+        return True
     
     def get_name(self) -> str:
         """Get the name of this tool."""

--- a/agent/tools/bash_tool.py
+++ b/agent/tools/bash_tool.py
@@ -8,9 +8,11 @@ with safety restrictions and timeout handling.
 import asyncio
 import os
 import re
+import shutil
 import shlex
 import signal
 import subprocess
+import tempfile
 from pathlib import Path
 from typing import Dict, Any, List
 import time
@@ -27,16 +29,26 @@ class BashTool(BaseTool):
     measures to prevent dangerous operations.
     """
     
-    def __init__(self, working_directory: str = None, timeout: int = 30):
+    def __init__(
+        self,
+        working_directory: str = None,
+        timeout: int = 30,
+        sandbox_manager: Any = None,
+        use_sandbox: bool = False,
+    ):
         """
         Initialize the Bash tool.
         
         Args:
             working_directory: Directory to execute commands in
             timeout: Default timeout for command execution
+            sandbox_manager: Optional Docker sandbox manager for command execution
+            use_sandbox: Whether to execute commands through the sandbox when available
         """
         self.working_directory = working_directory or os.getcwd()
         self.default_timeout = timeout
+        self.sandbox_manager = sandbox_manager
+        self.use_sandbox = use_sandbox
         
         # Commands that are blocked for safety
         self.blocked_commands = {
@@ -65,6 +77,15 @@ class BashTool(BaseTool):
             for key, value in os.environ.items()
             if not any(term in key.lower() for term in sensitive_terms)
         }
+
+    def _can_use_sandbox(self) -> bool:
+        """Return True when sandboxed command execution is configured."""
+        if not self.use_sandbox or self.sandbox_manager is None:
+            return False
+        availability_check = getattr(self.sandbox_manager, "is_docker_available", None)
+        if availability_check is None:
+            return True
+        return bool(availability_check())
     
     def get_name(self) -> str:
         """Get the name of this tool."""
@@ -141,6 +162,18 @@ class BashTool(BaseTool):
             
             # Handle special commands
             first_word = command.split()[0] if command.split() else ""
+            if first_word in {"cd", "pwd"}:
+                return await self.restricted_commands[first_word](command, timeout)
+
+            if self._can_use_sandbox():
+                result = await self._execute_sandbox_command(
+                    command,
+                    timeout,
+                    capture_output,
+                )
+                result.execution_time = time.time() - start_time
+                return result
+
             if first_word in self.restricted_commands:
                 return await self.restricted_commands[first_word](command, timeout)
             
@@ -160,6 +193,76 @@ class BashTool(BaseTool):
                 error=f"Failed to execute command: {str(e)}",
                 execution_time=execution_time
             )
+
+    async def _execute_sandbox_command(
+        self,
+        command: str,
+        timeout: int,
+        capture_output: bool,
+    ) -> ToolResult:
+        """Execute a shell command through the configured Docker sandbox."""
+        sandbox_temp_parent = Path.home() / ".cache" / "dgm-sandbox"
+        sandbox_temp_parent.mkdir(parents=True, exist_ok=True)
+        with tempfile.TemporaryDirectory(dir=str(sandbox_temp_parent)) as temp_dir:
+            staged_workspace = Path(temp_dir)
+            self._copy_workspace(
+                source=Path(self.working_directory),
+                destination=staged_workspace,
+            )
+            sandbox_result = await self.sandbox_manager.execute_in_sandbox(
+                command=command,
+                workspace_path=str(staged_workspace),
+                timeout=timeout,
+            )
+            self._copy_workspace(
+                source=staged_workspace,
+                destination=Path(self.working_directory),
+            )
+
+        timed_out = (
+            sandbox_result.exit_code is None
+            and "timed out" in (sandbox_result.error or "").lower()
+        )
+        if sandbox_result.success:
+            status = ToolExecutionStatus.SUCCESS
+        elif timed_out:
+            status = ToolExecutionStatus.TIMEOUT
+        else:
+            status = ToolExecutionStatus.ERROR
+
+        return ToolResult(
+            status=status,
+            output=sandbox_result.output if capture_output else "",
+            error=sandbox_result.error,
+            metadata={
+                "exit_code": sandbox_result.exit_code,
+                "sandboxed": True,
+            },
+            execution_time=sandbox_result.execution_time,
+        )
+
+    @staticmethod
+    def _copy_workspace(source: Path, destination: Path) -> None:
+        """Copy workspace files while skipping generated Python cache files."""
+        source = source.resolve()
+        destination = destination.resolve()
+        if not source.exists():
+            destination.mkdir(parents=True, exist_ok=True)
+            return
+
+        def ignore(_dir: str, names: List[str]) -> set:
+            return {
+                name
+                for name in names
+                if name == "__pycache__" or name.endswith((".pyc", ".pyo"))
+            }
+
+        shutil.copytree(
+            source,
+            destination,
+            dirs_exist_ok=True,
+            ignore=ignore,
+        )
     
     def _check_command_safety(self, command: str) -> Dict[str, Any]:
         """

--- a/agent/tools/edit_tool.py
+++ b/agent/tools/edit_tool.py
@@ -132,10 +132,21 @@ class EditTool(BaseTool):
         """Return True when sandboxed edit execution is configured."""
         if not self.use_sandbox or self.sandbox_manager is None:
             return False
+        readiness_check = getattr(self.sandbox_manager, "is_sandbox_ready", None)
+        if readiness_check is not None:
+            return bool(readiness_check())
         availability_check = getattr(self.sandbox_manager, "is_docker_available", None)
         if availability_check is None:
             return True
-        return bool(availability_check())
+        if not bool(availability_check()):
+            return False
+        ensure_image = getattr(self.sandbox_manager, "ensure_sandbox_image", None)
+        if ensure_image is not None:
+            try:
+                ensure_image()
+            except Exception:
+                return False
+        return True
     
     def get_name(self) -> str:
         """Get the name of this tool."""

--- a/agent/tools/edit_tool.py
+++ b/agent/tools/edit_tool.py
@@ -4,10 +4,64 @@ Edit tool implementation for file manipulation.
 This tool allows the DGM agent to read, write, and modify files.
 """
 
+import json
 import os
+import shlex
+import shutil
+import tempfile
+import time
 from pathlib import Path
 from typing import Dict, Any, List
 from .base_tool import BaseTool, ToolResult, ToolExecutionStatus, ToolParameter
+
+
+_EDIT_TOOL_RUNNER = r"""
+import asyncio
+import importlib.util
+import json
+import sys
+import types
+from pathlib import Path
+
+
+def load_edit_tool():
+    code_root = Path("/home/dgm_agent/agent_code")
+    agent_pkg = types.ModuleType("agent")
+    agent_pkg.__path__ = [str(code_root / "agent")]
+    sys.modules.setdefault("agent", agent_pkg)
+
+    tools_pkg = types.ModuleType("agent.tools")
+    tools_pkg.__path__ = [str(code_root / "agent" / "tools")]
+    sys.modules.setdefault("agent.tools", tools_pkg)
+
+    spec = importlib.util.spec_from_file_location(
+        "agent.tools.edit_tool",
+        code_root / "agent" / "tools" / "edit_tool.py",
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module.EditTool
+
+
+async def main():
+    if len(sys.argv) != 2:
+        raise SystemExit("Usage: edit_tool_runner.py PARAMS_JSON")
+
+    params_file = Path(sys.argv[1]).resolve()
+    parameters = json.loads(params_file.read_text(encoding="utf-8"))
+    edit_tool = load_edit_tool()(working_directory=str(Path.cwd()))
+    result = await edit_tool._execute_direct(parameters)
+    print(json.dumps({
+        "status": result.status.value,
+        "output": result.output,
+        "error": result.error or "",
+    }))
+
+
+if __name__ == "__main__":
+    asyncio.run(main())
+"""
 
 
 def _resolve_and_check(
@@ -52,15 +106,36 @@ class EditTool(BaseTool):
     will be implemented in a later phase of the MVP development.
     """
     
-    def __init__(self, working_directory: str = None):
+    def __init__(
+        self,
+        working_directory: str = None,
+        sandbox_manager: Any = None,
+        use_sandbox: bool = False,
+        timeout: int = 30,
+    ):
         """
         Initialize the Edit tool.
         
         Args:
             working_directory: Directory to operate in
+            sandbox_manager: Optional Docker sandbox manager for file operations
+            use_sandbox: Whether to execute edits through the sandbox when available
+            timeout: Default timeout for sandboxed edit operations
         """
         self.working_directory = working_directory
+        self.sandbox_manager = sandbox_manager
+        self.use_sandbox = use_sandbox
+        self.default_timeout = timeout
         super().__init__()
+
+    def _can_use_sandbox(self) -> bool:
+        """Return True when sandboxed edit execution is configured."""
+        if not self.use_sandbox or self.sandbox_manager is None:
+            return False
+        availability_check = getattr(self.sandbox_manager, "is_docker_available", None)
+        if availability_check is None:
+            return True
+        return bool(availability_check())
     
     def get_name(self) -> str:
         """Get the name of this tool."""
@@ -143,6 +218,17 @@ class EditTool(BaseTool):
                 output="",
                 error="File path parameter is required",
             )
+
+        if self.working_directory and self._can_use_sandbox():
+            return await self._execute_sandbox_edit(parameters)
+
+        return await self._execute_direct(parameters)
+
+    async def _execute_direct(self, parameters: Dict[str, Any]) -> ToolResult:
+        """Execute the edit operation directly in the configured workspace."""
+        action = parameters.get("action")
+        file_path_str = parameters.get("file_path")
+        content = parameters.get("content", "")
 
         # Resolve path and verify containment.
         if self.working_directory:
@@ -268,6 +354,147 @@ class EditTool(BaseTool):
                 output="",
                 error=f"Error executing {action} on {file_path_str}: {str(e)}",
             )
+
+    async def _execute_sandbox_edit(self, parameters: Dict[str, Any]) -> ToolResult:
+        """Execute the edit operation inside the configured Docker sandbox."""
+        started_at = time.time()
+        sandbox_temp_parent = Path.home() / ".cache" / "dgm-sandbox"
+        sandbox_temp_parent.mkdir(parents=True, exist_ok=True)
+
+        with tempfile.TemporaryDirectory(dir=str(sandbox_temp_parent)) as temp_dir:
+            temp_path = Path(temp_dir)
+            staged_workspace = temp_path / "workspace"
+            agent_code_dir = temp_path / "agent_code"
+            tool_code_dir = agent_code_dir / "agent" / "tools"
+            tool_code_dir.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(Path(__file__), tool_code_dir / "edit_tool.py")
+            shutil.copy2(
+                Path(__file__).with_name("base_tool.py"),
+                tool_code_dir / "base_tool.py",
+            )
+            self._copy_workspace(
+                source=Path(self.working_directory),
+                destination=staged_workspace,
+            )
+
+            params_path = staged_workspace / ".dgm_edit_tool_params.json"
+            params_path.write_text(json.dumps(parameters), encoding="utf-8")
+
+            sandbox_result = await self.sandbox_manager.execute_in_sandbox(
+                command=(
+                    f"python3 -c {shlex.quote(_EDIT_TOOL_RUNNER)} "
+                    ".dgm_edit_tool_params.json"
+                ),
+                agent_code_path=str(agent_code_dir),
+                workspace_path=str(staged_workspace),
+                timeout=self.default_timeout,
+            )
+
+            try:
+                params_path.unlink(missing_ok=True)
+            except TypeError:  # pragma: no cover - Python < 3.8
+                if params_path.exists():
+                    params_path.unlink()
+
+            if not sandbox_result.success:
+                timed_out = (
+                    sandbox_result.exit_code is None
+                    and "timed out" in (sandbox_result.error or "").lower()
+                )
+                return ToolResult(
+                    status=(
+                        ToolExecutionStatus.TIMEOUT
+                        if timed_out
+                        else ToolExecutionStatus.ERROR
+                    ),
+                    output=sandbox_result.output,
+                    error=sandbox_result.error,
+                    metadata={
+                        "exit_code": sandbox_result.exit_code,
+                        "sandboxed": True,
+                    },
+                    execution_time=(
+                        sandbox_result.execution_time or time.time() - started_at
+                    ),
+                )
+
+            parsed_result = self._parse_sandbox_result(sandbox_result.output)
+            parsed_result.metadata = {
+                **(parsed_result.metadata or {}),
+                "exit_code": sandbox_result.exit_code,
+                "sandboxed": True,
+            }
+            parsed_result.execution_time = (
+                sandbox_result.execution_time or time.time() - started_at
+            )
+
+            self._copy_workspace(
+                source=staged_workspace,
+                destination=Path(self.working_directory),
+            )
+            self._apply_successful_delete_to_host(parameters, parsed_result)
+            return parsed_result
+
+    @staticmethod
+    def _parse_sandbox_result(output: str) -> ToolResult:
+        """Parse the JSON result emitted by the sandbox edit runner."""
+        try:
+            payload = json.loads(output)
+            status = ToolExecutionStatus(payload.get("status", "error"))
+            return ToolResult(
+                status=status,
+                output=payload.get("output", ""),
+                error=payload.get("error", ""),
+            )
+        except Exception as exc:
+            return ToolResult(
+                status=ToolExecutionStatus.ERROR,
+                output=output,
+                error=f"Failed to parse sandbox edit result: {exc}",
+            )
+
+    def _apply_successful_delete_to_host(
+        self,
+        parameters: Dict[str, Any],
+        result: ToolResult,
+    ) -> None:
+        """Propagate the edit tool's file delete action after workspace copy-back."""
+        if result.status != ToolExecutionStatus.SUCCESS:
+            return
+        if parameters.get("action") != "delete":
+            return
+        file_path_str = parameters.get("file_path")
+        if not file_path_str or not self.working_directory:
+            return
+        full_path, escape_error = _resolve_and_check(
+            file_path_str,
+            self.working_directory,
+        )
+        if escape_error is None and full_path.exists():
+            full_path.unlink()
+
+    @staticmethod
+    def _copy_workspace(source: Path, destination: Path) -> None:
+        """Copy workspace files while skipping generated Python cache files."""
+        source = source.resolve()
+        destination = destination.resolve()
+        if not source.exists():
+            destination.mkdir(parents=True, exist_ok=True)
+            return
+
+        def ignore(_dir: str, names: List[str]) -> set:
+            return {
+                name
+                for name in names
+                if name == "__pycache__" or name.endswith((".pyc", ".pyo"))
+            }
+
+        shutil.copytree(
+            source,
+            destination,
+            dirs_exist_ok=True,
+            ignore=ignore,
+        )
 
 
 # TODO: Implement full Edit tool functionality

--- a/config/dgm_config.yaml
+++ b/config/dgm_config.yaml
@@ -51,9 +51,9 @@ evaluation:
   timeout_seconds: 30
   use_sandbox: false
 
-# Optional Docker sandbox settings for benchmark test scripts and agent bash
-# tool commands. The model orchestration loop and edit tool still run in the
-# configured host workspace.
+# Optional Docker sandbox settings for benchmark test scripts plus agent bash
+# and edit tool operations. The model orchestration loop and controller/archive
+# logic still run in the configured host workspace.
 sandbox:
   image_name: dgm-sandbox
   memory_limit: 2g

--- a/config/dgm_config.yaml
+++ b/config/dgm_config.yaml
@@ -49,6 +49,18 @@ evaluation:
   benchmarks_dir: config/benchmarks
   results_dir: results
   timeout_seconds: 30
+  use_sandbox: false
+
+# Optional Docker sandbox settings for benchmark test-script execution.
+# Agent solving and tool use still run directly in the configured workspace.
+sandbox:
+  image_name: dgm-sandbox
+  memory_limit: 2g
+  cpu_limit: "1"
+  timeout: 300
+  network_mode: none
+  working_dir: /home/dgm_agent/workspace
+  auto_build_image: true
   
 # Agent Settings
 agents:

--- a/config/dgm_config.yaml
+++ b/config/dgm_config.yaml
@@ -51,8 +51,9 @@ evaluation:
   timeout_seconds: 30
   use_sandbox: false
 
-# Optional Docker sandbox settings for benchmark test-script execution.
-# Agent solving and tool use still run directly in the configured workspace.
+# Optional Docker sandbox settings for benchmark test scripts and agent bash
+# tool commands. The model orchestration loop and edit tool still run in the
+# configured host workspace.
 sandbox:
   image_name: dgm-sandbox
   memory_limit: 2g

--- a/config/dgm_config.yaml
+++ b/config/dgm_config.yaml
@@ -51,9 +51,9 @@ evaluation:
   timeout_seconds: 30
   use_sandbox: false
 
-# Optional Docker sandbox settings for benchmark test scripts plus agent bash
-# and edit tool operations. The model orchestration loop and controller/archive
-# logic still run in the configured host workspace.
+# Optional Docker sandbox settings for benchmark test scripts, agent bash/edit
+# operations, and modified-agent runtime load checks. The model orchestration
+# loop and controller/archive logic still run in the configured host workspace.
 sandbox:
   image_name: dgm-sandbox
   memory_limit: 2g

--- a/dgm_controller.py
+++ b/dgm_controller.py
@@ -88,6 +88,8 @@ class DGMController:
                 }
             )
             sandbox_manager = SandboxManager(sandbox_config)
+        self.sandbox_manager = sandbox_manager
+        self.use_sandbox = use_sandbox
 
         self.benchmark_runner = BenchmarkRunner(
             benchmarks_dir=evaluation_config.get('benchmarks_dir', 'config/benchmarks'),
@@ -469,7 +471,9 @@ performance."""
                 fm_provider=primary_provider,
                 fm_config=self.config['fm_providers'][primary_provider],
                 working_directory=str(workspace_dir),
-                max_iterations=self.config['agents'].get('max_steps', 20)
+                max_iterations=self.config['agents'].get('max_steps', 20),
+                sandbox_manager=self.sandbox_manager,
+                use_sandbox=self.use_sandbox,
             )
 
             # Instantiate parent agent
@@ -545,6 +549,8 @@ performance."""
                     fm_config=provider_config,
                     working_directory=str(agent_path_obj.parent),
                     max_iterations=self.config['agents'].get('max_steps', 20),
+                    sandbox_manager=self.sandbox_manager,
+                    use_sandbox=self.use_sandbox,
                 )
 
                 # Load the agent class from the file path using load_from_path,

--- a/dgm_controller.py
+++ b/dgm_controller.py
@@ -88,6 +88,22 @@ class DGMController:
                 }
             )
             sandbox_manager = SandboxManager(sandbox_config)
+            readiness_check = getattr(sandbox_manager, "is_sandbox_ready", None)
+            if readiness_check is not None:
+                if not readiness_check():
+                    logger.warning(
+                        "Docker sandbox requested but unavailable; using direct host execution"
+                    )
+                    sandbox_manager = None
+                    use_sandbox = False
+            else:
+                availability_check = getattr(sandbox_manager, "is_docker_available", None)
+                if availability_check is not None and not availability_check():
+                    logger.warning(
+                        "Docker sandbox requested but unavailable; using direct host execution"
+                    )
+                    sandbox_manager = None
+                    use_sandbox = False
         self.sandbox_manager = sandbox_manager
         self.use_sandbox = use_sandbox
 

--- a/dgm_controller.py
+++ b/dgm_controller.py
@@ -17,6 +17,8 @@ import traceback
 import yaml
 
 from agent import Agent, Task, AgentConfig
+from agent.tools.base_tool import ToolExecutionStatus
+from agent.tools.edit_tool import EditTool
 from archive import AgentArchive, ParentSelector
 from evaluation.benchmark_runner import BenchmarkRunner
 from evaluation.agent_validator import AgentValidator
@@ -510,7 +512,26 @@ performance."""
                 if solution and isinstance(solution, str):
                     try:
                         ast.parse(solution)
-                        (workspace_dir / 'agent.py').write_text(solution)
+                        edit_tool = EditTool(
+                            working_directory=str(workspace_dir),
+                            sandbox_manager=self.sandbox_manager,
+                            use_sandbox=self.use_sandbox,
+                            timeout=self.config.get('evaluation', {}).get(
+                                'timeout_seconds',
+                                30,
+                            ),
+                        )
+                        edit_result = await edit_tool.execute({
+                            "action": "write",
+                            "file_path": "agent.py",
+                            "content": solution,
+                        })
+                        if edit_result.status != ToolExecutionStatus.SUCCESS:
+                            logger.error(
+                                "Failed to write solution string to workspace "
+                                f"agent.py: {edit_result.error}"
+                            )
+                            return None
                         logger.info("Wrote solution string to workspace agent.py")
                     except SyntaxError:
                         logger.warning(

--- a/dgm_controller.py
+++ b/dgm_controller.py
@@ -20,6 +20,7 @@ from agent import Agent, Task, AgentConfig
 from archive import AgentArchive, ParentSelector
 from evaluation.benchmark_runner import BenchmarkRunner
 from evaluation.agent_validator import AgentValidator
+from sandbox.sandbox_manager import SandboxConfig, SandboxManager
 from utils.logger import setup_logger
 from utils.agent_loader import AgentLoader
 
@@ -75,8 +76,23 @@ class DGMController:
             alpha_0=ps_cfg.get('alpha_0', 0.5)
         )
 
+        evaluation_config = self.config.get('evaluation', {})
+        sandbox_manager = None
+        use_sandbox = evaluation_config.get('use_sandbox', False)
+        if use_sandbox:
+            sandbox_config = SandboxConfig(
+                **{
+                    key: value
+                    for key, value in self.config.get('sandbox', {}).items()
+                    if key in SandboxConfig.__dataclass_fields__
+                }
+            )
+            sandbox_manager = SandboxManager(sandbox_config)
+
         self.benchmark_runner = BenchmarkRunner(
-            benchmarks_dir=self.config['evaluation']['benchmarks_dir']
+            benchmarks_dir=evaluation_config.get('benchmarks_dir', 'config/benchmarks'),
+            sandbox_manager=sandbox_manager,
+            use_sandbox=use_sandbox
         )
 
         self.validator = AgentValidator()

--- a/dgm_controller.py
+++ b/dgm_controller.py
@@ -97,7 +97,11 @@ class DGMController:
             use_sandbox=use_sandbox
         )
 
-        self.validator = AgentValidator()
+        self.validator = AgentValidator(
+            sandbox_manager=sandbox_manager,
+            use_sandbox=use_sandbox,
+            timeout=evaluation_config.get('timeout_seconds', 30),
+        )
 
         # Initialize agent loader
         self.agent_loader = AgentLoader(project_root=Path(self.workspace))

--- a/evaluation/agent_validator.py
+++ b/evaluation/agent_validator.py
@@ -159,10 +159,21 @@ class AgentValidator:
         """Return True when sandboxed runtime validation is configured."""
         if not self.use_sandbox or self.sandbox_manager is None:
             return False
+        readiness_check = getattr(self.sandbox_manager, "is_sandbox_ready", None)
+        if readiness_check is not None:
+            return bool(readiness_check())
         availability_check = getattr(self.sandbox_manager, "is_docker_available", None)
         if availability_check is None:
             return True
-        return bool(availability_check())
+        if not bool(availability_check()):
+            return False
+        ensure_image = getattr(self.sandbox_manager, "ensure_sandbox_image", None)
+        if ensure_image is not None:
+            try:
+                ensure_image()
+            except Exception:
+                return False
+        return True
     
     async def validate_agent(self, agent_path: str) -> Dict[str, Any]:
         """

--- a/evaluation/agent_validator.py
+++ b/evaluation/agent_validator.py
@@ -10,10 +10,120 @@ from pathlib import Path
 import ast
 import inspect
 import importlib.util
+import json
+import shlex
+import shutil
 import sys
+import tempfile
 import time
 
 from utils.agent_loader import AgentLoader
+
+
+_SANDBOX_VALIDATION_RUNNER = r"""
+import hashlib
+import importlib.util
+import inspect
+import json
+import sys
+import types
+from pathlib import Path
+
+
+def find_agent_class(module, mod_name, preferred_name):
+    candidate = getattr(module, preferred_name, None)
+    if isinstance(candidate, type):
+        return candidate
+
+    candidate = getattr(module, "Agent", None)
+    if isinstance(candidate, type):
+        return candidate
+
+    local_classes = [
+        obj for _name, obj in vars(module).items()
+        if isinstance(obj, type) and getattr(obj, "__module__", None) == mod_name
+    ]
+    for cls in local_classes:
+        if cls.__name__.endswith("Agent"):
+            return cls
+    for cls in local_classes:
+        if "Agent" in cls.__name__ and not cls.__name__.endswith("Config"):
+            return cls
+    return None
+
+
+def load_agent_class(agent_file, preferred_name):
+    agent_file = Path(agent_file).resolve()
+    agent_dir = agent_file.parent
+    digest = hashlib.md5(str(agent_file).encode()).hexdigest()[:12]
+    pkg_name = f"dgm_validation_pkg_{digest}"
+
+    pkg = types.ModuleType(pkg_name)
+    pkg.__path__ = [str(agent_dir)]
+    pkg.__package__ = pkg_name
+    sys.modules[pkg_name] = pkg
+
+    mod_name = f"{pkg_name}.{agent_file.stem}"
+    spec = importlib.util.spec_from_file_location(mod_name, agent_file)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Cannot create module spec for {agent_file}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[mod_name] = module
+    spec.loader.exec_module(module)
+
+    agent_class = find_agent_class(module, mod_name, preferred_name)
+    if agent_class is None:
+        raise AttributeError(f"No Agent class found in {agent_file}")
+    return agent_class
+
+
+def main():
+    if len(sys.argv) != 2:
+        raise SystemExit("Usage: sandbox_validator PARAMS_JSON")
+
+    params = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+    result = {
+        "valid": True,
+        "errors": [],
+        "warnings": [],
+        "checks_passed": [],
+    }
+
+    try:
+        agent_class = load_agent_class(
+            Path.cwd() / params["main_file"],
+            params["agent_class_name"],
+        )
+
+        for method_name in params["required_methods"]:
+            if not hasattr(agent_class, method_name):
+                result["valid"] = False
+                result["errors"].append(
+                    f"Loaded class missing required method: {method_name}"
+                )
+
+        if result["valid"] and hasattr(agent_class, "solve_task"):
+            sig = inspect.signature(agent_class.solve_task)
+            params_list = list(sig.parameters.keys())
+            if "task" not in params_list:
+                result["warnings"].append(
+                    "solve_task should have 'task' parameter"
+                )
+
+        if result["valid"]:
+            result["checks_passed"].append(
+                "Agent class loaded and verified successfully in sandbox"
+            )
+    except Exception as exc:
+        result["valid"] = False
+        result["errors"].append(f"Sandbox implementation validation failed: {exc}")
+
+    print(json.dumps(result))
+
+
+if __name__ == "__main__":
+    main()
+"""
 
 
 class AgentValidator:
@@ -24,7 +134,12 @@ class AgentValidator:
     follow the expected structure, and can be properly instantiated.
     """
     
-    def __init__(self):
+    def __init__(
+        self,
+        sandbox_manager: Optional[Any] = None,
+        use_sandbox: bool = False,
+        timeout: int = 30,
+    ):
         """Initialize the agent validator."""
         self.required_methods = [
             'solve_task',
@@ -36,6 +151,18 @@ class AgentValidator:
         ]
         self.validation_results = []
         self.agent_loader = AgentLoader()
+        self.sandbox_manager = sandbox_manager
+        self.use_sandbox = use_sandbox
+        self.timeout = timeout
+
+    def _can_use_sandbox(self) -> bool:
+        """Return True when sandboxed runtime validation is configured."""
+        if not self.use_sandbox or self.sandbox_manager is None:
+            return False
+        availability_check = getattr(self.sandbox_manager, "is_docker_available", None)
+        if availability_check is None:
+            return True
+        return bool(availability_check())
     
     async def validate_agent(self, agent_path: str) -> Dict[str, Any]:
         """
@@ -255,6 +382,14 @@ class AgentValidator:
             return False
 
         # --- Gate 4: try to load the actual file via importlib ---
+        if self._can_use_sandbox():
+            return await self._validate_runtime_load_in_sandbox(
+                agent_path=agent_path,
+                file_path=file_path,
+                agent_class_name=agent_class_name,
+                results=results,
+            )
+
         # Use a unique module name to avoid collisions with cached modules.
         unique_name = f"_dgm_agent_validate_{id(file_path)}_{int(time.time() * 1e6)}"
         try:
@@ -321,6 +456,108 @@ class AgentValidator:
         except Exception as e:
             results['errors'].append(f"Implementation validation failed: {str(e)}")
             return False
+
+    async def _validate_runtime_load_in_sandbox(
+        self,
+        agent_path: str,
+        file_path: Path,
+        agent_class_name: str,
+        results: Dict[str, Any],
+    ) -> bool:
+        """Run the runtime import/load validation inside the Docker sandbox."""
+        sandbox_temp_parent = Path.home() / ".cache" / "dgm-sandbox"
+        sandbox_temp_parent.mkdir(parents=True, exist_ok=True)
+
+        with tempfile.TemporaryDirectory(dir=str(sandbox_temp_parent)) as temp_dir:
+            staged_workspace = Path(temp_dir) / "workspace"
+            source_root, relative_agent_file = self._validation_source_root(
+                agent_path=agent_path,
+                file_path=file_path,
+            )
+            self._copy_workspace(source=source_root, destination=staged_workspace)
+
+            params_path = staged_workspace / ".dgm_validator_params.json"
+            params_path.write_text(
+                json.dumps({
+                    "main_file": str(relative_agent_file),
+                    "agent_class_name": agent_class_name,
+                    "required_methods": self.required_methods,
+                }),
+                encoding="utf-8",
+            )
+
+            sandbox_result = await self.sandbox_manager.execute_in_sandbox(
+                command=(
+                    f"python3 -c {shlex.quote(_SANDBOX_VALIDATION_RUNNER)} "
+                    ".dgm_validator_params.json"
+                ),
+                workspace_path=str(staged_workspace),
+                timeout=self.timeout,
+            )
+
+            try:
+                params_path.unlink(missing_ok=True)
+            except TypeError:  # pragma: no cover - Python < 3.8
+                if params_path.exists():
+                    params_path.unlink()
+
+        if not sandbox_result.success:
+            results['errors'].append(
+                "Sandbox implementation validation failed: "
+                f"{sandbox_result.error or sandbox_result.output}"
+            )
+            return False
+
+        try:
+            payload = json.loads(sandbox_result.output.strip().splitlines()[-1])
+        except Exception as exc:
+            results['errors'].append(
+                f"Failed to parse sandbox validation result: {exc}"
+            )
+            return False
+
+        results['warnings'].extend(payload.get("warnings", []))
+        results['checks_passed'].extend(payload.get("checks_passed", []))
+        if not payload.get("valid", False):
+            results['errors'].extend(payload.get("errors", []))
+            return False
+        return True
+
+    @staticmethod
+    def _validation_source_root(agent_path: str, file_path: Path) -> "tuple[Path, Path]":
+        """Return the source root to stage and the agent file path within it."""
+        requested_path = Path(agent_path).resolve()
+        file_path = file_path.resolve()
+        if requested_path.is_dir():
+            source_root = requested_path
+            relative_agent_file = file_path.relative_to(source_root)
+        else:
+            source_root = file_path.parent
+            relative_agent_file = Path(file_path.name)
+        return source_root, relative_agent_file
+
+    @staticmethod
+    def _copy_workspace(source: Path, destination: Path) -> None:
+        """Copy validation inputs while skipping generated Python cache files."""
+        source = source.resolve()
+        destination = destination.resolve()
+        if not source.exists():
+            destination.mkdir(parents=True, exist_ok=True)
+            return
+
+        def ignore(_dir: str, names: List[str]) -> set:
+            return {
+                name
+                for name in names
+                if name == "__pycache__" or name.endswith((".pyc", ".pyo"))
+            }
+
+        shutil.copytree(
+            source,
+            destination,
+            dirs_exist_ok=True,
+            ignore=ignore,
+        )
     
     def _validate_dependencies(self, agent_path: str, results: Dict[str, Any]) -> None:
         """

--- a/evaluation/benchmark_runner.py
+++ b/evaluation/benchmark_runner.py
@@ -8,6 +8,8 @@ import asyncio
 import json
 import os
 import re
+import shlex
+import sys
 import tempfile
 import time
 from dataclasses import dataclass
@@ -89,7 +91,7 @@ class BenchmarkRunner:
         self,
         benchmarks_dir: str = "./config/benchmarks",
         sandbox_manager: Optional[Any] = None,
-        use_sandbox: bool = True
+        use_sandbox: bool = False
     ):
         """
         Initialize the benchmark runner.
@@ -104,6 +106,28 @@ class BenchmarkRunner:
         self.use_sandbox = use_sandbox
         self.benchmarks: Dict[str, BenchmarkTask] = {}
         self._load_benchmarks()
+
+        if self.use_sandbox and self.sandbox_manager is None and _SandboxManager:
+            candidate = _SandboxManager()
+            if candidate.is_docker_available():
+                self.sandbox_manager = candidate
+            else:
+                logger.warning(
+                    "Docker sandbox requested but unavailable; using direct subprocess execution"
+                )
+                self.use_sandbox = False
+
+        if self.use_sandbox and self.sandbox_manager:
+            ensure_image = getattr(self.sandbox_manager, "ensure_sandbox_image", None)
+            if ensure_image is not None:
+                try:
+                    ensure_image()
+                except Exception as exc:
+                    logger.warning(
+                        "Docker sandbox image unavailable; using direct subprocess execution: %s",
+                        exc,
+                    )
+                    self.use_sandbox = False
 
     def _load_benchmarks(self) -> None:
         """Load all benchmark configurations."""
@@ -227,9 +251,24 @@ class BenchmarkRunner:
         task: Task,
         benchmark: BenchmarkTask
     ) -> Dict[str, Any]:
-        """Run agent in a sandboxed environment."""
-        logger.warning("Sandbox execution not fully implemented, using direct execution")
+        """
+        Run benchmark flow with sandboxed test execution where available.
+
+        Agent task solving still runs in-process because it may need configured
+        provider clients and workspace tools. The generated benchmark solution
+        test scripts are isolated by ``_run_test_case`` when sandboxing is
+        enabled and Docker is available.
+        """
         return await self._run_directly(agent, task, benchmark)
+
+    def _can_use_sandbox(self) -> bool:
+        """Return True when sandboxed subprocess execution is configured."""
+        if not self.use_sandbox or not self.sandbox_manager:
+            return False
+        availability_check = getattr(self.sandbox_manager, "is_docker_available", None)
+        if availability_check is None:
+            return True
+        return bool(availability_check())
 
     # ------------------------------------------------------------------
     # Test-generation helpers
@@ -354,66 +393,106 @@ print(json.dumps({{
             }
 
         solution_file: Optional[str] = None
+        temp_dir: Optional[tempfile.TemporaryDirectory] = None
         try:
-            with tempfile.NamedTemporaryFile(
-                mode='w',
-                suffix='.py',
-                delete=False
-            ) as f:
-                f.write(solution)
-                solution_file = f.name
+            use_sandbox = self._can_use_sandbox()
+            if use_sandbox:
+                sandbox_temp_parent = Path.home() / ".cache" / "dgm-sandbox"
+                sandbox_temp_parent.mkdir(parents=True, exist_ok=True)
+                temp_dir = tempfile.TemporaryDirectory(dir=str(sandbox_temp_parent))
+            else:
+                temp_dir = tempfile.TemporaryDirectory()
+
+            workspace_path = Path(temp_dir.name)
+            solution_path = workspace_path / "solution.py"
+            solution_path.write_text(solution)
+            solution_file = str(solution_path)
 
             inputs = test_case.get('inputs', [])
             expected_outputs = test_case.get('expected_outputs', [])
 
             results: List[Dict[str, Any]] = []
             overall_success = True
+            sandbox_working_dir = getattr(
+                getattr(self.sandbox_manager, "config", None),
+                "working_dir",
+                "/home/dgm_agent/workspace",
+            )
 
             for i, (input_val, expected_val) in enumerate(zip(inputs, expected_outputs)):
                 raw_input = str(input_val)
                 raw_expected = str(expected_val)
+                sandbox_solution_file = str(Path(sandbox_working_dir) / solution_path.name)
 
                 test_code = self._build_test_script(
-                    solution_file,
+                    sandbox_solution_file if use_sandbox else solution_file,
                     function_name,
                     raw_input,
                     raw_expected,
                     i
                 )
+                test_script_path = workspace_path / f"test_case_{i}.py"
+                test_script_path.write_text(test_code)
 
-                proc = await asyncio.create_subprocess_exec(
-                    'python3', '-c', test_code,
-                    stdout=asyncio.subprocess.PIPE,
-                    stderr=asyncio.subprocess.PIPE
-                )
-
-                try:
-                    stdout, stderr = await asyncio.wait_for(
-                        proc.communicate(),
-                        timeout=benchmark.timeout
+                if use_sandbox:
+                    sandbox_result = await self.sandbox_manager.execute_in_sandbox(
+                        command=f"{shlex.quote('python')} {shlex.quote(test_script_path.name)}",
+                        workspace_path=str(workspace_path),
+                        timeout=benchmark.timeout,
                     )
-                except asyncio.TimeoutError:
-                    # Kill the subprocess cleanly on timeout.
+                    output_text = sandbox_result.output.strip()
+                    stderr_text = (sandbox_result.error or "").strip()
+                    timed_out = (
+                        not sandbox_result.success
+                        and sandbox_result.exit_code is None
+                        and "timed out" in stderr_text.lower()
+                    )
+                else:
+                    proc = await asyncio.create_subprocess_exec(
+                        sys.executable,
+                        str(test_script_path),
+                        stdout=asyncio.subprocess.PIPE,
+                        stderr=asyncio.subprocess.PIPE
+                    )
+
                     try:
-                        proc.kill()
-                    except ProcessLookupError:
-                        pass
-                    await proc.wait()
-                    timeout_result = {
+                        stdout, stderr = await asyncio.wait_for(
+                            proc.communicate(),
+                            timeout=benchmark.timeout
+                        )
+                    except asyncio.TimeoutError:
+                        # Kill the subprocess cleanly on timeout.
+                        try:
+                            proc.kill()
+                        except ProcessLookupError:
+                            pass
+                        await proc.wait()
+                        timeout_result = {
+                            'success': False,
+                            'actual_output': None,
+                            'expected_output': raw_expected.strip(),
+                            'error': f'Timeout after {benchmark.timeout}s',
+                            'input': raw_input
+                        }
+                        results.append(timeout_result)
+                        overall_success = False
+                        continue
+
+                    output_text = stdout.decode().strip()
+                    stderr_text = stderr.decode().strip()
+                    timed_out = False
+
+                # Parse the machine-readable JSON marker.
+                test_result: Dict[str, Any] = {}
+                if timed_out:
+                    test_result = {
                         'success': False,
                         'actual_output': None,
                         'expected_output': raw_expected.strip(),
                         'error': f'Timeout after {benchmark.timeout}s',
                         'input': raw_input
                     }
-                    results.append(timeout_result)
-                    overall_success = False
-                    continue
-
-                # Parse the machine-readable JSON marker.
-                output_text = stdout.decode().strip()
-                test_result: Dict[str, Any] = {}
-                if output_text:
+                elif output_text:
                     try:
                         # The script prints exactly one JSON line.
                         last_json_line = output_text.split('\n')[-1]
@@ -427,7 +506,6 @@ print(json.dumps({{
                             'input': raw_input
                         }
                 else:
-                    stderr_text = stderr.decode().strip()
                     test_result = {
                         'success': False,
                         'actual_output': None,
@@ -462,6 +540,8 @@ print(json.dumps({{
                     os.unlink(solution_file)
                 except OSError:
                     pass
+            if temp_dir is not None:
+                temp_dir.cleanup()
 
     def _calculate_score(
         self,

--- a/evaluation/benchmark_runner.py
+++ b/evaluation/benchmark_runner.py
@@ -273,10 +273,21 @@ class BenchmarkRunner:
         """Return True when sandboxed subprocess execution is configured."""
         if not self.use_sandbox or not self.sandbox_manager:
             return False
+        readiness_check = getattr(self.sandbox_manager, "is_sandbox_ready", None)
+        if readiness_check is not None:
+            return bool(readiness_check())
         availability_check = getattr(self.sandbox_manager, "is_docker_available", None)
         if availability_check is None:
             return True
-        return bool(availability_check())
+        if not bool(availability_check()):
+            return False
+        ensure_image = getattr(self.sandbox_manager, "ensure_sandbox_image", None)
+        if ensure_image is not None:
+            try:
+                ensure_image()
+            except Exception:
+                return False
+        return True
 
     # ------------------------------------------------------------------
     # Test-generation helpers

--- a/evaluation/benchmark_runner.py
+++ b/evaluation/benchmark_runner.py
@@ -118,16 +118,24 @@ class BenchmarkRunner:
                 self.use_sandbox = False
 
         if self.use_sandbox and self.sandbox_manager:
-            ensure_image = getattr(self.sandbox_manager, "ensure_sandbox_image", None)
-            if ensure_image is not None:
-                try:
-                    ensure_image()
-                except Exception as exc:
+            readiness_check = getattr(self.sandbox_manager, "is_sandbox_ready", None)
+            if readiness_check is not None:
+                if not readiness_check():
                     logger.warning(
-                        "Docker sandbox image unavailable; using direct subprocess execution: %s",
-                        exc,
+                        "Docker sandbox image unavailable; using direct subprocess execution"
                     )
                     self.use_sandbox = False
+            else:
+                ensure_image = getattr(self.sandbox_manager, "ensure_sandbox_image", None)
+                if ensure_image is not None:
+                    try:
+                        ensure_image()
+                    except Exception as exc:
+                        logger.warning(
+                            "Docker sandbox image unavailable; using direct subprocess execution: %s",
+                            exc,
+                        )
+                        self.use_sandbox = False
 
     def _load_benchmarks(self) -> None:
         """Load all benchmark configurations."""

--- a/sandbox/sandbox_manager.py
+++ b/sandbox/sandbox_manager.py
@@ -1,16 +1,13 @@
-"""
-Sandbox manager for safe agent execution (placeholder).
+"""Docker-backed sandbox manager for isolated command execution.
 
-NOTE: Not implemented yet. Benchmark execution currently runs in a subprocess
-with timeouts. Docker isolation is planned for a future phase.
-
-This module provides Docker-based sandboxing for agent execution,
-ensuring safe isolation during self-modification and task execution.
-The docker SDK import is deferred so that missing the optional
-`docker` package does not crash the entire program at startup.
+The docker SDK import is deferred so that missing the optional ``docker``
+package does not crash the entire program at startup. Callers can check
+``is_docker_available()`` and fall back to direct subprocess execution.
 """
 
 import asyncio
+import os
+import time
 from typing import Dict, Any, Optional, List
 from dataclasses import dataclass
 from pathlib import Path
@@ -34,6 +31,7 @@ class SandboxConfig:
     timeout: int = 300
     network_mode: str = "none"
     working_dir: str = "/home/dgm_agent/workspace"
+    auto_build_image: bool = True
 
 
 @dataclass
@@ -47,16 +45,7 @@ class SandboxResult:
 
 
 class SandboxManager:
-    """
-    Manager for Docker-based agent sandboxing.
-
-    NOT IMPLEMENTED YET. Benchmark execution currently runs in a subprocess
-    with timeouts. Docker isolation is planned for a future phase of MVP
-    development.
-
-    All methods raise NotImplementedError. The docker SDK is imported lazily
-    so that a missing ``docker`` package does not prevent importing this module.
-    """
+    """Manager for Docker-based command execution."""
 
     def __init__(self, config: SandboxConfig = None):
         """
@@ -68,6 +57,65 @@ class SandboxManager:
         self.config = config or SandboxConfig()
         self.docker_client = None  # Initialised lazily when/if docker is needed
 
+    def _get_client(self):
+        """Return a cached docker client, creating it on first use."""
+        self._require_docker()
+        if self.docker_client is None:
+            self.docker_client = self._create_docker_client()
+        return self.docker_client
+
+    def _create_docker_client(self):
+        """Create a Docker client, including common local context fallbacks."""
+        candidates = [docker.from_env]
+        for socket_path in self._candidate_socket_paths():
+            candidates.append(
+                lambda socket_path=socket_path: docker.DockerClient(
+                    base_url=f"unix://{socket_path}"
+                )
+            )
+
+        last_error = None
+        for make_client in candidates:
+            client = None
+            try:
+                client = make_client()
+                client.ping()
+                return client
+            except Exception as exc:
+                last_error = exc
+                if client is not None:
+                    try:
+                        client.close()
+                    except Exception:
+                        pass
+
+        raise RuntimeError(f"Docker daemon is not reachable: {last_error}")
+
+    @staticmethod
+    def _candidate_socket_paths() -> List[Path]:
+        """Return common Docker socket paths not always exposed via DOCKER_HOST."""
+        paths: List[Path] = []
+        docker_host = os.environ.get("DOCKER_HOST", "")
+        if docker_host.startswith("unix://"):
+            paths.append(Path(docker_host.removeprefix("unix://")))
+
+        home = Path.home()
+        paths.extend([
+            home / ".docker" / "run" / "docker.sock",
+            home / ".colima" / "default" / "docker.sock",
+            Path("/var/run/docker.sock"),
+        ])
+
+        seen = set()
+        existing_paths = []
+        for path in paths:
+            resolved = path.expanduser()
+            if resolved in seen or not resolved.exists():
+                continue
+            seen.add(resolved)
+            existing_paths.append(resolved)
+        return existing_paths
+
     def _require_docker(self):
         """Raise a clear error if the docker SDK is not installed."""
         if docker is None:
@@ -77,55 +125,93 @@ class SandboxManager:
                 "direct subprocess execution (use_sandbox=False) instead."
             )
 
+    @staticmethod
+    def _cpu_limit_to_nano_cpus(cpu_limit: str) -> Optional[int]:
+        """Convert a Docker-style CPU count string into nano CPUs."""
+        try:
+            value = float(cpu_limit)
+        except (TypeError, ValueError):
+            return None
+        if value <= 0:
+            return None
+        return int(value * 1_000_000_000)
+
     async def execute_in_sandbox(
         self,
         command: str,
-        agent_code_path: str,
-        workspace_path: str,
+        agent_code_path: Optional[str] = None,
+        workspace_path: Optional[str] = None,
         timeout: Optional[int] = None
     ) -> SandboxResult:
-        """
-        Execute a command in a sandboxed environment (NOT IMPLEMENTED).
-
-        Raises:
-            NotImplementedError: Sandbox execution is not yet implemented.
-        """
-        self._require_docker()
-        raise NotImplementedError(
-            "Sandbox manager is not yet implemented. "
-            "This is a placeholder for a future phase. "
-            "Agent execution currently runs in a subprocess with timeouts."
+        """Execute a shell command inside a one-shot Docker container."""
+        return await asyncio.to_thread(
+            self._execute_in_sandbox_sync,
+            command,
+            agent_code_path,
+            workspace_path,
+            timeout,
         )
 
     async def create_sandbox_environment(self, agent_id: str) -> str:
-        """
-        Create a new sandbox environment for an agent (NOT IMPLEMENTED).
-
-        Raises:
-            NotImplementedError: Sandbox creation is not yet implemented.
-        """
-        self._require_docker()
-        raise NotImplementedError("Sandbox environment creation is not yet implemented.")
+        """Create a stopped container and return its id."""
+        client = self._get_client()
+        container = await asyncio.to_thread(
+            client.containers.create,
+            image=self.config.image_name,
+            command=["/bin/bash", "-lc", "sleep infinity"],
+            name=None,
+            detach=True,
+            working_dir=self.config.working_dir,
+            mem_limit=self.config.memory_limit,
+            nano_cpus=self._cpu_limit_to_nano_cpus(self.config.cpu_limit),
+            network_mode=self.config.network_mode,
+            labels={"dgm_agent_id": agent_id},
+        )
+        return container.id
 
     async def cleanup_sandbox(self, container_id: str) -> None:
-        """
-        Clean up a sandbox environment (NOT IMPLEMENTED).
+        """Remove a sandbox container if it still exists."""
+        client = self._get_client()
 
-        Raises:
-            NotImplementedError: Sandbox cleanup is not yet implemented.
-        """
-        self._require_docker()
-        raise NotImplementedError("Sandbox cleanup is not yet implemented.")
+        def _remove() -> None:
+            container = client.containers.get(container_id)
+            try:
+                container.remove(force=True)
+            except Exception:
+                pass
+
+        await asyncio.to_thread(_remove)
 
     def build_sandbox_image(self) -> bool:
-        """
-        Build the Docker image for sandboxing (NOT IMPLEMENTED).
+        """Build the local sandbox image from ``sandbox/Dockerfile``."""
+        client = self._get_client()
+        project_root = Path(__file__).resolve().parents[1]
+        client.images.build(
+            path=str(project_root),
+            dockerfile="sandbox/Dockerfile",
+            tag=self.config.image_name,
+            rm=True,
+        )
+        return True
 
-        Raises:
-            NotImplementedError: Image building is not yet implemented.
+    def ensure_sandbox_image(self) -> bool:
         """
-        self._require_docker()
-        raise NotImplementedError("Sandbox image building is not yet implemented.")
+        Ensure the configured image exists.
+
+        Returns True when this call built the image, False when it already
+        existed.
+        """
+        client = self._get_client()
+        try:
+            client.images.get(self.config.image_name)
+            return False
+        except Exception as exc:
+            if docker is None or not isinstance(exc, docker.errors.ImageNotFound):
+                raise
+            if not self.config.auto_build_image:
+                raise
+            self.build_sandbox_image()
+            return True
 
     def is_docker_available(self) -> bool:
         """
@@ -137,8 +223,84 @@ class SandboxManager:
         if docker is None:
             return False
         try:
-            client = docker.from_env()
-            client.ping()
+            self._get_client()
             return True
         except Exception:
             return False
+
+    def _execute_in_sandbox_sync(
+        self,
+        command: str,
+        agent_code_path: Optional[str],
+        workspace_path: Optional[str],
+        timeout: Optional[int],
+    ) -> SandboxResult:
+        """Synchronous Docker execution body used via ``asyncio.to_thread``."""
+        client = self._get_client()
+        effective_timeout = timeout or self.config.timeout
+        started_at = time.time()
+        container = None
+
+        volumes: Dict[str, Dict[str, str]] = {}
+        if workspace_path:
+            workspace = Path(workspace_path).resolve()
+            volumes[str(workspace)] = {
+                "bind": self.config.working_dir,
+                "mode": "rw",
+            }
+
+        if agent_code_path:
+            agent_code = Path(agent_code_path).resolve()
+            agent_mount = agent_code if agent_code.is_dir() else agent_code.parent
+            volumes[str(agent_mount)] = {
+                "bind": "/home/dgm_agent/agent_code",
+                "mode": "ro",
+            }
+
+        try:
+            container = client.containers.run(
+                image=self.config.image_name,
+                command=["/bin/bash", "-lc", command],
+                detach=True,
+                working_dir=self.config.working_dir,
+                volumes=volumes,
+                mem_limit=self.config.memory_limit,
+                nano_cpus=self._cpu_limit_to_nano_cpus(self.config.cpu_limit),
+                network_mode=self.config.network_mode,
+            )
+            wait_result = container.wait(timeout=effective_timeout)
+            exit_code = wait_result.get("StatusCode", 1)
+            output = container.logs(stdout=True, stderr=False).decode(
+                "utf-8",
+                errors="replace",
+            )
+            error = container.logs(stdout=False, stderr=True).decode(
+                "utf-8",
+                errors="replace",
+            ) or None
+            return SandboxResult(
+                success=exit_code == 0,
+                output=output,
+                error=error,
+                exit_code=exit_code,
+                execution_time=time.time() - started_at,
+            )
+        except Exception as exc:
+            if container is not None:
+                try:
+                    container.kill()
+                except Exception:
+                    pass
+            return SandboxResult(
+                success=False,
+                output="",
+                error=f"Sandbox execution failed or timed out after {effective_timeout}s: {exc}",
+                exit_code=None,
+                execution_time=time.time() - started_at,
+            )
+        finally:
+            if container is not None:
+                try:
+                    container.remove(force=True)
+                except Exception:
+                    pass

--- a/sandbox/sandbox_manager.py
+++ b/sandbox/sandbox_manager.py
@@ -228,6 +228,23 @@ class SandboxManager:
         except Exception:
             return False
 
+    def is_sandbox_ready(self) -> bool:
+        """
+        Check whether Docker is reachable and the configured image is available.
+
+        This is the readiness predicate callers should use before opting into
+        sandbox execution. It includes the image build/presence check so callers
+        can fall back consistently when Docker is installed but the configured
+        sandbox image cannot be built or found.
+        """
+        if not self.is_docker_available():
+            return False
+        try:
+            self.ensure_sandbox_image()
+            return True
+        except Exception:
+            return False
+
     def _execute_in_sandbox_sync(
         self,
         command: str,

--- a/tests/unit/test_agent.py
+++ b/tests/unit/test_agent.py
@@ -78,6 +78,21 @@ class TestAgentInit:
         assert bash_tool.sandbox_manager is sandbox_manager
         assert bash_tool.use_sandbox is True
 
+    def test_edit_tool_receives_sandbox_config(self, tmp_path):
+        sandbox_manager = object()
+        cfg = _make_config(tmp_path)
+        cfg.sandbox_manager = sandbox_manager
+        cfg.use_sandbox = True
+        cfg.tool_timeout = 17
+
+        agent = Agent(cfg)
+
+        edit_tool = agent.tool_registry.get_tool("edit")
+        assert isinstance(edit_tool, EditTool)
+        assert edit_tool.sandbox_manager is sandbox_manager
+        assert edit_tool.use_sandbox is True
+        assert edit_tool.default_timeout == 17
+
     def test_edit_tool_is_edit_tool(self, tmp_path):
         agent = Agent(_make_config(tmp_path))
         assert isinstance(agent.tool_registry.get_tool("edit"), EditTool)

--- a/tests/unit/test_agent.py
+++ b/tests/unit/test_agent.py
@@ -65,6 +65,19 @@ class TestAgentInit:
         agent = Agent(_make_config(tmp_path))
         assert isinstance(agent.tool_registry.get_tool("bash"), BashTool)
 
+    def test_bash_tool_receives_sandbox_config(self, tmp_path):
+        sandbox_manager = object()
+        cfg = _make_config(tmp_path)
+        cfg.sandbox_manager = sandbox_manager
+        cfg.use_sandbox = True
+
+        agent = Agent(cfg)
+
+        bash_tool = agent.tool_registry.get_tool("bash")
+        assert isinstance(bash_tool, BashTool)
+        assert bash_tool.sandbox_manager is sandbox_manager
+        assert bash_tool.use_sandbox is True
+
     def test_edit_tool_is_edit_tool(self, tmp_path):
         agent = Agent(_make_config(tmp_path))
         assert isinstance(agent.tool_registry.get_tool("edit"), EditTool)

--- a/tests/unit/test_dgm_controller.py
+++ b/tests/unit/test_dgm_controller.py
@@ -2,6 +2,7 @@
 Unit tests for DGMController initialization and helper methods.
 """
 
+import json
 import pytest
 import yaml
 from pathlib import Path
@@ -198,3 +199,107 @@ class TestDGMControllerInit:
         assert ctrl.benchmark_runner.use_sandbox is False
         assert ctrl.validator.sandbox_manager is None
         assert ctrl.validator.use_sandbox is False
+
+    async def test_self_modification_solution_write_uses_sandbox_edit_tool(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        from archive.agent_archive import ArchivedAgent
+        from agent.agent import Task
+        from dgm_controller import DGMController
+        from sandbox.sandbox_manager import SandboxResult
+
+        class FakeSandboxManager:
+            instances = []
+
+            def __init__(self, config):
+                self.config = config
+                self.calls = []
+                self.instances.append(self)
+
+            def is_sandbox_ready(self):
+                return True
+
+            async def execute_in_sandbox(
+                self,
+                command,
+                agent_code_path=None,
+                workspace_path=None,
+                timeout=None,
+            ):
+                params_path = Path(workspace_path) / ".dgm_edit_tool_params.json"
+                params = json.loads(params_path.read_text(encoding="utf-8"))
+                Path(workspace_path, params["file_path"]).write_text(
+                    params["content"],
+                    encoding="utf-8",
+                )
+                self.calls.append({
+                    "command": command,
+                    "agent_code_path": agent_code_path,
+                    "workspace_path": workspace_path,
+                    "timeout": timeout,
+                })
+                return SandboxResult(
+                    success=True,
+                    output=json.dumps({
+                        "status": "success",
+                        "output": "wrote agent.py",
+                        "error": "",
+                    }),
+                    exit_code=0,
+                    execution_time=0.1,
+                )
+
+        solution = (
+            "class Agent:\n"
+            "    def __init__(self, config=None): pass\n"
+            "    def solve_task(self, task): return 'done'\n"
+        )
+
+        class FakeAgent:
+            def __init__(self, config):
+                self.config = config
+
+            async def solve_task(self, task):
+                return {"success": True, "solution": solution}
+
+        monkeypatch.setattr("dgm_controller.SandboxManager", FakeSandboxManager)
+        monkeypatch.setattr("dgm_controller.Agent", FakeAgent)
+
+        cfg = _minimal_config(tmp_path)
+        cfg["evaluation"]["use_sandbox"] = True
+        cfg["evaluation"]["timeout_seconds"] = 9
+        ctrl = DGMController(config_or_path=cfg, workspace=str(tmp_path))
+
+        parent_dir = tmp_path / "parent_agent"
+        parent_dir.mkdir()
+        (parent_dir / "agent.py").write_text(
+            "class Agent:\n"
+            "    def __init__(self, config=None): pass\n"
+            "    def solve_task(self, task): return 'old'\n",
+            encoding="utf-8",
+        )
+        parent = ArchivedAgent(
+            agent_id="parent_001",
+            parent_id=None,
+            generation=0,
+            source_path=str(parent_dir / "agent.py"),
+            created_at="2026-06-15T00:00:00",
+            benchmark_scores={"dummy": 0.0},
+            average_score=0.0,
+            is_valid=True,
+            metadata={},
+        )
+        task = Task(task_id="self_modify_parent_001_0", description="modify")
+
+        result_path = await ctrl._perform_self_modification(parent, task)
+
+        assert result_path is not None
+        result_file = Path(result_path)
+        assert result_file.read_text(encoding="utf-8") == solution
+        assert not (result_file.parent / ".dgm_edit_tool_params.json").exists()
+        sandbox_manager = FakeSandboxManager.instances[0]
+        assert len(sandbox_manager.calls) == 1
+        assert sandbox_manager.calls[0]["timeout"] == 9
+        assert sandbox_manager.calls[0]["workspace_path"] != str(result_file.parent)

--- a/tests/unit/test_dgm_controller.py
+++ b/tests/unit/test_dgm_controller.py
@@ -6,6 +6,7 @@ import json
 import pytest
 import yaml
 from pathlib import Path
+from types import SimpleNamespace
 
 
 def _minimal_config(tmp_path: Path) -> dict:
@@ -303,3 +304,58 @@ class TestDGMControllerInit:
         assert len(sandbox_manager.calls) == 1
         assert sandbox_manager.calls[0]["timeout"] == 9
         assert sandbox_manager.calls[0]["workspace_path"] != str(result_file.parent)
+
+    async def test_evaluate_agent_passes_sandbox_config_to_loaded_agent(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        from dgm_controller import DGMController
+
+        class FakeSandboxManager:
+            def __init__(self, config):
+                self.config = config
+
+            def is_sandbox_ready(self):
+                return True
+
+        monkeypatch.setattr("dgm_controller.SandboxManager", FakeSandboxManager)
+        cfg = _minimal_config(tmp_path)
+        cfg["evaluation"]["use_sandbox"] = True
+        ctrl = DGMController(config_or_path=cfg, workspace=str(tmp_path))
+
+        agent_file = tmp_path / "candidate_agent.py"
+        agent_file.write_text(
+            "class Agent:\n"
+            "    def __init__(self, config): self.config = config\n"
+            "    def solve_task(self, task): return {'success': True, 'solution': ''}\n",
+            encoding="utf-8",
+        )
+
+        captured = {}
+
+        class LoadedAgent:
+            def __init__(self, config):
+                captured["config"] = config
+                self.config = config
+                self.agent_id = config.agent_id
+
+        ctrl.agent_loader.load_from_path = lambda _path: LoadedAgent
+
+        async def fake_run_benchmark(agent, benchmark_name, verbose=False):
+            captured["agent"] = agent
+            captured["benchmark_name"] = benchmark_name
+            captured["verbose"] = verbose
+            return SimpleNamespace(score=0.75)
+
+        ctrl.benchmark_runner.run_benchmark = fake_run_benchmark
+
+        scores = await ctrl._evaluate_agent(str(agent_file))
+
+        assert scores == {"dummy": 0.75}
+        assert captured["config"].sandbox_manager is ctrl.sandbox_manager
+        assert captured["config"].use_sandbox is True
+        assert captured["config"].working_directory == str(agent_file.parent)
+        assert captured["agent"].config is captured["config"]
+        assert captured["benchmark_name"] == "dummy"
+        assert captured["verbose"] is False

--- a/tests/unit/test_dgm_controller.py
+++ b/tests/unit/test_dgm_controller.py
@@ -175,3 +175,26 @@ class TestDGMControllerInit:
         assert ctrl.benchmark_runner.use_sandbox is True
         assert ctrl.validator.sandbox_manager is ctrl.sandbox_manager
         assert ctrl.validator.use_sandbox is True
+
+    def test_init_disables_sandbox_when_manager_not_ready(self, tmp_path, monkeypatch):
+        from dgm_controller import DGMController
+
+        class NotReadySandboxManager:
+            def __init__(self, config):
+                self.config = config
+
+            def is_sandbox_ready(self):
+                return False
+
+        monkeypatch.setattr("dgm_controller.SandboxManager", NotReadySandboxManager)
+        cfg = _minimal_config(tmp_path)
+        cfg["evaluation"]["use_sandbox"] = True
+
+        ctrl = DGMController(config_or_path=cfg, workspace=str(tmp_path))
+
+        assert ctrl.sandbox_manager is None
+        assert ctrl.use_sandbox is False
+        assert ctrl.benchmark_runner.sandbox_manager is None
+        assert ctrl.benchmark_runner.use_sandbox is False
+        assert ctrl.validator.sandbox_manager is None
+        assert ctrl.validator.use_sandbox is False

--- a/tests/unit/test_dgm_controller.py
+++ b/tests/unit/test_dgm_controller.py
@@ -173,3 +173,5 @@ class TestDGMControllerInit:
         assert ctrl.use_sandbox is True
         assert ctrl.benchmark_runner.sandbox_manager is ctrl.sandbox_manager
         assert ctrl.benchmark_runner.use_sandbox is True
+        assert ctrl.validator.sandbox_manager is ctrl.sandbox_manager
+        assert ctrl.validator.use_sandbox is True

--- a/tests/unit/test_dgm_controller.py
+++ b/tests/unit/test_dgm_controller.py
@@ -153,3 +153,23 @@ class TestDGMControllerInit:
         assert redacted["nested"]["api_token"] == "[REDACTED]"
         assert redacted["nested"]["items"][0]["password"] == "[REDACTED]"
         assert redacted["nested"]["items"][1]["safe"] == "visible"
+
+    def test_init_wires_sandbox_manager_when_enabled(self, tmp_path, monkeypatch):
+        from dgm_controller import DGMController
+
+        class FakeSandboxManager:
+            def __init__(self, config):
+                self.config = config
+
+        monkeypatch.setattr("dgm_controller.SandboxManager", FakeSandboxManager)
+        cfg = _minimal_config(tmp_path)
+        cfg["evaluation"]["use_sandbox"] = True
+        cfg["sandbox"] = {"image_name": "custom-sandbox"}
+
+        ctrl = DGMController(config_or_path=cfg, workspace=str(tmp_path))
+
+        assert isinstance(ctrl.sandbox_manager, FakeSandboxManager)
+        assert ctrl.sandbox_manager.config.image_name == "custom-sandbox"
+        assert ctrl.use_sandbox is True
+        assert ctrl.benchmark_runner.sandbox_manager is ctrl.sandbox_manager
+        assert ctrl.benchmark_runner.use_sandbox is True

--- a/tests/unit/test_evaluation.py
+++ b/tests/unit/test_evaluation.py
@@ -18,6 +18,7 @@ from evaluation.scorer import (
     JsonScorer, FunctionOutputScorer
 )
 from evaluation.agent_validator import AgentValidator
+from sandbox.sandbox_manager import SandboxManager, SandboxResult
 
 
 # ---------------------------------------------------------------------------
@@ -169,6 +170,88 @@ class TestRunTestCase:
         assert any("Timeout" in (e or "") or "timeout" in (e or "") for e in errors), (
             f"Expected timeout error, got: {errors}"
         )
+
+    async def test_uses_sandbox_manager_when_available(self, tmp_path):
+        task = _make_task(tmp_path)
+
+        class FakeConfig:
+            working_dir = "/home/dgm_agent/workspace"
+
+        class FakeSandboxManager:
+            config = FakeConfig()
+
+            def __init__(self):
+                self.calls = []
+
+            def is_docker_available(self):
+                return True
+
+            async def execute_in_sandbox(self, command, workspace_path, timeout, **kwargs):
+                self.calls.append({
+                    "command": command,
+                    "workspace_path": workspace_path,
+                    "timeout": timeout,
+                    "kwargs": kwargs,
+                })
+                return SandboxResult(
+                    success=True,
+                    output='{"success": true, "actual_output": "3", "expected_output": "3", "error": null}\n',
+                    exit_code=0,
+                )
+
+        fake_sandbox = FakeSandboxManager()
+        runner = _make_runner(tmp_path, task)
+        runner.use_sandbox = True
+        runner.sandbox_manager = fake_sandbox
+
+        result = await runner._run_test_case(
+            "def add(a, b):\n    return a + b\n",
+            task.test_cases[0],
+            task,
+        )
+
+        assert result["success"] is True
+        assert result["passed"] == result["total"] == 3
+        assert len(fake_sandbox.calls) == 3
+        assert all(call["command"].startswith("python test_case_") for call in fake_sandbox.calls)
+
+    async def test_sandbox_request_falls_back_when_unavailable(self, tmp_path):
+        task = _make_task(tmp_path)
+
+        class UnavailableSandboxManager:
+            def __init__(self):
+                self.calls = []
+
+            def is_docker_available(self):
+                return False
+
+            async def execute_in_sandbox(self, *args, **kwargs):
+                self.calls.append((args, kwargs))
+                raise AssertionError("Sandbox should not be used when unavailable")
+
+        sandbox_manager = UnavailableSandboxManager()
+        runner = _make_runner(tmp_path, task)
+        runner.use_sandbox = True
+        runner.sandbox_manager = sandbox_manager
+
+        result = await runner._run_test_case(
+            "def add(a, b):\n    return a + b\n",
+            task.test_cases[0],
+            task,
+        )
+
+        assert result["success"] is True
+        assert result["passed"] == result["total"] == 3
+        assert sandbox_manager.calls == []
+
+
+class TestSandboxManager:
+
+    def test_cpu_limit_to_nano_cpus(self):
+        assert SandboxManager._cpu_limit_to_nano_cpus("1") == 1_000_000_000
+        assert SandboxManager._cpu_limit_to_nano_cpus("0.5") == 500_000_000
+        assert SandboxManager._cpu_limit_to_nano_cpus("bad") is None
+        assert SandboxManager._cpu_limit_to_nano_cpus("0") is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_evaluation.py
+++ b/tests/unit/test_evaluation.py
@@ -428,3 +428,87 @@ class TestAgentValidator:
         summary = validator.get_validation_summary(result)
         assert isinstance(summary, str)
         assert "Agent Validation Summary" in summary
+
+    async def test_runtime_load_uses_sandbox_when_enabled(self, tmp_path):
+        f = tmp_path / "agent.py"
+        f.write_text(
+            'from pathlib import Path\n'
+            'Path(__file__).with_name("host_import_marker.txt").write_text("bad")\n'
+            'class Agent:\n'
+            '    def __init__(self): pass\n'
+            '    def solve_task(self, task): return "done"\n'
+        )
+
+        class FakeSandboxManager:
+            def __init__(self):
+                self.calls = []
+
+            def is_docker_available(self):
+                return True
+
+            async def execute_in_sandbox(self, command, workspace_path, timeout):
+                self.calls.append({
+                    "command": command,
+                    "workspace_path": workspace_path,
+                    "timeout": timeout,
+                    "agent_present": Path(workspace_path, "agent.py").exists(),
+                    "marker_present": Path(
+                        workspace_path,
+                        "host_import_marker.txt",
+                    ).exists(),
+                })
+                return SandboxResult(
+                    success=True,
+                    output=(
+                        '{"valid": true, "errors": [], "warnings": [], '
+                        '"checks_passed": ["Agent class loaded and verified successfully in sandbox"]}'
+                    ),
+                    exit_code=0,
+                )
+
+        sandbox_manager = FakeSandboxManager()
+        validator = AgentValidator(
+            sandbox_manager=sandbox_manager,
+            use_sandbox=True,
+            timeout=11,
+        )
+
+        result = await validator.validate_agent(str(f))
+
+        assert result["valid"] is True, f"Errors: {result['errors']}"
+        assert sandbox_manager.calls[0]["command"].startswith("python3 -c ")
+        assert sandbox_manager.calls[0]["timeout"] == 11
+        assert sandbox_manager.calls[0]["agent_present"] is True
+        assert sandbox_manager.calls[0]["marker_present"] is False
+        assert not (tmp_path / "host_import_marker.txt").exists()
+        assert any("in sandbox" in check for check in result["checks_passed"])
+
+    async def test_sandbox_runtime_load_falls_back_when_unavailable(self, tmp_path):
+        f = tmp_path / "agent.py"
+        f.write_text(MINIMAL_AGENT)
+
+        class UnavailableSandboxManager:
+            def __init__(self):
+                self.calls = []
+
+            def is_docker_available(self):
+                return False
+
+            async def execute_in_sandbox(self, *args, **kwargs):
+                self.calls.append((args, kwargs))
+                raise AssertionError("Sandbox should not be used when unavailable")
+
+        sandbox_manager = UnavailableSandboxManager()
+        validator = AgentValidator(
+            sandbox_manager=sandbox_manager,
+            use_sandbox=True,
+        )
+
+        result = await validator.validate_agent(str(f))
+
+        assert result["valid"] is True, f"Errors: {result['errors']}"
+        assert sandbox_manager.calls == []
+        assert any(
+            "Agent class loaded and verified successfully" == check
+            for check in result["checks_passed"]
+        )

--- a/tests/unit/test_evaluation.py
+++ b/tests/unit/test_evaluation.py
@@ -244,6 +244,38 @@ class TestRunTestCase:
         assert result["passed"] == result["total"] == 3
         assert sandbox_manager.calls == []
 
+    async def test_sandbox_request_falls_back_when_not_ready_at_runtime(
+        self,
+        tmp_path,
+    ):
+        task = _make_task(tmp_path)
+
+        class NotReadySandboxManager:
+            def __init__(self):
+                self.calls = []
+
+            def is_sandbox_ready(self):
+                return False
+
+            async def execute_in_sandbox(self, *args, **kwargs):
+                self.calls.append((args, kwargs))
+                raise AssertionError("Sandbox should not be used when not ready")
+
+        sandbox_manager = NotReadySandboxManager()
+        runner = _make_runner(tmp_path, task)
+        runner.use_sandbox = True
+        runner.sandbox_manager = sandbox_manager
+
+        result = await runner._run_test_case(
+            "def add(a, b):\n    return a + b\n",
+            task.test_cases[0],
+            task,
+        )
+
+        assert result["success"] is True
+        assert result["passed"] == result["total"] == 3
+        assert sandbox_manager.calls == []
+
     def test_constructor_disables_sandbox_when_manager_not_ready(self, tmp_path):
         task = _make_task(tmp_path)
 

--- a/tests/unit/test_evaluation.py
+++ b/tests/unit/test_evaluation.py
@@ -244,6 +244,33 @@ class TestRunTestCase:
         assert result["passed"] == result["total"] == 3
         assert sandbox_manager.calls == []
 
+    def test_constructor_disables_sandbox_when_manager_not_ready(self, tmp_path):
+        task = _make_task(tmp_path)
+
+        class NotReadySandboxManager:
+            def is_sandbox_ready(self):
+                return False
+
+        bdir = tmp_path / "benchmarks"
+        bdir.mkdir(exist_ok=True)
+        cfg = {
+            "name": task.name,
+            "description": task.description,
+            "task_prompt": task.task_prompt,
+            "test_cases": task.test_cases,
+            "timeout": task.timeout,
+            "scoring_method": task.scoring_method,
+        }
+        (bdir / f"{task.name}.yaml").write_text(yaml.dump(cfg))
+
+        runner = BenchmarkRunner(
+            benchmarks_dir=str(bdir),
+            sandbox_manager=NotReadySandboxManager(),
+            use_sandbox=True,
+        )
+
+        assert runner.use_sandbox is False
+
 
 class TestSandboxManager:
 
@@ -252,6 +279,24 @@ class TestSandboxManager:
         assert SandboxManager._cpu_limit_to_nano_cpus("0.5") == 500_000_000
         assert SandboxManager._cpu_limit_to_nano_cpus("bad") is None
         assert SandboxManager._cpu_limit_to_nano_cpus("0") is None
+
+    def test_sandbox_ready_requires_docker_and_image(self, monkeypatch):
+        manager = SandboxManager()
+
+        monkeypatch.setattr(manager, "is_docker_available", lambda: False)
+        assert manager.is_sandbox_ready() is False
+
+        calls = []
+        monkeypatch.setattr(manager, "is_docker_available", lambda: True)
+        monkeypatch.setattr(manager, "ensure_sandbox_image", lambda: calls.append("ok"))
+        assert manager.is_sandbox_ready() is True
+        assert calls == ["ok"]
+
+        def fail_image():
+            raise RuntimeError("image unavailable")
+
+        monkeypatch.setattr(manager, "ensure_sandbox_image", fail_image)
+        assert manager.is_sandbox_ready() is False
 
 
 # ---------------------------------------------------------------------------
@@ -499,6 +544,39 @@ class TestAgentValidator:
                 raise AssertionError("Sandbox should not be used when unavailable")
 
         sandbox_manager = UnavailableSandboxManager()
+        validator = AgentValidator(
+            sandbox_manager=sandbox_manager,
+            use_sandbox=True,
+        )
+
+        result = await validator.validate_agent(str(f))
+
+        assert result["valid"] is True, f"Errors: {result['errors']}"
+        assert sandbox_manager.calls == []
+        assert any(
+            "Agent class loaded and verified successfully" == check
+            for check in result["checks_passed"]
+        )
+
+    async def test_sandbox_image_setup_failure_falls_back(self, tmp_path):
+        f = tmp_path / "agent.py"
+        f.write_text(MINIMAL_AGENT)
+
+        class ImageUnavailableSandboxManager:
+            def __init__(self):
+                self.calls = []
+
+            def is_docker_available(self):
+                return True
+
+            def ensure_sandbox_image(self):
+                raise RuntimeError("image unavailable")
+
+            async def execute_in_sandbox(self, *args, **kwargs):
+                self.calls.append((args, kwargs))
+                raise AssertionError("Sandbox should not be used when image setup fails")
+
+        sandbox_manager = ImageUnavailableSandboxManager()
         validator = AgentValidator(
             sandbox_manager=sandbox_manager,
             use_sandbox=True,

--- a/tests/unit/test_tools.py
+++ b/tests/unit/test_tools.py
@@ -203,6 +203,35 @@ class TestBashTool:
         assert "fallback" in result.output
         assert sandbox_manager.calls == []
 
+    async def test_sandbox_image_setup_failure_falls_back(self, tmp_path):
+        class ImageUnavailableSandboxManager:
+            def __init__(self):
+                self.calls = []
+
+            def is_docker_available(self):
+                return True
+
+            def ensure_sandbox_image(self):
+                raise RuntimeError("image unavailable")
+
+            async def execute_in_sandbox(self, *args, **kwargs):
+                self.calls.append((args, kwargs))
+                raise AssertionError("Sandbox should not be used when image setup fails")
+
+        sandbox_manager = ImageUnavailableSandboxManager()
+        tool = BashTool(
+            working_directory=str(tmp_path),
+            timeout=10,
+            sandbox_manager=sandbox_manager,
+            use_sandbox=True,
+        )
+
+        result = await tool.execute({"command": "echo image fallback"})
+
+        assert result.status == ToolExecutionStatus.SUCCESS
+        assert "image fallback" in result.output
+        assert sandbox_manager.calls == []
+
     def test_tool_name(self):
         assert self.tool.get_name() == "bash"
 
@@ -457,6 +486,38 @@ class TestEditTool:
                 raise AssertionError("Sandbox should not be used when unavailable")
 
         sandbox_manager = UnavailableSandboxManager()
+        tool = EditTool(
+            working_directory=str(tmp_path),
+            sandbox_manager=sandbox_manager,
+            use_sandbox=True,
+        )
+
+        result = await tool.execute({
+            "action": "write",
+            "file_path": "fallback.txt",
+            "content": "direct write",
+        })
+
+        assert result.status == ToolExecutionStatus.SUCCESS
+        assert (tmp_path / "fallback.txt").read_text() == "direct write"
+        assert sandbox_manager.calls == []
+
+    async def test_sandbox_image_setup_failure_falls_back(self, tmp_path):
+        class ImageUnavailableSandboxManager:
+            def __init__(self):
+                self.calls = []
+
+            def is_docker_available(self):
+                return True
+
+            def ensure_sandbox_image(self):
+                raise RuntimeError("image unavailable")
+
+            async def execute_in_sandbox(self, *args, **kwargs):
+                self.calls.append((args, kwargs))
+                raise AssertionError("Sandbox should not be used when image setup fails")
+
+        sandbox_manager = ImageUnavailableSandboxManager()
         tool = EditTool(
             working_directory=str(tmp_path),
             sandbox_manager=sandbox_manager,

--- a/tests/unit/test_tools.py
+++ b/tests/unit/test_tools.py
@@ -14,6 +14,7 @@ from agent.tools.base_tool import (
 )
 from agent.tools.bash_tool import BashTool
 from agent.tools.edit_tool import EditTool
+from sandbox.sandbox_manager import SandboxResult
 
 
 # ---------------------------------------------------------------------------
@@ -131,6 +132,75 @@ class TestBashTool:
         assert result.status == ToolExecutionStatus.SUCCESS
         assert "sk-test-secret" not in result.output
         assert "visible" in result.output
+
+    async def test_uses_sandbox_manager_when_enabled(self, tmp_path):
+        class FakeSandboxManager:
+            def __init__(self):
+                self.calls = []
+
+            def is_docker_available(self):
+                return True
+
+            async def execute_in_sandbox(self, command, workspace_path, timeout):
+                Path(workspace_path, "from_sandbox.txt").write_text("created in sandbox")
+                self.calls.append({
+                    "command": command,
+                    "workspace_path": workspace_path,
+                    "timeout": timeout,
+                })
+                return SandboxResult(
+                    success=True,
+                    output="sandbox hello\n",
+                    exit_code=0,
+                    execution_time=0.1,
+                )
+
+        sandbox_manager = FakeSandboxManager()
+        tool = BashTool(
+            working_directory=str(tmp_path),
+            timeout=10,
+            sandbox_manager=sandbox_manager,
+            use_sandbox=True,
+        )
+
+        result = await tool.execute({"command": "python3 hello.py", "timeout": 7})
+
+        assert result.status == ToolExecutionStatus.SUCCESS
+        assert result.output == "sandbox hello\n"
+        assert result.metadata == {"exit_code": 0, "sandboxed": True}
+        assert sandbox_manager.calls[0]["command"] == "python3 hello.py"
+        assert sandbox_manager.calls[0]["timeout"] == 7
+        assert sandbox_manager.calls[0]["workspace_path"] != str(tmp_path)
+        assert str(Path(sandbox_manager.calls[0]["workspace_path"])).startswith(
+            str(Path.home() / ".cache" / "dgm-sandbox")
+        )
+        assert (tmp_path / "from_sandbox.txt").read_text() == "created in sandbox"
+
+    async def test_sandbox_request_falls_back_when_unavailable(self, tmp_path):
+        class UnavailableSandboxManager:
+            def __init__(self):
+                self.calls = []
+
+            def is_docker_available(self):
+                return False
+
+            async def execute_in_sandbox(self, *args, **kwargs):
+                self.calls.append((args, kwargs))
+                raise AssertionError("Sandbox should not be used when unavailable")
+
+        sandbox_manager = UnavailableSandboxManager()
+        tool = BashTool(
+            working_directory=str(tmp_path),
+            timeout=10,
+            sandbox_manager=sandbox_manager,
+            use_sandbox=True,
+        )
+
+        result = await tool.execute({"command": "echo fallback"})
+
+        assert result.status == ToolExecutionStatus.SUCCESS
+        assert "fallback" in result.output
+        assert sandbox_manager.calls == []
 
     def test_tool_name(self):
         assert self.tool.get_name() == "bash"

--- a/tests/unit/test_tools.py
+++ b/tests/unit/test_tools.py
@@ -4,6 +4,7 @@ Unit tests for tool implementations: BashTool, EditTool, and base ToolRegistry.
 All async tests use pytest-asyncio (asyncio_mode = auto in pytest.ini).
 """
 
+import json
 import pytest
 import shutil
 import tempfile
@@ -338,6 +339,139 @@ class TestEditTool:
         read = await self.tool.execute({"action": "read", "file_path": "app.txt"})
         assert "line1" in read.output
         assert "line2" in read.output
+
+    async def test_uses_sandbox_manager_when_enabled(self, tmp_path):
+        class FakeSandboxManager:
+            def __init__(self):
+                self.calls = []
+
+            def is_docker_available(self):
+                return True
+
+            async def execute_in_sandbox(
+                self,
+                command,
+                agent_code_path=None,
+                workspace_path=None,
+                timeout=None,
+            ):
+                Path(workspace_path, "from_sandbox.txt").write_text(
+                    "created in sandbox"
+                )
+                self.calls.append({
+                    "command": command,
+                    "agent_code_path": agent_code_path,
+                    "agent_edit_tool_exists": (
+                        Path(agent_code_path) / "agent" / "tools" / "edit_tool.py"
+                    ).exists(),
+                    "workspace_path": workspace_path,
+                    "timeout": timeout,
+                })
+                return SandboxResult(
+                    success=True,
+                    output=json.dumps({
+                        "status": "success",
+                        "output": "Successfully wrote from_sandbox.txt",
+                        "error": "",
+                    }),
+                    exit_code=0,
+                    execution_time=0.1,
+                )
+
+        sandbox_manager = FakeSandboxManager()
+        tool = EditTool(
+            working_directory=str(tmp_path),
+            sandbox_manager=sandbox_manager,
+            use_sandbox=True,
+            timeout=12,
+        )
+
+        result = await tool.execute({
+            "action": "write",
+            "file_path": "from_sandbox.txt",
+            "content": "created in sandbox",
+        })
+
+        assert result.status == ToolExecutionStatus.SUCCESS
+        assert result.metadata == {"exit_code": 0, "sandboxed": True}
+        assert sandbox_manager.calls[0]["timeout"] == 12
+        assert sandbox_manager.calls[0]["workspace_path"] != str(tmp_path)
+        assert str(Path(sandbox_manager.calls[0]["workspace_path"])).startswith(
+            str(Path.home() / ".cache" / "dgm-sandbox")
+        )
+        assert sandbox_manager.calls[0]["agent_edit_tool_exists"] is True
+        assert sandbox_manager.calls[0]["command"].startswith("python3 -c ")
+        assert (tmp_path / "from_sandbox.txt").read_text() == "created in sandbox"
+        assert not (tmp_path / ".dgm_edit_tool_params.json").exists()
+
+    async def test_sandbox_delete_removes_host_file(self, tmp_path):
+        (tmp_path / "delete_me.txt").write_text("delete me")
+
+        class FakeSandboxManager:
+            def is_docker_available(self):
+                return True
+
+            async def execute_in_sandbox(
+                self,
+                command,
+                agent_code_path=None,
+                workspace_path=None,
+                timeout=None,
+            ):
+                Path(workspace_path, "delete_me.txt").unlink()
+                return SandboxResult(
+                    success=True,
+                    output=json.dumps({
+                        "status": "success",
+                        "output": "Successfully deleted delete_me.txt",
+                        "error": "",
+                    }),
+                    exit_code=0,
+                    execution_time=0.1,
+                )
+
+        tool = EditTool(
+            working_directory=str(tmp_path),
+            sandbox_manager=FakeSandboxManager(),
+            use_sandbox=True,
+        )
+
+        result = await tool.execute({
+            "action": "delete",
+            "file_path": "delete_me.txt",
+        })
+
+        assert result.status == ToolExecutionStatus.SUCCESS
+        assert not (tmp_path / "delete_me.txt").exists()
+
+    async def test_sandbox_request_falls_back_when_unavailable(self, tmp_path):
+        class UnavailableSandboxManager:
+            def __init__(self):
+                self.calls = []
+
+            def is_docker_available(self):
+                return False
+
+            async def execute_in_sandbox(self, *args, **kwargs):
+                self.calls.append((args, kwargs))
+                raise AssertionError("Sandbox should not be used when unavailable")
+
+        sandbox_manager = UnavailableSandboxManager()
+        tool = EditTool(
+            working_directory=str(tmp_path),
+            sandbox_manager=sandbox_manager,
+            use_sandbox=True,
+        )
+
+        result = await tool.execute({
+            "action": "write",
+            "file_path": "fallback.txt",
+            "content": "direct write",
+        })
+
+        assert result.status == ToolExecutionStatus.SUCCESS
+        assert (tmp_path / "fallback.txt").read_text() == "direct write"
+        assert sandbox_manager.calls == []
 
     async def test_unknown_action_is_error(self):
         result = await self.tool.execute({


### PR DESCRIPTION
## What changed

- Implemented a concrete Docker-backed `SandboxManager` for one-shot command execution with memory, CPU, timeout, working-directory, and network settings.
- Added Docker client socket fallbacks for local contexts such as Docker Desktop and Colima.
- Added a shared sandbox readiness check that verifies both Docker reachability and sandbox image setup before components opt into container execution.
- Wired generated benchmark test scripts through Docker when `evaluation.use_sandbox: true`.
- Extended the opt-in sandbox boundary to agent bash tool commands during benchmark solving and self-modification attempts.
- Extended the opt-in sandbox boundary to agent edit tool operations against a staged workspace, with successful changes synced back to the configured host workspace.
- Routed parseable self-modification solution strings through the sandbox-aware edit tool instead of direct controller writes.
- Extended modified-agent runtime load validation into Docker after local file and AST checks.
- Kept the default no-Docker path unchanged, with consistent fallback when Docker or image setup is unavailable.
- Updated config/docs for the new opt-in path while keeping README/SECURITY honest about the remaining host-side boundary.
- Added unit coverage for sandbox routing, fallback behavior, workspace staging/copy-back, edit delete propagation, solution-write sandboxing, validator isolation, readiness fallback, and controller-to-agent/validator wiring.

## Why

This advances roadmap item 1 from benchmark-script isolation toward runtime isolation. The DGM agent bash and edit tools are the surfaces that execute model-requested shell commands and file mutations during benchmark solving and self-modification attempts. Runtime validation is another sensitive surface because it imports modified agent code. Routing those operations through Docker is a material safety improvement without requiring Docker for the default test suite.

## Current boundary

With `evaluation.use_sandbox: true` and Docker/image setup available:

- Generated benchmark test scripts run in one-shot Docker containers.
- Agent bash tool commands run in one-shot Docker containers with the configured memory, CPU, timeout, working directory, and network mode.
- Agent edit tool operations run in one-shot Docker containers against a staged workspace, with successful changes synced back afterward.
- Self-modification returned-solution writes to `agent.py` are applied through the sandbox-aware edit tool.
- Modified-agent runtime load validation imports candidate code in a one-shot Docker container after local file/AST checks pass.
- Tool and validation workspaces are staged into a Docker-mountable cache before execution.

Still not fully isolated:

- The model orchestration loop runs in the host Python process.
- Controller/archive logic runs on the host.
- Successful tool/controller-applied changes intentionally sync back to the configured host workspace after sandbox execution; this is not yet a full persistent VM/container boundary for the whole DGM loop.

This PR is ready for review as a partial sandboxing slice. It should be merged only if we are comfortable landing this incremental boundary improvement before the remaining orchestration/controller isolation work.

## Validation

- Current `main` baseline after PR #13: `PATH="$PWD/.venv/bin:$PATH" python -m pytest` -> `167 passed, 7 skipped, 2 warnings`.
- PR branch after merging current `origin/main`: `PATH="$PWD/.venv/bin:$PATH" python -m pytest` -> `189 passed, 7 skipped, 2 warnings`.
- Live Docker smoke on Docker `27.4.0`:
  - sandbox readiness: `ready True`
  - benchmark generated test execution: `benchmark True 5 5`
  - bash tool: `bash success {"exit_code": 0, "sandboxed": True}`
  - edit tool: `edit success {"exit_code": 0, "sandboxed": True}`
  - runtime validator: `validator True` with `Agent class loaded and verified successfully in sandbox`.

## Review focus

- Confirm the documented boundary is acceptable for an incremental merge.
- Confirm the remaining full-loop orchestration/controller isolation should stay as follow-up work rather than blocking this slice.
