### PR TITLE
[codex] visualize archive lineage

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,13 @@ LLM-powered coding agents with:
 #### 3. **Archive Management** (`archive/`)
 - **Agent Archive**: Stores every valid agent (unbounded, per the paper) with full lineage
 - **Parent Selector**: Implements the paper's selection rule — sigmoid-scaled performance times a 1/(1+children) exploration bonus, sampled categorically
+- **Lineage Visualization**: Generate an SVG or HTML family tree from archive metadata
+
+```bash
+python scripts/generate_archive_lineage.py --archive-dir archive/agents --output docs/archive-lineage.html
+```
+
+![Archive lineage example](docs/archive-lineage-example.svg)
 
 #### 4. **Evaluation System** (`evaluation/`)
 - **Benchmark Runner**: Executes agents on coding challenges

--- a/archive/__init__.py
+++ b/archive/__init__.py
@@ -7,10 +7,13 @@ novelty_calculator are deleted dead code.
 """
 
 from .agent_archive import AgentArchive, ArchivedAgent
+from .lineage_visualizer import render_archive_lineage_html, render_archive_lineage_svg
 from .parent_selector import ParentSelector
 
 __all__ = [
     'AgentArchive',
     'ArchivedAgent',
     'ParentSelector',
+    'render_archive_lineage_html',
+    'render_archive_lineage_svg',
 ]

--- a/archive/lineage_visualizer.py
+++ b/archive/lineage_visualizer.py
@@ -1,0 +1,153 @@
+"""Archive lineage visualization helpers."""
+
+from collections import defaultdict
+from html import escape
+from typing import Dict, Iterable, List, Tuple
+
+from .agent_archive import ArchivedAgent
+
+
+def _short_id(agent_id: str) -> str:
+    return agent_id[:8]
+
+
+def _score_label(score: float) -> str:
+    return f"{score:.3f}"
+
+
+def _sorted_agents(agents: Iterable[ArchivedAgent]) -> List[ArchivedAgent]:
+    return sorted(agents, key=lambda agent: (agent.generation, agent.created_at, agent.agent_id))
+
+
+def render_archive_lineage_svg(agents: Iterable[ArchivedAgent]) -> str:
+    """Render archived agents as a simple SVG family tree."""
+    sorted_agents = _sorted_agents(agents)
+    if not sorted_agents:
+        return (
+            '<svg xmlns="http://www.w3.org/2000/svg" width="480" height="160" '
+            'viewBox="0 0 480 160" role="img" aria-label="Empty archive lineage">'
+            '<rect width="480" height="160" fill="#ffffff"/>'
+            '<text x="240" y="82" text-anchor="middle" font-family="Arial, sans-serif" '
+            'font-size="18" fill="#475569">No archived agents yet</text>'
+            "</svg>"
+        )
+
+    levels: Dict[int, List[ArchivedAgent]] = defaultdict(list)
+    for agent in sorted_agents:
+        levels[agent.generation].append(agent)
+
+    node_width = 150
+    node_height = 72
+    x_gap = 40
+    y_gap = 70
+    margin = 40
+    max_nodes = max(len(level) for level in levels.values())
+    max_generation = max(levels)
+    width = max(520, margin * 2 + max_nodes * node_width + (max_nodes - 1) * x_gap)
+    height = margin * 2 + (max_generation + 1) * node_height + max_generation * y_gap
+
+    positions: Dict[str, Tuple[int, int]] = {}
+    for generation, level_agents in levels.items():
+        row_width = len(level_agents) * node_width + (len(level_agents) - 1) * x_gap
+        start_x = (width - row_width) // 2
+        y = margin + generation * (node_height + y_gap)
+        for index, agent in enumerate(level_agents):
+            x = start_x + index * (node_width + x_gap)
+            positions[agent.agent_id] = (x, y)
+
+    parts = [
+        f'<svg xmlns="http://www.w3.org/2000/svg" width="{width}" height="{height}" '
+        f'viewBox="0 0 {width} {height}" role="img" aria-label="DGM archive lineage">',
+        '<rect width="100%" height="100%" fill="#ffffff"/>',
+        '<style>'
+        '.node-label{font-family:Arial,sans-serif;font-size:13px;fill:#0f172a}'
+        '.node-meta{font-family:Arial,sans-serif;font-size:11px;fill:#475569}'
+        '.edge{stroke:#94a3b8;stroke-width:2;fill:none}'
+        "</style>",
+    ]
+
+    for agent in sorted_agents:
+        if not agent.parent_id or agent.parent_id not in positions:
+            continue
+        parent_x, parent_y = positions[agent.parent_id]
+        child_x, child_y = positions[agent.agent_id]
+        x1 = parent_x + node_width // 2
+        y1 = parent_y + node_height
+        x2 = child_x + node_width // 2
+        y2 = child_y
+        mid_y = (y1 + y2) // 2
+        parts.append(
+            f'<path class="edge" d="M{x1},{y1} C{x1},{mid_y} {x2},{mid_y} {x2},{y2}"/>'
+        )
+
+    for agent in sorted_agents:
+        x, y = positions[agent.agent_id]
+        fill = "#ecfdf5" if agent.is_valid else "#fef2f2"
+        stroke = "#10b981" if agent.is_valid else "#ef4444"
+        label = escape(_short_id(agent.agent_id))
+        score = escape(_score_label(agent.average_score))
+        parent = escape(_short_id(agent.parent_id)) if agent.parent_id else "root"
+        parts.extend([
+            f'<rect x="{x}" y="{y}" width="{node_width}" height="{node_height}" '
+            f'rx="8" fill="{fill}" stroke="{stroke}" stroke-width="2"/>',
+            f'<text class="node-label" x="{x + 12}" y="{y + 24}">agent {label}</text>',
+            f'<text class="node-meta" x="{x + 12}" y="{y + 43}">gen {agent.generation} '
+            f'| score {score}</text>',
+            f'<text class="node-meta" x="{x + 12}" y="{y + 60}">parent {parent}</text>',
+        ])
+
+    parts.append("</svg>")
+    return "\n".join(parts)
+
+
+def render_archive_lineage_html(agents: Iterable[ArchivedAgent]) -> str:
+    """Render archived agents as a standalone HTML lineage report."""
+    sorted_agents = _sorted_agents(agents)
+    svg = render_archive_lineage_svg(sorted_agents)
+    rows = []
+    for agent in sorted_agents:
+        rows.append(
+            "<tr>"
+            f"<td>{escape(agent.agent_id)}</td>"
+            f"<td>{escape(agent.parent_id or '')}</td>"
+            f"<td>{agent.generation}</td>"
+            f"<td>{escape(_score_label(agent.average_score))}</td>"
+            f"<td>{'yes' if agent.is_valid else 'no'}</td>"
+            f"<td>{escape(agent.created_at)}</td>"
+            "</tr>"
+        )
+
+    table_body = "\n".join(rows) or '<tr><td colspan="6">No archived agents yet</td></tr>'
+    return f"""<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>DGM Archive Lineage</title>
+  <style>
+    body {{ font-family: Arial, sans-serif; margin: 32px; color: #0f172a; }}
+    table {{ border-collapse: collapse; width: 100%; margin-top: 24px; }}
+    th, td {{ border: 1px solid #cbd5e1; padding: 8px 10px; text-align: left; }}
+    th {{ background: #f8fafc; }}
+  </style>
+</head>
+<body>
+  <h1>DGM Archive Lineage</h1>
+  {svg}
+  <table>
+    <thead>
+      <tr>
+        <th>Agent</th>
+        <th>Parent</th>
+        <th>Generation</th>
+        <th>Average score</th>
+        <th>Valid</th>
+        <th>Created</th>
+      </tr>
+    </thead>
+    <tbody>
+      {table_body}
+    </tbody>
+  </table>
+</body>
+</html>
+"""

--- a/docs/archive-lineage-example.svg
+++ b/docs/archive-lineage-example.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="520" height="436" viewBox="0 0 520 436" role="img" aria-label="DGM archive lineage">
+<rect width="100%" height="100%" fill="#ffffff"/>
+<style>.node-label{font-family:Arial,sans-serif;font-size:13px;fill:#0f172a}.node-meta{font-family:Arial,sans-serif;font-size:11px;fill:#475569}.edge{stroke:#94a3b8;stroke-width:2;fill:none}</style>
+<path class="edge" d="M260,112 C260,147 165,147 165,182"/>
+<path class="edge" d="M260,112 C260,147 355,147 355,182"/>
+<path class="edge" d="M165,254 C165,289 260,289 260,324"/>
+<rect x="185" y="40" width="150" height="72" rx="8" fill="#ecfdf5" stroke="#10b981" stroke-width="2"/>
+<text class="node-label" x="197" y="64">agent rootdemo</text>
+<text class="node-meta" x="197" y="83">gen 0 | score 0.500</text>
+<text class="node-meta" x="197" y="100">parent root</text>
+<rect x="90" y="182" width="150" height="72" rx="8" fill="#ecfdf5" stroke="#10b981" stroke-width="2"/>
+<text class="node-label" x="102" y="206">agent branchA1</text>
+<text class="node-meta" x="102" y="225">gen 1 | score 0.720</text>
+<text class="node-meta" x="102" y="242">parent rootdemo</text>
+<rect x="280" y="182" width="150" height="72" rx="8" fill="#fef2f2" stroke="#ef4444" stroke-width="2"/>
+<text class="node-label" x="292" y="206">agent branchB1</text>
+<text class="node-meta" x="292" y="225">gen 1 | score 0.350</text>
+<text class="node-meta" x="292" y="242">parent rootdemo</text>
+<rect x="185" y="324" width="150" height="72" rx="8" fill="#ecfdf5" stroke="#10b981" stroke-width="2"/>
+<text class="node-label" x="197" y="348">agent leafA101</text>
+<text class="node-meta" x="197" y="367">gen 2 | score 0.810</text>
+<text class="node-meta" x="197" y="384">parent branchA1</text>
+</svg>

--- a/scripts/generate_archive_lineage.py
+++ b/scripts/generate_archive_lineage.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Generate an SVG or HTML archive lineage report."""
+
+import argparse
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from archive import AgentArchive
+from archive.lineage_visualizer import (
+    render_archive_lineage_html,
+    render_archive_lineage_svg,
+)
+
+
+def _infer_format(output_path: Path) -> str:
+    suffix = output_path.suffix.lower()
+    if suffix == ".svg":
+        return "svg"
+    if suffix in {".html", ".htm"}:
+        return "html"
+    raise ValueError("Cannot infer format: output must end in .svg, .html, or .htm")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--archive-dir",
+        default="archive/agents",
+        help="Directory containing archive_metadata.json",
+    )
+    parser.add_argument(
+        "--output",
+        default="docs/archive-lineage.html",
+        help="Output path ending in .svg or .html",
+    )
+    parser.add_argument(
+        "--format",
+        choices=["svg", "html"],
+        help="Output format. Defaults to the output file extension.",
+    )
+    args = parser.parse_args()
+
+    output_path = Path(args.output)
+    output_format = args.format or _infer_format(output_path)
+    archive = AgentArchive(archive_dir=args.archive_dir)
+    agents = archive.get_all_agents()
+
+    if output_format == "svg":
+        rendered = render_archive_lineage_svg(agents)
+    else:
+        rendered = render_archive_lineage_html(agents)
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(rendered, encoding="utf-8")
+    print(f"Wrote {output_format} lineage report to {output_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_archive.py
+++ b/tests/unit/test_archive.py
@@ -12,10 +12,15 @@ import random
 import shutil
 import tempfile
 from pathlib import Path
+from typing import Optional
 
 import pytest
 
 from archive.agent_archive import AgentArchive, ArchivedAgent
+from archive.lineage_visualizer import (
+    render_archive_lineage_html,
+    render_archive_lineage_svg,
+)
 from archive.parent_selector import ParentSelector
 
 
@@ -33,6 +38,26 @@ def _make_agent_file(tmp_path: Path, name: str = "agent.py") -> Path:
 def _add_agent(archive: AgentArchive, agent_file: Path, **kwargs) -> ArchivedAgent:
     """Thin wrapper so tests don't repeat keyword noise."""
     return archive.add_agent(agent_path=str(agent_file), **kwargs)
+
+
+def _archived_agent(
+    agent_id: str,
+    parent_id: Optional[str],
+    generation: int,
+    score: float,
+    is_valid: bool = True,
+) -> ArchivedAgent:
+    return ArchivedAgent(
+        agent_id=agent_id,
+        parent_id=parent_id,
+        generation=generation,
+        source_path=f"/tmp/{agent_id}",
+        created_at=f"2026-06-12T00:00:0{generation}",
+        benchmark_scores={"bench": score},
+        average_score=score,
+        is_valid=is_valid,
+        metadata={},
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -159,6 +184,37 @@ class TestAgentArchive:
 
         children = archive.get_agent_children(parent.agent_id)
         assert len(children) == 2
+
+
+class TestArchiveLineageVisualizer:
+
+    def test_render_archive_lineage_svg_contains_nodes_and_edges(self):
+        root = _archived_agent("root-agent", None, 0, 0.4)
+        child = _archived_agent("child-agent", root.agent_id, 1, 0.8)
+
+        svg = render_archive_lineage_svg([child, root])
+
+        assert svg.startswith('<svg xmlns="http://www.w3.org/2000/svg"')
+        assert "agent root-age" in svg
+        assert "agent child-ag" in svg
+        assert "score 0.800" in svg
+        assert "<path" in svg
+
+    def test_render_archive_lineage_svg_empty_archive(self):
+        svg = render_archive_lineage_svg([])
+        assert "No archived agents yet" in svg
+
+    def test_render_archive_lineage_html_contains_table(self):
+        root = _archived_agent("root-agent", None, 0, 0.4)
+        child = _archived_agent("child-agent", root.agent_id, 1, 0.8, is_valid=False)
+
+        html = render_archive_lineage_html([root, child])
+
+        assert "<!doctype html>" in html
+        assert "<table>" in html
+        assert "root-agent" in html
+        assert "child-agent" in html
+        assert "<td>no</td>" in html
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What changed

- Added `archive.lineage_visualizer` with SVG and standalone HTML renderers for archived agent family trees.
- Added `scripts/generate_archive_lineage.py` to generate `.svg` or `.html` reports from `archive_metadata.json`.
- Added a checked-in sample SVG and embedded it in README.
- Added unit tests for populated, empty, and HTML lineage rendering.

## Why

This completes roadmap item 4: archive lineage visualization generated from archive metadata with a visual example in README.

## Validation

- `PATH="$PWD/.venv/bin:$PATH" python -m pytest tests/unit/test_archive.py` -> `21 passed`
- `PATH="$PWD/.venv/bin:$PATH" python scripts/generate_archive_lineage.py --archive-dir /tmp/dgm-empty-archive --output /tmp/dgm-lineage-smoke.svg` -> wrote SVG
- `PATH="$PWD/.venv/bin:$PATH" python -m pytest` -> `159 passed, 7 skipped, 2 warnings`