### PR TITLE
[codex] honor run_dgm generation flag

### DIFF
--- a/run_dgm.py
+++ b/run_dgm.py
@@ -3,6 +3,7 @@
 Run the Darwin Gödel Machine with basic benchmarks.
 """
 
+import argparse
 import asyncio
 import logging
 import sys
@@ -30,18 +31,34 @@ logging.basicConfig(
 logger = logging.getLogger(__name__)
 
 
-async def main():
+def parse_args(argv=None):
+    """Parse CLI arguments."""
+    parser = argparse.ArgumentParser(description="Run the Darwin Gödel Machine")
+    parser.add_argument(
+        "--config",
+        default="config/dgm_config.yaml",
+        help="Path to DGM configuration file",
+    )
+    parser.add_argument(
+        "--generations",
+        type=int,
+        default=3,
+        help="Number of DGM generations to run",
+    )
+    return parser.parse_args(argv)
+
+
+async def main(argv=None):
     """Run the DGM loop."""
+    args = parse_args(argv)
     try:
         # Initialize the DGM controller
         logger.info("Initializing Darwin Gödel Machine...")
-        controller = DGMController()
+        controller = DGMController(config_or_path=args.config)
         
-        # Run for a limited number of generations
-        num_generations = 3  # Start with 3 generations for testing
-        logger.info(f"Running DGM for {num_generations} generations...")
+        logger.info(f"Running DGM for {args.generations} generations...")
         
-        await controller.run(num_generations=num_generations)
+        await controller.run(num_generations=args.generations)
         
         logger.info("DGM run completed successfully!")
         

--- a/tests/unit/test_run_dgm_cli.py
+++ b/tests/unit/test_run_dgm_cli.py
@@ -1,0 +1,47 @@
+import pytest
+
+import run_dgm
+
+
+def test_parse_args_defaults_to_documented_three_generations():
+    args = run_dgm.parse_args([])
+
+    assert args.config == "config/dgm_config.yaml"
+    assert args.generations == 3
+
+
+def test_parse_args_accepts_generation_and_config_override():
+    args = run_dgm.parse_args([
+        "--config",
+        "custom.yaml",
+        "--generations",
+        "10",
+    ])
+
+    assert args.config == "custom.yaml"
+    assert args.generations == 10
+
+
+async def test_main_passes_cli_args_to_controller(monkeypatch):
+    calls = {}
+
+    class FakeController:
+        def __init__(self, config_or_path):
+            calls["config_or_path"] = config_or_path
+
+        async def run(self, num_generations):
+            calls["num_generations"] = num_generations
+
+    monkeypatch.setattr(run_dgm, "DGMController", FakeController)
+
+    await run_dgm.main(["--config", "custom.yaml", "--generations", "2"])
+
+    assert calls == {
+        "config_or_path": "custom.yaml",
+        "num_generations": 2,
+    }
+
+
+def test_parse_args_rejects_non_integer_generations():
+    with pytest.raises(SystemExit):
+        run_dgm.parse_args(["--generations", "many"])


### PR DESCRIPTION
## What changed

- Added `--generations` to `run_dgm.py`, defaulting to the existing 3-generation behavior.
- Added `--config` so the runner can use a non-default config file.
- Added no-network unit tests for argument parsing and the controller handoff.

## Why

README documents `python run_dgm.py --generations 10`, but `run_dgm.py` previously ignored CLI arguments and always ran 3 generations. This fixes that mismatch and makes the live-run approval gate easier to execute exactly after Chris approves a scope.

## Validation

- `PATH="$PWD/.venv/bin:$PATH" python -m pytest tests/unit/test_run_dgm_cli.py` -> `4 passed, 1 warning`
- `PATH="$PWD/.venv/bin:$PATH" python run_dgm.py --help` -> shows `--config` and `--generations`
- `PATH="$PWD/.venv/bin:$PATH" python -m pytest` -> `163 passed, 7 skipped, 2 warnings`