### PR TITLE
[codex] run pytest on GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  test:
+    name: pytest
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements.txt
+
+      - name: Run tests
+        run: python -m pytest

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 **A Self-Improving AI System for Evolutionary Code Enhancement**
 
 [![GitHub](https://img.shields.io/badge/GitHub-lemoz%2Fdarwin--godel--machine-blue?logo=github)](https://github.com/lemoz/darwin-godel-machine)
+[![CI](https://github.com/lemoz/darwin-godel-machine/actions/workflows/ci.yml/badge.svg)](https://github.com/lemoz/darwin-godel-machine/actions/workflows/ci.yml)
 ![Python](https://img.shields.io/badge/python-3.8+-blue.svg)
 ![License](https://img.shields.io/badge/license-MIT-green.svg)
 ![Status](https://img.shields.io/badge/status-beta-orange.svg)


### PR DESCRIPTION
## What changed

- Added `.github/workflows/ci.yml` to run `python -m pytest` on pushes to `main` and pull requests.
- Uses Python 3.11 and installs dependencies from `requirements.txt`.
- Added a README CI badge pointing at the workflow.

## Why

This completes roadmap item 2: GitHub Actions CI plus README badge. The default test suite is API-key-free, so it is safe for hosted CI.

## Validation

- `PATH="$PWD/.venv/bin:$PATH" python -m pytest` -> `155 passed, 7 skipped, 2 warnings`