### PR TITLE
[codex] add HumanEval-style benchmark pack

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,11 @@ inputs: ["abc123def", "hello5world"]
 expected_outputs: ["fed123cba", "dlrow5olleh"]
 ```
 
+For a harder no-network smoke path, see `config/benchmarks/humaneval_style.yaml`.
+It contains HumanEval-style standalone function tasks with reference solutions
+verified by the integration test suite; add `humaneval_style` to
+`benchmarks.enabled` when you want the DGM loop to evaluate against it.
+
 ## 🧪 Running Experiments
 
 ### Basic Evolution Run

--- a/config/benchmarks/humaneval_style.yaml
+++ b/config/benchmarks/humaneval_style.yaml
@@ -1,0 +1,72 @@
+name: humaneval_style
+description: HumanEval-style standalone Python function tasks with edge cases
+difficulty: medium
+timeout: 30
+category: algorithms
+scoring_method: partial
+
+task_prompt: |
+  Implement the requested standalone Python functions. Each function should be
+  deterministic, side-effect free, and should handle the listed edge cases.
+  Return only Python code that defines the requested functions.
+
+test_cases:
+  - function_name: has_close_pair
+    task_description: returns True when any two numbers are closer than the given threshold
+    inputs:
+      - "[1.0, 2.0, 3.0], 0.5"
+      - "[1.0, 2.0, 3.0], 1.1"
+      - "[], 1.0"
+      - "[5.0], 0.1"
+      - "[-1.0, -1.4, 2.0], 0.5"
+    expected_outputs:
+      - "False"
+      - "True"
+      - "False"
+      - "False"
+      - "True"
+
+  - function_name: split_balanced_parens
+    task_description: splits a string of parentheses into top-level balanced groups
+    inputs:
+      - "'(())()'"
+      - "'(()())(())'"
+      - "''"
+      - "'()()()'"
+      - "'((()))'"
+    expected_outputs:
+      - "['(())', '()']"
+      - "['(()())', '(())']"
+      - "[]"
+      - "['()', '()', '()']"
+      - "['((()))']"
+
+  - function_name: rolling_minimum
+    task_description: returns the running minimum after each item in a list of numbers
+    inputs:
+      - "[3, 2, 5, 1, 4]"
+      - "[1, 2, 3]"
+      - "[-1, -3, 0, -2]"
+      - "[]"
+      - "[5]"
+    expected_outputs:
+      - "[3, 2, 2, 1, 1]"
+      - "[1, 1, 1]"
+      - "[-1, -3, -3, -3]"
+      - "[]"
+      - "[5]"
+
+  - function_name: below_zero
+    task_description: returns True if a running account balance ever drops below zero
+    inputs:
+      - "[1, 2, -4, 1]"
+      - "[5, -3, -1]"
+      - "[-1]"
+      - "[]"
+      - "[2, -2, -1]"
+    expected_outputs:
+      - "True"
+      - "False"
+      - "True"
+      - "False"
+      - "True"

--- a/tests/fixtures/reference_solutions/humaneval_style.py
+++ b/tests/fixtures/reference_solutions/humaneval_style.py
@@ -1,0 +1,43 @@
+def has_close_pair(numbers, threshold):
+    for i, left in enumerate(numbers):
+        for right in numbers[i + 1:]:
+            if abs(left - right) < threshold:
+                return True
+    return False
+
+
+def split_balanced_parens(text):
+    groups = []
+    depth = 0
+    start = None
+
+    for index, char in enumerate(text):
+        if char == "(":
+            if depth == 0:
+                start = index
+            depth += 1
+        elif char == ")":
+            depth -= 1
+            if depth == 0 and start is not None:
+                groups.append(text[start:index + 1])
+                start = None
+
+    return groups
+
+
+def rolling_minimum(numbers):
+    result = []
+    current = None
+    for value in numbers:
+        current = value if current is None else min(current, value)
+        result.append(current)
+    return result
+
+
+def below_zero(changes):
+    balance = 0
+    for change in changes:
+        balance += change
+        if balance < 0:
+            return True
+    return False

--- a/tests/integration/test_benchmark_evaluation.py
+++ b/tests/integration/test_benchmark_evaluation.py
@@ -114,3 +114,25 @@ class TestBenchmarkEvaluationPipeline:
         }
         avg = self.runner.get_average_score(results)
         assert avg == pytest.approx(0.7)
+
+
+async def test_humaneval_style_reference_solution_passes():
+    """The shipped HumanEval-style pack must be verified without API calls."""
+    project_root = Path(__file__).resolve().parents[2]
+    runner = BenchmarkRunner(
+        benchmarks_dir=str(project_root / "config" / "benchmarks"),
+        use_sandbox=False,
+    )
+    task = runner.benchmarks["humaneval_style"]
+    reference_solution = (
+        project_root / "tests" / "fixtures" / "reference_solutions" / "humaneval_style.py"
+    ).read_text()
+
+    test_results = []
+    for test_case in task.test_cases:
+        result = await runner._run_test_case(reference_solution, test_case, task)
+        test_results.append(result)
+
+    assert len(task.test_cases) == 4
+    assert all(result["success"] for result in test_results)
+    assert runner._calculate_score({"test_results": test_results}, task) == pytest.approx(1.0)


### PR DESCRIPTION
## What changed

- Added `config/benchmarks/humaneval_style.yaml` with four HumanEval-style standalone function tasks and edge cases.
- Added a checked-in reference solution fixture for the pack.
- Added a no-network integration test that runs every task in the pack through `BenchmarkRunner` and verifies a perfect score.
- Documented the optional pack in README without enabling it by default, so live run cost and behavior stay unchanged unless `humaneval_style` is added to `benchmarks.enabled`.

## Why

This completes roadmap item 3: a harder benchmark pack with reference solutions that the default no-network suite verifies.

## Validation

- `PATH="$PWD/.venv/bin:$PATH" python -m pytest tests/integration/test_benchmark_evaluation.py` -> `8 passed, 1 warning`
- `PATH="$PWD/.venv/bin:$PATH" python -m pytest` -> `156 passed, 7 skipped, 2 warnings`