### PR TITLE
[codex] use Node 24-ready CI actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,10 +13,10 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
           cache: pip


### PR DESCRIPTION
## What changed

- Updated `actions/checkout` from `@v4` to `@v6`.
- Updated `actions/setup-python` from `@v5` to `@v6`.

## Why

The first `main` CI run passed, but GitHub emitted a warning that the current actions use Node 20 and may be affected by the June 16, 2026 Node 24 transition. The official action repos now have current v6 releases, so this keeps CI current immediately.

## Validation

- `PATH="$PWD/.venv/bin:$PATH" python -m pytest` -> `155 passed, 7 skipped, 2 warnings`