### PR TITLE
[codex] add live run cost gate

### DIFF
--- a/docs/live-run-cost-gate-2026-06-12.md
+++ b/docs/live-run-cost-gate-2026-06-12.md
@@ -1,0 +1,56 @@
+# Live Run Cost Gate - 2026-06-12
+
+This is the approval gate for the roadmap item "Documented live run." No live
+DGM run has been executed for this estimate.
+
+## Configuration Snapshot
+
+- Entry point: `python run_dgm.py`
+- Generations: 3, as hard-coded in `run_dgm.py`
+- Provider/model: `anthropic` / `claude-sonnet-4-6`
+- Enabled benchmarks: `string_manipulation`, `list_processing`, `simple_algorithm`
+- Agent max steps per task: 20
+- Max output tokens per request: 8,192
+
+## Pricing Snapshot
+
+Anthropic's official pricing pages list Claude Sonnet 4.6 at $3 per million
+input tokens and $15 per million output tokens as of 2026-06-12:
+
+- https://docs.anthropic.com/en/docs/about-claude/pricing
+- https://www.anthropic.com/claude/sonnet
+
+Re-check pricing before executing a live run; provider pricing can change.
+
+## Estimate Command
+
+```bash
+python scripts/estimate_live_run_cost.py \
+  --generations 3 \
+  --avg-input-tokens-per-call 8000 \
+  --input-usd-per-mtok 3 \
+  --output-usd-per-mtok 15
+```
+
+## Estimate
+
+- Agent tasks: 15 (3 base evaluation + 3 generations x 4)
+- Request upper bound: 300 (20 max steps per task)
+- Assumed input tokens: 2,400,000 (8,000 average per request)
+- Output token ceiling: 2,457,600 (8,192 max output per request)
+- Estimated input cost: $7.2000
+- Estimated output ceiling cost: $36.8640
+- Estimated total ceiling: $44.0640
+
+This is an upper-bound-style estimate for output tokens, not a forecast. Actual
+usage can be lower when agents finish before `max_steps` or emit less than
+`max_tokens`, and can differ if prompt growth pushes average input tokens above
+the 8,000-token assumption.
+
+## Approval Needed
+
+Before running `python run_dgm.py`, Chris should approve one of:
+
+- Approve the default 3-generation run with a soft budget ceiling of $45.
+- Reduce scope to 1 generation before the flagship run.
+- Change provider/model, max steps, or benchmark set and regenerate this estimate.

--- a/docs/live-run-cost-gate-2026-06-12.md
+++ b/docs/live-run-cost-gate-2026-06-12.md
@@ -5,8 +5,8 @@ DGM run has been executed for this estimate.
 
 ## Configuration Snapshot
 
-- Entry point: `python run_dgm.py`
-- Generations: 3, as hard-coded in `run_dgm.py`
+- Entry point: `python run_dgm.py --generations 3`
+- Generations: 3, matching the default `run_dgm.py` CLI value
 - Provider/model: `anthropic` / `claude-sonnet-4-6`
 - Enabled benchmarks: `string_manipulation`, `list_processing`, `simple_algorithm`
 - Agent max steps per task: 20
@@ -49,7 +49,7 @@ the 8,000-token assumption.
 
 ## Approval Needed
 
-Before running `python run_dgm.py`, Chris should approve one of:
+Before running `python run_dgm.py --generations 3`, Chris should approve one of:
 
 - Approve the default 3-generation run with a soft budget ceiling of $45.
 - Reduce scope to 1 generation before the flagship run.

--- a/scripts/estimate_live_run_cost.py
+++ b/scripts/estimate_live_run_cost.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Estimate a DGM live-run token and cost ceiling without calling model APIs."""
+
+import argparse
+import json
+from typing import Any, Dict
+
+import yaml
+
+
+def load_config(path: str) -> Dict[str, Any]:
+    with open(path, "r", encoding="utf-8") as file:
+        return yaml.safe_load(file)
+
+
+def estimate_live_run(
+    config: Dict[str, Any],
+    generations: int,
+    avg_input_tokens_per_call: int,
+    input_usd_per_mtok: float,
+    output_usd_per_mtok: float,
+) -> Dict[str, Any]:
+    """Estimate upper-bound output spend and assumed input spend."""
+    provider = config["fm_providers"]["primary"]
+    provider_config = config["fm_providers"][provider]
+    enabled_benchmarks = config["benchmarks"]["enabled"]
+    max_steps = int(config["agents"].get("max_steps", 20))
+    max_output_tokens = int(provider_config.get("max_tokens", 8192))
+
+    base_evaluation_tasks = len(enabled_benchmarks)
+    tasks_per_generation = 1 + len(enabled_benchmarks)  # self-modification + evaluation
+    total_agent_tasks = base_evaluation_tasks + generations * tasks_per_generation
+    request_upper_bound = total_agent_tasks * max_steps
+    input_tokens = request_upper_bound * avg_input_tokens_per_call
+    output_token_ceiling = request_upper_bound * max_output_tokens
+    input_cost = input_tokens / 1_000_000 * input_usd_per_mtok
+    output_cost = output_token_ceiling / 1_000_000 * output_usd_per_mtok
+
+    return {
+        "provider": provider,
+        "model": provider_config.get("model"),
+        "generations": generations,
+        "enabled_benchmarks": enabled_benchmarks,
+        "base_evaluation_tasks": base_evaluation_tasks,
+        "tasks_per_generation": tasks_per_generation,
+        "total_agent_tasks": total_agent_tasks,
+        "max_steps_per_task": max_steps,
+        "request_upper_bound": request_upper_bound,
+        "avg_input_tokens_per_call": avg_input_tokens_per_call,
+        "input_tokens_assumed": input_tokens,
+        "max_output_tokens_per_call": max_output_tokens,
+        "output_token_ceiling": output_token_ceiling,
+        "input_usd_per_mtok": input_usd_per_mtok,
+        "output_usd_per_mtok": output_usd_per_mtok,
+        "input_cost_usd": round(input_cost, 4),
+        "output_cost_ceiling_usd": round(output_cost, 4),
+        "estimated_total_usd": round(input_cost + output_cost, 4),
+    }
+
+
+def render_markdown(estimate: Dict[str, Any]) -> str:
+    benchmarks = ", ".join(estimate["enabled_benchmarks"])
+    return f"""# DGM Live Run Cost Estimate
+
+- Provider/model: `{estimate["provider"]}` / `{estimate["model"]}`
+- Generations: {estimate["generations"]}
+- Enabled benchmarks: {benchmarks}
+- Agent tasks: {estimate["total_agent_tasks"]} ({estimate["base_evaluation_tasks"]} base evaluation + {estimate["generations"]} generations x {estimate["tasks_per_generation"]})
+- Request upper bound: {estimate["request_upper_bound"]} ({estimate["max_steps_per_task"]} max steps per task)
+- Assumed input tokens: {estimate["input_tokens_assumed"]:,} ({estimate["avg_input_tokens_per_call"]:,} average per request)
+- Output token ceiling: {estimate["output_token_ceiling"]:,} ({estimate["max_output_tokens_per_call"]:,} max output per request)
+- Rates: ${estimate["input_usd_per_mtok"]}/MTok input, ${estimate["output_usd_per_mtok"]}/MTok output
+- Estimated input cost: ${estimate["input_cost_usd"]:.4f}
+- Estimated output ceiling cost: ${estimate["output_cost_ceiling_usd"]:.4f}
+- Estimated total ceiling: ${estimate["estimated_total_usd"]:.4f}
+"""
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--config", default="config/dgm_config.yaml")
+    parser.add_argument("--generations", type=int, default=3)
+    parser.add_argument("--avg-input-tokens-per-call", type=int, required=True)
+    parser.add_argument("--input-usd-per-mtok", type=float, required=True)
+    parser.add_argument("--output-usd-per-mtok", type=float, required=True)
+    parser.add_argument("--format", choices=["json", "markdown"], default="markdown")
+    args = parser.parse_args()
+
+    estimate = estimate_live_run(
+        config=load_config(args.config),
+        generations=args.generations,
+        avg_input_tokens_per_call=args.avg_input_tokens_per_call,
+        input_usd_per_mtok=args.input_usd_per_mtok,
+        output_usd_per_mtok=args.output_usd_per_mtok,
+    )
+
+    if args.format == "json":
+        print(json.dumps(estimate, indent=2))
+    else:
+        print(render_markdown(estimate))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_live_run_cost_estimator.py
+++ b/tests/unit/test_live_run_cost_estimator.py
@@ -1,0 +1,49 @@
+from scripts.estimate_live_run_cost import estimate_live_run, render_markdown
+
+
+def _config():
+    return {
+        "fm_providers": {
+            "primary": "anthropic",
+            "anthropic": {
+                "model": "claude-sonnet-4-6",
+                "max_tokens": 1000,
+            },
+        },
+        "agents": {"max_steps": 2},
+        "benchmarks": {"enabled": ["a", "b", "c"]},
+    }
+
+
+def test_estimate_live_run_counts_base_eval_and_generations():
+    estimate = estimate_live_run(
+        config=_config(),
+        generations=3,
+        avg_input_tokens_per_call=100,
+        input_usd_per_mtok=3.0,
+        output_usd_per_mtok=15.0,
+    )
+
+    assert estimate["base_evaluation_tasks"] == 3
+    assert estimate["tasks_per_generation"] == 4
+    assert estimate["total_agent_tasks"] == 15
+    assert estimate["request_upper_bound"] == 30
+    assert estimate["input_tokens_assumed"] == 3000
+    assert estimate["output_token_ceiling"] == 30000
+    assert estimate["estimated_total_usd"] == 0.459
+
+
+def test_render_markdown_includes_approval_relevant_numbers():
+    estimate = estimate_live_run(
+        config=_config(),
+        generations=1,
+        avg_input_tokens_per_call=100,
+        input_usd_per_mtok=3.0,
+        output_usd_per_mtok=15.0,
+    )
+
+    markdown = render_markdown(estimate)
+
+    assert "Provider/model: `anthropic` / `claude-sonnet-4-6`" in markdown
+    assert "Request upper bound: 14" in markdown
+    assert "Estimated total ceiling:" in markdown


### PR DESCRIPTION
## What changed

- Added `scripts/estimate_live_run_cost.py`, a no-API estimator for DGM live-run request ceilings and cost assumptions.
- Added `docs/live-run-cost-gate-2026-06-12.md` with a dated estimate for `python run_dgm.py --generations 3`.
- Added unit tests for estimator math and markdown output.
- Refreshed the gate after `run_dgm.py` gained the documented `--generations` CLI.

## Why

Roadmap item 5 requires a cost estimate and Chris approval before spending API budget on a documented live run. This PR creates that approval gate without executing the DGM or making API calls.

## Pricing source

- Anthropic pricing docs: https://docs.anthropic.com/en/docs/about-claude/pricing
- Anthropic Sonnet page: https://www.anthropic.com/claude/sonnet

The estimate uses $3/MTok input and $15/MTok output for Claude Sonnet 4.6, checked on 2026-06-12. Pricing should be re-checked before execution.

## Validation

- `PATH="$PWD/.venv/bin:$PATH" python -m pytest tests/unit/test_live_run_cost_estimator.py tests/unit/test_run_dgm_cli.py` -> `6 passed, 1 warning`
- `PATH="$PWD/.venv/bin:$PATH" python -m pytest` -> `165 passed, 7 skipped, 2 warnings`

## Needs Chris

Approve one of the options in the gate document before any live API run: default 3 generations with a $45 soft ceiling, reduce to 1 generation, or change provider/model/max steps/benchmarks and regenerate the estimate.