### PR TITLE
[codex] prove live DGM run

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -140,6 +140,7 @@ results/
 exports/
 debug/
 test_workspace/
+.dgm-live-runs/
 agents/workspace/
 archive/agents/
 *.pid

--- a/agent/agent.py
+++ b/agent/agent.py
@@ -199,7 +199,7 @@ class Agent:
             Solution string
         """
         solution = ""
-        max_steps = 20  # Reasonable limit based on observed agent behavior
+        max_steps = max(1, int(self.config.max_iterations))
         
         logger.info(f"Starting task solution with up to {max_steps} steps for task {task.task_id}")
         
@@ -224,6 +224,8 @@ class Agent:
                     logger.info(f"Recent message {i+1}: Role={msg.role}, Content preview={msg.content[:100] if msg.content else 'None'}...")
             response = await self.fm_handler.get_completion(request)
             logger.info(f"API call completed. Tool calls: {len(response.tool_calls) if response.tool_calls else 0}")
+            if response.usage:
+                logger.info(f"API usage: {response.usage}")
             
             # Log agent's response for debugging
             if response.content:

--- a/agent/tools/bash_tool.py
+++ b/agent/tools/bash_tool.py
@@ -56,6 +56,15 @@ class BashTool(BaseTool):
         }
         
         super().__init__()
+
+    def _sanitized_environment(self) -> Dict[str, str]:
+        """Return the process environment without credential-like variables."""
+        sensitive_terms = ("key", "token", "secret", "password", "credential")
+        return {
+            key: value
+            for key, value in os.environ.items()
+            if not any(term in key.lower() for term in sensitive_terms)
+        }
     
     def get_name(self) -> str:
         """Get the name of this tool."""
@@ -271,7 +280,7 @@ class BashTool(BaseTool):
                 stdout=subprocess.PIPE if capture_output else None,
                 stderr=subprocess.PIPE if capture_output else None,
                 cwd=self.working_directory,
-                env=os.environ.copy(),
+                env=self._sanitized_environment(),
                 start_new_session=True,  # puts the shell in its own process group
             )
 

--- a/config/live_dgm_proof.yaml
+++ b/config/live_dgm_proof.yaml
@@ -1,0 +1,42 @@
+# Minimal live DGM proof configuration.
+#
+# This config is intentionally narrower than config/dgm_config.yaml so a live
+# API-backed run can prove the full loop without using the default budget.
+
+fm_providers:
+  primary: anthropic
+  anthropic:
+    model: claude-sonnet-4-6
+    api_key: ${ANTHROPIC_API_KEY}
+    max_tokens: 2048
+    temperature: 0.1
+    timeout: 60
+
+archive:
+  path: .dgm-live-runs/2026-06-12-proof/archive
+
+parent_selection:
+  lambda: 10
+  alpha_0: 0.5
+
+evaluation:
+  benchmarks_dir: config/benchmarks
+  results_dir: .dgm-live-runs/2026-06-12-proof/results
+  timeout_seconds: 30
+
+agents:
+  workspace_dir: .dgm-live-runs/2026-06-12-proof/workspace
+  initial_agent_path: agent/agent.py
+  max_steps: 5
+
+benchmarks:
+  timeout_default: 30
+  max_attempts: 3
+  enabled:
+    - list_processing
+
+logging:
+  level: INFO
+
+generation_delay_seconds: 0
+stop_on_error: true

--- a/dgm_controller.py
+++ b/dgm_controller.py
@@ -122,6 +122,31 @@ class DGMController:
 
         return obj
 
+    def _redact_sensitive_values(self, obj):
+        """Return a copy of config-like data with secret values redacted."""
+        def is_sensitive_key(key: Any) -> bool:
+            key_lower = str(key).lower()
+            return (
+                key_lower in {"api_key", "token", "secret", "password"}
+                or key_lower.endswith("_api_key")
+                or key_lower.endswith("_token")
+                or key_lower.endswith("_secret")
+                or key_lower.endswith("_password")
+                or "credential" in key_lower
+            )
+
+        if isinstance(obj, dict):
+            redacted = {}
+            for key, value in obj.items():
+                if is_sensitive_key(key):
+                    redacted[key] = "[REDACTED]"
+                else:
+                    redacted[key] = self._redact_sensitive_values(value)
+            return redacted
+        if isinstance(obj, list):
+            return [self._redact_sensitive_values(item) for item in obj]
+        return obj
+
     def get_or_create_initial_agent(self) -> str:
         """
         Get or create the initial agent (agent_0).
@@ -164,7 +189,7 @@ class Agent:
             num_generations: Number of generations to run. If None, runs indefinitely.
         """
         logger.info("Starting Darwin Gödel Machine")
-        logger.info(f"Configuration: {self.config}")
+        logger.info(f"Configuration: {self._redact_sensitive_values(self.config)}")
 
         # Initialize with base agent if archive is empty
         if len(self.archive.agents) == 0:
@@ -502,7 +527,8 @@ performance."""
                     agent_id=f"eval_{agent_path_obj.stem}_{benchmark_name}",
                     fm_provider=primary_provider,
                     fm_config=provider_config,
-                    working_directory=str(agent_path_obj.parent)
+                    working_directory=str(agent_path_obj.parent),
+                    max_iterations=self.config['agents'].get('max_steps', 20),
                 )
 
                 # Load the agent class from the file path using load_from_path,

--- a/docs/live-runs/2026-06-12-proof/README.md
+++ b/docs/live-runs/2026-06-12-proof/README.md
@@ -1,0 +1,88 @@
+# Live DGM Run Proof - 2026-06-12
+
+This directory contains the first committed live-run proof artifact for this
+repository. The run used real Anthropic API calls, not mocks, and completed two
+DGM generations.
+
+## Command
+
+```bash
+PATH="$PWD/.venv/bin:$PATH" python run_dgm.py \
+  --config config/live_dgm_proof.yaml \
+  --generations 2
+```
+
+The full captured transcript is in `transcript.txt`.
+
+## Scope
+
+- Provider/model: `anthropic` / `claude-sonnet-4-6`
+- Benchmark: `list_processing`
+- Generations: 2
+- Max model turns per task: 5
+- Max output tokens per call: 2,048
+- Runtime output directory: `.dgm-live-runs/2026-06-12-proof/`
+
+The runtime directory is intentionally ignored by git. It contains copied agent
+workspaces and the generated JSON report. This directory commits the stable proof
+materials instead.
+
+## Cost Gate
+
+Pricing was checked against Anthropic's official pricing page on 2026-06-12:
+Claude Sonnet 4.6 was listed at $3 / MTok input and $15 / MTok output.
+
+- <https://platform.claude.com/docs/en/about-claude/pricing>
+- <https://www.anthropic.com/claude/sonnet>
+
+Pre-run ceiling estimate for this bounded config:
+
+- Agent tasks: 5
+- Request upper bound: 25
+- Assumed input tokens: 200,000
+- Output token ceiling: 51,200
+- Estimated ceiling: $1.3680
+
+Measured usage from the transcript:
+
+- API calls: 20
+- Input tokens: 81,943
+- Output tokens: 3,333
+- Estimated spend at listed rates: $0.295824
+
+## Result
+
+| Generation | Agent ID | Benchmark | Score |
+| --- | --- | --- | --- |
+| 0 | `686d489b-7bcb-4d8d-a007-d971ddafcfdd` | `list_processing` | 1.000 |
+| 1 | `08150f6d-25ca-4bce-93ef-3172cc3a5a0d` | `list_processing` | 1.000 |
+| 2 | `321422b4-3747-4896-af61-c2060fcf6884` | `list_processing` | 1.000 |
+
+Final report summary:
+
+- Total generations: 2
+- Agents created: 2
+- Final archive size: 3
+- Successful improvements: 0
+- Top score: 1.000
+
+## Evidence Notes
+
+- The transcript includes successful `POST https://api.anthropic.com/v1/messages`
+  responses and per-call token usage.
+- The controller redacted API keys before logging config.
+- The bash tool removed credential-like environment variables from subprocesses
+  before the run.
+- A post-run scan of `transcript.txt` and `dgm_run.log` found no live API key or
+  token strings.
+
+## Caveats
+
+This proves a real multi-generation DGM execution path: base evaluation, parent
+selection, live self-modification attempts, validation, modified-agent
+evaluation, archive update, and final report generation.
+
+It does not prove benchmark improvement. Both child agents matched the already
+perfect base score on the selected benchmark. It also does not complete full
+Docker sandboxing; the live agent still ran on the host with the current tool
+safety restrictions.

--- a/docs/live-runs/2026-06-12-proof/transcript.txt
+++ b/docs/live-runs/2026-06-12-proof/transcript.txt
@@ -1,0 +1,917 @@
+/Volumes/Crucial X10/pcc-projects/canonical/projects/darwin-godel-machine/agent/fm_interface/providers/gemini.py:12: FutureWarning: 
+
+All support for the `google.generativeai` package has ended. It will no longer be receiving 
+updates or bug fixes. Please switch to the `google.genai` package as soon as possible.
+See README for more details:
+
+https://github.com/google-gemini/deprecated-generative-ai-python/blob/main/README.md
+
+  import google.generativeai as genai
+2026-06-12 13:59:20,474 - __main__ - INFO - Initializing Darwin Gödel Machine...
+2026-06-12 13:59:20,478 - evaluation.benchmark_runner - INFO - Loaded benchmark: simple_algorithm
+2026-06-12 13:59:20,479 - evaluation.benchmark_runner - INFO - Loaded benchmark: list_processing
+2026-06-12 13:59:20,481 - evaluation.benchmark_runner - INFO - Loaded benchmark: humaneval_style
+2026-06-12 13:59:20,482 - evaluation.benchmark_runner - INFO - Loaded benchmark: string_manipulation
+2026-06-12 13:59:20,482 - __main__ - INFO - Running DGM for 2 generations...
+2026-06-12 13:59:20,482 - dgm_controller - INFO - Starting Darwin Gödel Machine
+2026-06-12 13:59:20,482 - dgm_controller - INFO - Configuration: {'fm_providers': {'primary': 'anthropic', 'anthropic': {'model': 'claude-sonnet-4-6', 'api_key': '[REDACTED]', 'max_tokens': '[REDACTED]', 'temperature': 0.1, 'timeout': 60}}, 'archive': {'path': '.dgm-live-runs/2026-06-12-proof/archive'}, 'parent_selection': {'lambda': 10, 'alpha_0': 0.5}, 'evaluation': {'benchmarks_dir': 'config/benchmarks', 'results_dir': '.dgm-live-runs/2026-06-12-proof/results', 'timeout_seconds': 30}, 'agents': {'workspace_dir': '.dgm-live-runs/2026-06-12-proof/workspace', 'initial_agent_path': 'agent/agent.py', 'max_steps': 5}, 'benchmarks': {'timeout_default': 30, 'max_attempts': 3, 'enabled': ['list_processing']}, 'logging': {'level': 'INFO'}, 'generation_delay_seconds': 0, 'stop_on_error': True}
+2026-06-12 13:59:20,482 - dgm_controller - INFO - Initializing archive with base agent...
+2026-06-12 13:59:20,493 - utils.agent_loader - INFO - Successfully loaded agent from /Volumes/Crucial X10/pcc-projects/canonical/projects/darwin-godel-machine/agent/agent.py
+2026-06-12 13:59:20,493 - dgm_controller - INFO - Running benchmark: list_processing
+2026-06-12 13:59:20,494 - utils.agent_loader - INFO - Successfully loaded agent from /Volumes/Crucial X10/pcc-projects/canonical/projects/darwin-godel-machine/agent/agent.py
+2026-06-12 13:59:20,522 - dgm_agent_pkg_82e6953a8249.agent - INFO - Starting task solving steps for task: benchmark_list_processing_1781287160
+2026-06-12 13:59:20,522 - dgm_agent_pkg_82e6953a8249.agent - INFO - Starting task solution with up to 5 steps for task benchmark_list_processing_1781287160
+2026-06-12 13:59:20,522 - dgm_agent_pkg_82e6953a8249.agent - INFO - Step 1/5
+2026-06-12 13:59:20,522 - dgm_agent_pkg_82e6953a8249.agent - INFO - Making API call - Step 1
+2026-06-12 13:59:20,522 - dgm_agent_pkg_82e6953a8249.agent - INFO - Conversation history has 2 messages
+2026-06-12 13:59:20,522 - dgm_agent_pkg_82e6953a8249.fm_interface.providers.anthropic - INFO - Starting Anthropic API request (timeout: 60s, model: claude-sonnet-4-6)
+2026-06-12 13:59:23,985 - httpx - INFO - HTTP Request: POST https://api.anthropic.com/v1/messages "HTTP/1.1 200 OK"
+2026-06-12 13:59:24,012 - dgm_agent_pkg_82e6953a8249.fm_interface.providers.anthropic - INFO - Anthropic API request completed successfully in 3.49s
+2026-06-12 13:59:24,013 - dgm_agent_pkg_82e6953a8249.agent - INFO - API call completed. Tool calls: 1
+2026-06-12 13:59:24,013 - dgm_agent_pkg_82e6953a8249.agent - INFO - API usage: {'prompt_tokens': 1944, 'completion_tokens': 198, 'total_tokens': 2142}
+2026-06-12 13:59:24,013 - dgm_agent_pkg_82e6953a8249.agent - INFO - === AGENT RESPONSE (Step 1) ===
+2026-06-12 13:59:24,013 - dgm_agent_pkg_82e6953a8249.agent - INFO - Looking at the task, I need to implement a `reverse_list` function that:
+1. Reverses a list
+2. Returns the reversed list
+3. Does NOT use `reverse()` method or `[::-1]` slicing
+
+Let me implement and test this:
+2026-06-12 13:59:24,013 - dgm_agent_pkg_82e6953a8249.agent - INFO - === END RESPONSE ===
+2026-06-12 13:59:24,013 - dgm_agent_pkg_82e6953a8249.agent - INFO - Executing 1 tool calls
+2026-06-12 13:59:24,013 - dgm_agent_pkg_82e6953a8249.agent - INFO - === TOOL CALL 1 ===
+2026-06-12 13:59:24,013 - dgm_agent_pkg_82e6953a8249.agent - INFO - Tool: edit
+2026-06-12 13:59:24,013 - dgm_agent_pkg_82e6953a8249.agent - INFO - Parameters: {'action': 'write', 'file_path': 'solution.py', 'content': 'def reverse_list(lst):\n    result = []\n    for i in range(len(lst) - 1, -1, -1):\n        result.append(lst[i])\n    return result\n'}
+2026-06-12 13:59:24,014 - dgm_agent_pkg_82e6953a8249.agent - INFO - Tool Result Status: ToolExecutionStatus.SUCCESS
+2026-06-12 13:59:24,014 - dgm_agent_pkg_82e6953a8249.agent - INFO - Tool Result Output: Successfully wrote 129 characters to solution.py...
+2026-06-12 13:59:24,014 - dgm_agent_pkg_82e6953a8249.agent - INFO - === END TOOL CALL 1 ===
+2026-06-12 13:59:24,014 - dgm_agent_pkg_82e6953a8249.agent - INFO - Step 2/5
+2026-06-12 13:59:24,014 - dgm_agent_pkg_82e6953a8249.agent - INFO - Making API call - Step 2
+2026-06-12 13:59:24,014 - dgm_agent_pkg_82e6953a8249.agent - INFO - Conversation history has 4 messages
+2026-06-12 13:59:24,014 - dgm_agent_pkg_82e6953a8249.agent - INFO - Recent message 1: Role=MessageRole.ASSISTANT, Content preview=Looking at the task, I need to implement a `reverse_list` function that:
+1. Reverses a list
+2. Retur...
+2026-06-12 13:59:24,014 - dgm_agent_pkg_82e6953a8249.agent - INFO - Recent message 2: Role=MessageRole.TOOL, Content preview=Tool execution successful:
+Successfully wrote 129 characters to solution.py...
+2026-06-12 13:59:24,014 - dgm_agent_pkg_82e6953a8249.fm_interface.providers.anthropic - INFO - Starting Anthropic API request (timeout: 60s, model: claude-sonnet-4-6)
+2026-06-12 13:59:26,928 - httpx - INFO - HTTP Request: POST https://api.anthropic.com/v1/messages "HTTP/1.1 200 OK"
+2026-06-12 13:59:26,931 - dgm_agent_pkg_82e6953a8249.fm_interface.providers.anthropic - INFO - Anthropic API request completed successfully in 2.92s
+2026-06-12 13:59:26,932 - dgm_agent_pkg_82e6953a8249.agent - INFO - API call completed. Tool calls: 1
+2026-06-12 13:59:26,932 - dgm_agent_pkg_82e6953a8249.agent - INFO - API usage: {'prompt_tokens': 2169, 'completion_tokens': 172, 'total_tokens': 2341}
+2026-06-12 13:59:26,932 - dgm_agent_pkg_82e6953a8249.agent - INFO - === AGENT RESPONSE (Step 2) ===
+2026-06-12 13:59:26,932 - dgm_agent_pkg_82e6953a8249.agent - INFO - No response generated
+2026-06-12 13:59:26,933 - dgm_agent_pkg_82e6953a8249.agent - INFO - === END RESPONSE ===
+2026-06-12 13:59:26,933 - dgm_agent_pkg_82e6953a8249.agent - INFO - Executing 1 tool calls
+2026-06-12 13:59:26,933 - dgm_agent_pkg_82e6953a8249.agent - INFO - === TOOL CALL 1 ===
+2026-06-12 13:59:26,933 - dgm_agent_pkg_82e6953a8249.agent - INFO - Tool: bash
+2026-06-12 13:59:26,933 - dgm_agent_pkg_82e6953a8249.agent - INFO - Parameters: {'command': 'python3 -c "\nfrom solution import reverse_list\n\n# Official test cases\nprint(reverse_list([1, 2, 3, 4, 5]))   # Expected: [5, 4, 3, 2, 1]\nprint(reverse_list([\'a\', \'b\', \'c\']))   # Expected: [\'c\', \'b\', \'a\']\nprint(reverse_list([]))                # Expected: []\nprint(reverse_list([1]))               # Expected: [1]\n"\n'}
+2026-06-12 13:59:27,005 - dgm_agent_pkg_82e6953a8249.agent - INFO - Tool Result Status: ToolExecutionStatus.SUCCESS
+2026-06-12 13:59:27,005 - dgm_agent_pkg_82e6953a8249.agent - INFO - Tool Result Output: [5, 4, 3, 2, 1]
+['c', 'b', 'a']
+[]
+[1]
+...
+2026-06-12 13:59:27,005 - dgm_agent_pkg_82e6953a8249.agent - INFO - === END TOOL CALL 1 ===
+2026-06-12 13:59:27,005 - dgm_agent_pkg_82e6953a8249.agent - INFO - Step 3/5
+2026-06-12 13:59:27,005 - dgm_agent_pkg_82e6953a8249.agent - INFO - Making API call - Step 3
+2026-06-12 13:59:27,005 - dgm_agent_pkg_82e6953a8249.agent - INFO - Conversation history has 6 messages
+2026-06-12 13:59:27,005 - dgm_agent_pkg_82e6953a8249.agent - INFO - Recent message 1: Role=MessageRole.ASSISTANT, Content preview=No response generated...
+2026-06-12 13:59:27,005 - dgm_agent_pkg_82e6953a8249.agent - INFO - Recent message 2: Role=MessageRole.TOOL, Content preview=Tool execution successful:
+[5, 4, 3, 2, 1]
+['c', 'b', 'a']
+[]
+[1]
+...
+2026-06-12 13:59:27,005 - dgm_agent_pkg_82e6953a8249.fm_interface.providers.anthropic - INFO - Starting Anthropic API request (timeout: 60s, model: claude-sonnet-4-6)
+2026-06-12 13:59:34,733 - httpx - INFO - HTTP Request: POST https://api.anthropic.com/v1/messages "HTTP/1.1 200 OK"
+2026-06-12 13:59:34,738 - dgm_agent_pkg_82e6953a8249.fm_interface.providers.anthropic - INFO - Anthropic API request completed successfully in 7.73s
+2026-06-12 13:59:34,738 - dgm_agent_pkg_82e6953a8249.agent - INFO - API call completed. Tool calls: 0
+2026-06-12 13:59:34,738 - dgm_agent_pkg_82e6953a8249.agent - INFO - API usage: {'prompt_tokens': 2396, 'completion_tokens': 157, 'total_tokens': 2553}
+2026-06-12 13:59:34,738 - dgm_agent_pkg_82e6953a8249.agent - INFO - === AGENT RESPONSE (Step 3) ===
+2026-06-12 13:59:34,738 - dgm_agent_pkg_82e6953a8249.agent - INFO - All 4 official test cases pass. Here's the final solution:
+
+```python
+def reverse_list(lst):
+    result = []
+    for i in range(len(lst) - 1, -1, -1):
+        result.append(lst[i])
+    return result
+```
+
+**How it works:**
+- Iterates from the last index (`len(lst) - 1`) down to `0` (inclusive), stepping by `-1`
+- Appends each element to a new `result` list in that reverse order
+- Returns the new reversed list
+- No `reverse()` method or `[::-1]` slicing used ✅
+
+Task complete
+2026-06-12 13:59:34,739 - dgm_agent_pkg_82e6953a8249.agent - INFO - === END RESPONSE ===
+2026-06-12 13:59:34,739 - dgm_agent_pkg_82e6953a8249.agent - INFO - Task completion detected with primary indicator: 'task complete'
+2026-06-12 13:59:34,739 - dgm_agent_pkg_82e6953a8249.agent - INFO - _is_task_complete returned: True
+2026-06-12 13:59:34,739 - dgm_agent_pkg_82e6953a8249.agent - INFO - Task complete after Step 3
+2026-06-12 13:59:34,739 - dgm_agent_pkg_82e6953a8249.agent - INFO - Extracted code from markdown block: 128 characters
+2026-06-12 13:59:34,739 - dgm_agent_pkg_82e6953a8249.agent - INFO - Completed task solving with 7 total messages
+2026-06-12 13:59:34,937 - dgm_controller - INFO - list_processing score: 1.000
+2026-06-12 13:59:34,948 - archive.agent_archive - INFO - Archive metadata saved
+2026-06-12 13:59:34,948 - archive.agent_archive - INFO - Added agent 686d489b-7bcb-4d8d-a007-d971ddafcfdd to archive (gen 0, score: 1.00)
+2026-06-12 13:59:34,948 - dgm_controller - INFO - Base agent 686d489b-7bcb-4d8d-a007-d971ddafcfdd added to archive
+2026-06-12 13:59:34,948 - dgm_controller - INFO - Base agent score: 1.000
+2026-06-12 13:59:34,948 - dgm_controller - INFO - 
+==================================================
+2026-06-12 13:59:34,948 - dgm_controller - INFO - GENERATION 1
+2026-06-12 13:59:34,948 - dgm_controller - INFO - ==================================================
+2026-06-12 13:59:34,948 - dgm_controller - INFO - Selected parent: 686d489b-7bcb-4d8d-a007-d971ddafcfdd (score: 1.000)
+2026-06-12 13:59:34,951 - dgm_controller - INFO - Attempting self-modification...
+2026-06-12 13:59:34,961 - agent.agent - INFO - Starting task solving steps for task: self_modify_686d489b-7bcb-4d8d-a007-d971ddafcfdd_1
+2026-06-12 13:59:34,961 - agent.agent - INFO - Starting task solution with up to 5 steps for task self_modify_686d489b-7bcb-4d8d-a007-d971ddafcfdd_1
+2026-06-12 13:59:34,961 - agent.agent - INFO - Step 1/5
+2026-06-12 13:59:34,961 - agent.agent - INFO - Making API call - Step 1
+2026-06-12 13:59:34,961 - agent.agent - INFO - Conversation history has 2 messages
+2026-06-12 13:59:34,961 - agent.fm_interface.providers.anthropic - INFO - Starting Anthropic API request (timeout: 60s, model: claude-sonnet-4-6)
+2026-06-12 13:59:37,852 - httpx - INFO - HTTP Request: POST https://api.anthropic.com/v1/messages "HTTP/1.1 200 OK"
+2026-06-12 13:59:37,855 - agent.fm_interface.providers.anthropic - INFO - Anthropic API request completed successfully in 2.89s
+2026-06-12 13:59:37,855 - agent.agent - INFO - API call completed. Tool calls: 2
+2026-06-12 13:59:37,855 - agent.agent - INFO - API usage: {'prompt_tokens': 2019, 'completion_tokens': 144, 'total_tokens': 2163}
+2026-06-12 13:59:37,855 - agent.agent - INFO - === AGENT RESPONSE (Step 1) ===
+2026-06-12 13:59:37,856 - agent.agent - INFO - I'll analyze the current source code and make meaningful improvements to enhance benchmark performance.
+2026-06-12 13:59:37,856 - agent.agent - INFO - === END RESPONSE ===
+2026-06-12 13:59:37,856 - agent.agent - INFO - Executing 2 tool calls
+2026-06-12 13:59:37,856 - agent.agent - INFO - === TOOL CALL 1 ===
+2026-06-12 13:59:37,856 - agent.agent - INFO - Tool: bash
+2026-06-12 13:59:37,856 - agent.agent - INFO - Parameters: {'command': 'find . -type f -name "*.py" | head -50 && echo "---" && ls -la'}
+2026-06-12 13:59:37,856 - agent.agent - INFO - Tool Result Status: ToolExecutionStatus.ERROR
+2026-06-12 13:59:37,856 - agent.agent - INFO - Tool Result Output: None...
+2026-06-12 13:59:37,856 - agent.agent - INFO - Tool Result Error: Command blocked for safety: Pattern '&&' requires careful review
+2026-06-12 13:59:37,856 - agent.agent - INFO - === END TOOL CALL 1 ===
+2026-06-12 13:59:37,856 - agent.agent - INFO - === TOOL CALL 2 ===
+2026-06-12 13:59:37,856 - agent.agent - INFO - Tool: bash
+2026-06-12 13:59:37,856 - agent.agent - INFO - Parameters: {'command': 'cat agent.py 2>/dev/null || echo "agent.py not found"'}
+2026-06-12 13:59:37,857 - agent.agent - INFO - Tool Result Status: ToolExecutionStatus.ERROR
+2026-06-12 13:59:37,857 - agent.agent - INFO - Tool Result Output: None...
+2026-06-12 13:59:37,857 - agent.agent - INFO - Tool Result Error: Command blocked for safety: Pattern '>' requires careful review
+2026-06-12 13:59:37,857 - agent.agent - INFO - === END TOOL CALL 2 ===
+2026-06-12 13:59:37,857 - agent.agent - INFO - Step 2/5
+2026-06-12 13:59:37,857 - agent.agent - INFO - Making API call - Step 2
+2026-06-12 13:59:37,857 - agent.agent - INFO - Conversation history has 5 messages
+2026-06-12 13:59:37,857 - agent.agent - INFO - Recent message 1: Role=MessageRole.TOOL, Content preview=Tool execution failed:
+Command blocked for safety: Pattern '&&' requires careful review...
+2026-06-12 13:59:37,857 - agent.agent - INFO - Recent message 2: Role=MessageRole.TOOL, Content preview=Tool execution failed:
+Command blocked for safety: Pattern '>' requires careful review...
+2026-06-12 13:59:37,857 - agent.fm_interface.providers.anthropic - INFO - Starting Anthropic API request (timeout: 60s, model: claude-sonnet-4-6)
+2026-06-12 13:59:40,070 - httpx - INFO - HTTP Request: POST https://api.anthropic.com/v1/messages "HTTP/1.1 200 OK"
+2026-06-12 13:59:40,072 - agent.fm_interface.providers.anthropic - INFO - Anthropic API request completed successfully in 2.22s
+2026-06-12 13:59:40,073 - agent.agent - INFO - API call completed. Tool calls: 2
+2026-06-12 13:59:40,073 - agent.agent - INFO - API usage: {'prompt_tokens': 2255, 'completion_tokens': 97, 'total_tokens': 2352}
+2026-06-12 13:59:40,073 - agent.agent - INFO - === AGENT RESPONSE (Step 2) ===
+2026-06-12 13:59:40,073 - agent.agent - INFO - No response generated
+2026-06-12 13:59:40,073 - agent.agent - INFO - === END RESPONSE ===
+2026-06-12 13:59:40,073 - agent.agent - INFO - Executing 2 tool calls
+2026-06-12 13:59:40,073 - agent.agent - INFO - === TOOL CALL 1 ===
+2026-06-12 13:59:40,073 - agent.agent - INFO - Tool: bash
+2026-06-12 13:59:40,073 - agent.agent - INFO - Parameters: {'command': 'find . -type f -name "*.py"'}
+2026-06-12 13:59:40,095 - agent.agent - INFO - Tool Result Status: ToolExecutionStatus.SUCCESS
+2026-06-12 13:59:40,095 - agent.agent - INFO - Tool Result Output: ./tools/edit_tool.py
+./tools/bash_tool.py
+./tools/__init__.py
+./tools/base_tool.py
+./solution.py
+./fm_interface/api_handler.py
+./fm_interface/providers/test_anthropic_format.py
+./fm_interface/providers/__init__.py
+./fm_interface/providers/gemini.py
+./fm_interface/providers/anthropic.py
+./fm_interface/__init__.py
+./fm_interface/message_formatter.py
+./__init__.py
+./agent.py
+...
+2026-06-12 13:59:40,095 - agent.agent - INFO - === END TOOL CALL 1 ===
+2026-06-12 13:59:40,095 - agent.agent - INFO - === TOOL CALL 2 ===
+2026-06-12 13:59:40,095 - agent.agent - INFO - Tool: bash
+2026-06-12 13:59:40,095 - agent.agent - INFO - Parameters: {'command': 'ls -la'}
+2026-06-12 13:59:40,118 - agent.agent - INFO - Tool Result Status: ToolExecutionStatus.SUCCESS
+2026-06-12 13:59:40,118 - agent.agent - INFO - Tool Result Output: total 72
+drwxr-xr-x@ 7 cdossman  staff    224 Jun 12 13:59 .
+drwxr-xr-x@ 3 cdossman  staff     96 Jun 12 13:59 ..
+-rw-r--r--@ 1 cdossman  staff    293 Feb 15 17:06 __init__.py
+-rw-r--r--@ 1 cdossman  staff  26043 Jun 12 13:58 agent.py
+drwxr-xr-x@ 6 cdossman  staff    192 Jun 11 14:00 fm_interface
+-rw-r--r--@ 1 cdossman  staff    129 Jun 12 13:59 solution.py
+drwxr-xr-x@ 6 cdossman  staff    192 Jun 11 15:05 tools
+...
+2026-06-12 13:59:40,118 - agent.agent - INFO - === END TOOL CALL 2 ===
+2026-06-12 13:59:40,118 - agent.agent - INFO - Step 3/5
+2026-06-12 13:59:40,118 - agent.agent - INFO - Making API call - Step 3
+2026-06-12 13:59:40,118 - agent.agent - INFO - Conversation history has 8 messages
+2026-06-12 13:59:40,118 - agent.agent - INFO - Recent message 1: Role=MessageRole.TOOL, Content preview=Tool execution successful:
+./tools/edit_tool.py
+./tools/bash_tool.py
+./tools/__init__.py
+./tools/bas...
+2026-06-12 13:59:40,118 - agent.agent - INFO - Recent message 2: Role=MessageRole.TOOL, Content preview=Tool execution successful:
+total 72
+drwxr-xr-x@ 7 cdossman  staff    224 Jun 12 13:59 .
+drwxr-xr-x@ ...
+2026-06-12 13:59:40,118 - agent.fm_interface.providers.anthropic - INFO - Starting Anthropic API request (timeout: 60s, model: claude-sonnet-4-6)
+2026-06-12 13:59:42,099 - httpx - INFO - HTTP Request: POST https://api.anthropic.com/v1/messages "HTTP/1.1 200 OK"
+2026-06-12 13:59:42,101 - agent.fm_interface.providers.anthropic - INFO - Anthropic API request completed successfully in 1.98s
+2026-06-12 13:59:42,102 - agent.agent - INFO - API call completed. Tool calls: 1
+2026-06-12 13:59:42,102 - agent.agent - INFO - API usage: {'prompt_tokens': 2785, 'completion_tokens': 72, 'total_tokens': 2857}
+2026-06-12 13:59:42,102 - agent.agent - INFO - === AGENT RESPONSE (Step 3) ===
+2026-06-12 13:59:42,102 - agent.agent - INFO - No response generated
+2026-06-12 13:59:42,102 - agent.agent - INFO - === END RESPONSE ===
+2026-06-12 13:59:42,102 - agent.agent - INFO - Executing 1 tool calls
+2026-06-12 13:59:42,102 - agent.agent - INFO - === TOOL CALL 1 ===
+2026-06-12 13:59:42,102 - agent.agent - INFO - Tool: edit
+2026-06-12 13:59:42,102 - agent.agent - INFO - Parameters: {'action': 'read', 'file_path': 'agent.py'}
+2026-06-12 13:59:42,103 - agent.agent - INFO - Tool Result Status: ToolExecutionStatus.SUCCESS
+2026-06-12 13:59:42,103 - agent.agent - INFO - Tool Result Output: """
+Main DGM Agent implementation.
+
+This module contains the core Agent class that represents a self-modifying
+coding agent in the Darwin Gödel Machine system.
+"""
+
+import asyncio
+import json
+import logging
+import uuid
+from typing import Dict, Any, List, Optional, Union
+from dataclasses import dataclass, field
+from pathlib import Path
+import yaml
+import os
+
+logger = logging.getLogger(__name__)
+
+from .fm_interface.api_handler import (
+    ApiHandler, CompletionRequest, CompletionResponse, Message...
+2026-06-12 13:59:42,103 - agent.agent - INFO - === END TOOL CALL 1 ===
+2026-06-12 13:59:42,104 - agent.agent - INFO - Step 4/5
+2026-06-12 13:59:42,104 - agent.agent - INFO - Making API call - Step 4
+2026-06-12 13:59:42,104 - agent.agent - INFO - Conversation history has 10 messages
+2026-06-12 13:59:42,104 - agent.agent - INFO - Recent message 1: Role=MessageRole.ASSISTANT, Content preview=No response generated...
+2026-06-12 13:59:42,104 - agent.agent - INFO - Recent message 2: Role=MessageRole.TOOL, Content preview=Tool execution successful:
+"""
+Main DGM Agent implementation.
+
+This module contains the core Agent c...
+2026-06-12 13:59:42,104 - agent.fm_interface.providers.anthropic - INFO - Starting Anthropic API request (timeout: 60s, model: claude-sonnet-4-6)
+2026-06-12 13:59:46,985 - httpx - INFO - HTTP Request: POST https://api.anthropic.com/v1/messages "HTTP/1.1 200 OK"
+2026-06-12 13:59:46,987 - agent.fm_interface.providers.anthropic - INFO - Anthropic API request completed successfully in 4.88s
+2026-06-12 13:59:46,987 - agent.agent - INFO - API call completed. Tool calls: 2
+2026-06-12 13:59:46,987 - agent.agent - INFO - API usage: {'prompt_tokens': 9156, 'completion_tokens': 131, 'total_tokens': 9287}
+2026-06-12 13:59:46,987 - agent.agent - INFO - === AGENT RESPONSE (Step 4) ===
+2026-06-12 13:59:46,987 - agent.agent - INFO - No response generated
+2026-06-12 13:59:46,987 - agent.agent - INFO - === END RESPONSE ===
+2026-06-12 13:59:46,987 - agent.agent - INFO - Executing 2 tool calls
+2026-06-12 13:59:46,987 - agent.agent - INFO - === TOOL CALL 1 ===
+2026-06-12 13:59:46,988 - agent.agent - INFO - Tool: edit
+2026-06-12 13:59:46,988 - agent.agent - INFO - Parameters: {'action': 'read', 'file_path': 'solution.py'}
+2026-06-12 13:59:46,988 - agent.agent - INFO - Tool Result Status: ToolExecutionStatus.SUCCESS
+2026-06-12 13:59:46,988 - agent.agent - INFO - Tool Result Output: def reverse_list(lst):
+    result = []
+    for i in range(len(lst) - 1, -1, -1):
+        result.append(lst[i])
+    return result
+...
+2026-06-12 13:59:46,988 - agent.agent - INFO - === END TOOL CALL 1 ===
+2026-06-12 13:59:46,988 - agent.agent - INFO - === TOOL CALL 2 ===
+2026-06-12 13:59:46,988 - agent.agent - INFO - Tool: edit
+2026-06-12 13:59:46,988 - agent.agent - INFO - Parameters: {'action': 'read', 'file_path': 'tools/bash_tool.py'}
+2026-06-12 13:59:46,989 - agent.agent - INFO - Tool Result Status: ToolExecutionStatus.SUCCESS
+2026-06-12 13:59:46,989 - agent.agent - INFO - Tool Result Output: """
+Bash tool implementation for executing shell commands.
+
+This tool allows the DGM agent to execute bash commands in a controlled manner,
+with safety restrictions and timeout handling.
+"""
+
+import asyncio
+import os
+import re
+import shlex
+import signal
+import subprocess
+from pathlib import Path
+from typing import Dict, Any, List
+import time
+
+from .base_tool import BaseTool, ToolResult, ToolExecutionStatus, ToolParameter
+
+
+class BashTool(BaseTool):
+    """
+    Tool for executing bash commands wi...
+2026-06-12 13:59:46,989 - agent.agent - INFO - === END TOOL CALL 2 ===
+2026-06-12 13:59:46,989 - agent.agent - INFO - Step 5/5
+2026-06-12 13:59:46,989 - agent.agent - INFO - Making API call - Step 5
+2026-06-12 13:59:46,989 - agent.agent - INFO - Conversation history has 13 messages
+2026-06-12 13:59:46,989 - agent.agent - INFO - Recent message 1: Role=MessageRole.TOOL, Content preview=Tool execution successful:
+def reverse_list(lst):
+    result = []
+    for i in range(len(lst) - 1, -...
+2026-06-12 13:59:46,989 - agent.agent - INFO - Recent message 2: Role=MessageRole.TOOL, Content preview=Tool execution successful:
+"""
+Bash tool implementation for executing shell commands.
+
+This tool all...
+2026-06-12 13:59:46,989 - agent.fm_interface.providers.anthropic - INFO - Starting Anthropic API request (timeout: 60s, model: claude-sonnet-4-6)
+2026-06-12 13:59:50,126 - httpx - INFO - HTTP Request: POST https://api.anthropic.com/v1/messages "HTTP/1.1 200 OK"
+2026-06-12 13:59:50,129 - agent.fm_interface.providers.anthropic - INFO - Anthropic API request completed successfully in 3.14s
+2026-06-12 13:59:50,130 - agent.agent - INFO - API call completed. Tool calls: 2
+2026-06-12 13:59:50,130 - agent.agent - INFO - API usage: {'prompt_tokens': 13012, 'completion_tokens': 141, 'total_tokens': 13153}
+2026-06-12 13:59:50,130 - agent.agent - INFO - === AGENT RESPONSE (Step 5) ===
+2026-06-12 13:59:50,130 - agent.agent - INFO - No response generated
+2026-06-12 13:59:50,130 - agent.agent - INFO - === END RESPONSE ===
+2026-06-12 13:59:50,130 - agent.agent - INFO - Executing 2 tool calls
+2026-06-12 13:59:50,130 - agent.agent - INFO - === TOOL CALL 1 ===
+2026-06-12 13:59:50,130 - agent.agent - INFO - Tool: edit
+2026-06-12 13:59:50,130 - agent.agent - INFO - Parameters: {'action': 'read', 'file_path': 'tools/edit_tool.py'}
+2026-06-12 13:59:50,132 - agent.agent - INFO - Tool Result Status: ToolExecutionStatus.SUCCESS
+2026-06-12 13:59:50,132 - agent.agent - INFO - Tool Result Output: """
+Edit tool implementation for file manipulation.
+
+This tool allows the DGM agent to read, write, and modify files.
+"""
+
+import os
+from pathlib import Path
+from typing import Dict, Any, List
+from .base_tool import BaseTool, ToolResult, ToolExecutionStatus, ToolParameter
+
+
+def _resolve_and_check(
+    file_path_str: str, working_directory: str
+) -> "tuple[Path, ToolResult | None]":
+    """
+    Resolve *file_path_str* relative to *working_directory* and verify that the
+    result is contained wit...
+2026-06-12 13:59:50,132 - agent.agent - INFO - === END TOOL CALL 1 ===
+2026-06-12 13:59:50,132 - agent.agent - INFO - === TOOL CALL 2 ===
+2026-06-12 13:59:50,132 - agent.agent - INFO - Tool: edit
+2026-06-12 13:59:50,132 - agent.agent - INFO - Parameters: {'action': 'read', 'file_path': 'fm_interface/message_formatter.py'}
+2026-06-12 13:59:50,133 - agent.agent - INFO - Tool Result Status: ToolExecutionStatus.SUCCESS
+2026-06-12 13:59:50,133 - agent.agent - INFO - Tool Result Output: """
+Message formatting utilities for Foundation Model interactions.
+
+This module provides utilities for transforming messages between different formats,
+handling context assembly, and managing conversation history for the DGM system.
+"""
+
+from typing import List, Dict, Any, Optional, Union
+from dataclasses import dataclass, field
+from enum import Enum
+
+from .api_handler import Message, MessageRole, ToolCall, ToolResult
+from ..tools.base_tool import ToolExecutionStatus
+
+
+class MessageContext(Enum...
+2026-06-12 13:59:50,133 - agent.agent - INFO - === END TOOL CALL 2 ===
+2026-06-12 13:59:50,133 - agent.agent - WARNING - Reached max steps (5) without task completion
+2026-06-12 13:59:50,133 - agent.agent - INFO - Completed task solving with 16 total messages
+2026-06-12 13:59:50,133 - dgm_controller - INFO - No solution string provided; relying on in-place edits.
+2026-06-12 13:59:50,133 - dgm_controller - INFO - Validating modified agent...
+2026-06-12 13:59:50,217 - utils.agent_loader - INFO - Successfully loaded agent from /Volumes/Crucial X10/pcc-projects/canonical/projects/darwin-godel-machine/.dgm-live-runs/2026-06-12-proof/workspace/self_modify_686d489b-7bcb-4d8d-a007-d971ddafcfdd_1/agent.py
+2026-06-12 13:59:50,217 - dgm_controller - INFO - Evaluating modified agent on benchmarks...
+2026-06-12 13:59:50,217 - dgm_controller - INFO - Running benchmark: list_processing
+2026-06-12 13:59:50,218 - utils.agent_loader - INFO - Successfully loaded agent from /Volumes/Crucial X10/pcc-projects/canonical/projects/darwin-godel-machine/.dgm-live-runs/2026-06-12-proof/workspace/self_modify_686d489b-7bcb-4d8d-a007-d971ddafcfdd_1/agent.py
+2026-06-12 13:59:50,225 - dgm_agent_pkg_069592d521de.agent - INFO - Starting task solving steps for task: benchmark_list_processing_1781287190
+2026-06-12 13:59:50,225 - dgm_agent_pkg_069592d521de.agent - INFO - Starting task solution with up to 5 steps for task benchmark_list_processing_1781287190
+2026-06-12 13:59:50,225 - dgm_agent_pkg_069592d521de.agent - INFO - Step 1/5
+2026-06-12 13:59:50,225 - dgm_agent_pkg_069592d521de.agent - INFO - Making API call - Step 1
+2026-06-12 13:59:50,225 - dgm_agent_pkg_069592d521de.agent - INFO - Conversation history has 2 messages
+2026-06-12 13:59:50,225 - dgm_agent_pkg_069592d521de.fm_interface.providers.anthropic - INFO - Starting Anthropic API request (timeout: 60s, model: claude-sonnet-4-6)
+2026-06-12 13:59:53,461 - httpx - INFO - HTTP Request: POST https://api.anthropic.com/v1/messages "HTTP/1.1 200 OK"
+2026-06-12 13:59:53,462 - dgm_agent_pkg_069592d521de.fm_interface.providers.anthropic - INFO - Anthropic API request completed successfully in 3.24s
+2026-06-12 13:59:53,462 - dgm_agent_pkg_069592d521de.agent - INFO - API call completed. Tool calls: 1
+2026-06-12 13:59:53,462 - dgm_agent_pkg_069592d521de.agent - INFO - API usage: {'prompt_tokens': 1944, 'completion_tokens': 198, 'total_tokens': 2142}
+2026-06-12 13:59:53,462 - dgm_agent_pkg_069592d521de.agent - INFO - === AGENT RESPONSE (Step 1) ===
+2026-06-12 13:59:53,462 - dgm_agent_pkg_069592d521de.agent - INFO - Looking at the task, I need to implement a `reverse_list` function that:
+1. Reverses a list
+2. Returns the reversed list
+3. Does NOT use `reverse()` method or `[::-1]` slicing
+
+Let me implement and test this:
+2026-06-12 13:59:53,462 - dgm_agent_pkg_069592d521de.agent - INFO - === END RESPONSE ===
+2026-06-12 13:59:53,462 - dgm_agent_pkg_069592d521de.agent - INFO - Executing 1 tool calls
+2026-06-12 13:59:53,462 - dgm_agent_pkg_069592d521de.agent - INFO - === TOOL CALL 1 ===
+2026-06-12 13:59:53,462 - dgm_agent_pkg_069592d521de.agent - INFO - Tool: edit
+2026-06-12 13:59:53,462 - dgm_agent_pkg_069592d521de.agent - INFO - Parameters: {'action': 'write', 'file_path': 'solution.py', 'content': 'def reverse_list(lst):\n    result = []\n    for i in range(len(lst) - 1, -1, -1):\n        result.append(lst[i])\n    return result\n'}
+2026-06-12 13:59:53,463 - dgm_agent_pkg_069592d521de.agent - INFO - Tool Result Status: ToolExecutionStatus.SUCCESS
+2026-06-12 13:59:53,463 - dgm_agent_pkg_069592d521de.agent - INFO - Tool Result Output: Successfully wrote 129 characters to solution.py...
+2026-06-12 13:59:53,463 - dgm_agent_pkg_069592d521de.agent - INFO - === END TOOL CALL 1 ===
+2026-06-12 13:59:53,463 - dgm_agent_pkg_069592d521de.agent - INFO - Step 2/5
+2026-06-12 13:59:53,463 - dgm_agent_pkg_069592d521de.agent - INFO - Making API call - Step 2
+2026-06-12 13:59:53,463 - dgm_agent_pkg_069592d521de.agent - INFO - Conversation history has 4 messages
+2026-06-12 13:59:53,463 - dgm_agent_pkg_069592d521de.agent - INFO - Recent message 1: Role=MessageRole.ASSISTANT, Content preview=Looking at the task, I need to implement a `reverse_list` function that:
+1. Reverses a list
+2. Retur...
+2026-06-12 13:59:53,463 - dgm_agent_pkg_069592d521de.agent - INFO - Recent message 2: Role=MessageRole.TOOL, Content preview=Tool execution successful:
+Successfully wrote 129 characters to solution.py...
+2026-06-12 13:59:53,463 - dgm_agent_pkg_069592d521de.fm_interface.providers.anthropic - INFO - Starting Anthropic API request (timeout: 60s, model: claude-sonnet-4-6)
+2026-06-12 13:59:57,978 - httpx - INFO - HTTP Request: POST https://api.anthropic.com/v1/messages "HTTP/1.1 200 OK"
+2026-06-12 13:59:57,980 - dgm_agent_pkg_069592d521de.fm_interface.providers.anthropic - INFO - Anthropic API request completed successfully in 4.52s
+2026-06-12 13:59:57,981 - dgm_agent_pkg_069592d521de.agent - INFO - API call completed. Tool calls: 1
+2026-06-12 13:59:57,981 - dgm_agent_pkg_069592d521de.agent - INFO - API usage: {'prompt_tokens': 2169, 'completion_tokens': 343, 'total_tokens': 2512}
+2026-06-12 13:59:57,981 - dgm_agent_pkg_069592d521de.agent - INFO - === AGENT RESPONSE (Step 2) ===
+2026-06-12 13:59:57,981 - dgm_agent_pkg_069592d521de.agent - INFO - No response generated
+2026-06-12 13:59:57,981 - dgm_agent_pkg_069592d521de.agent - INFO - === END RESPONSE ===
+2026-06-12 13:59:57,981 - dgm_agent_pkg_069592d521de.agent - INFO - Executing 1 tool calls
+2026-06-12 13:59:57,981 - dgm_agent_pkg_069592d521de.agent - INFO - === TOOL CALL 1 ===
+2026-06-12 13:59:57,981 - dgm_agent_pkg_069592d521de.agent - INFO - Tool: bash
+2026-06-12 13:59:57,981 - dgm_agent_pkg_069592d521de.agent - INFO - Parameters: {'command': 'cd / && python3 solution.py && python3 -c "\nfrom solution import reverse_list\n\n# Test case 1\nresult = reverse_list([1, 2, 3, 4, 5])\nprint(f\'Test 1: {result} -> Expected: [5, 4, 3, 2, 1] -> {\\"PASS\\" if result == [5, 4, 3, 2, 1] else \\"FAIL\\"}\')\n\n# Test case 2\nresult = reverse_list([\'a\', \'b\', \'c\'])\nprint(f\'Test 2: {result} -> Expected: [\\"c\\", \\"b\\", \\"a\\"] -> {\\"PASS\\" if result == [\\"c\\", \\"b\\", \\"a\\"] else \\"FAIL\\"}\')\n\n# Test case 3\nresult = reverse_list([])\nprint(f\'Test 3: {result} -> Expected: [] -> {\\"PASS\\" if result == [] else \\"FAIL\\"}\')\n\n# Test case 4\nresult = reverse_list([1])\nprint(f\'Test 4: {result} -> Expected: [1] -> {\\"PASS\\" if result == [1] else \\"FAIL\\"}\')\n"\n'}
+2026-06-12 13:59:57,983 - dgm_agent_pkg_069592d521de.agent - INFO - Tool Result Status: ToolExecutionStatus.ERROR
+2026-06-12 13:59:57,983 - dgm_agent_pkg_069592d521de.agent - INFO - Tool Result Output: None...
+2026-06-12 13:59:57,983 - dgm_agent_pkg_069592d521de.agent - INFO - Tool Result Error: Command blocked for safety: Pattern '&&' requires careful review
+2026-06-12 13:59:57,983 - dgm_agent_pkg_069592d521de.agent - INFO - === END TOOL CALL 1 ===
+2026-06-12 13:59:57,983 - dgm_agent_pkg_069592d521de.agent - INFO - Step 3/5
+2026-06-12 13:59:57,983 - dgm_agent_pkg_069592d521de.agent - INFO - Making API call - Step 3
+2026-06-12 13:59:57,983 - dgm_agent_pkg_069592d521de.agent - INFO - Conversation history has 6 messages
+2026-06-12 13:59:57,983 - dgm_agent_pkg_069592d521de.agent - INFO - Recent message 1: Role=MessageRole.ASSISTANT, Content preview=No response generated...
+2026-06-12 13:59:57,983 - dgm_agent_pkg_069592d521de.agent - INFO - Recent message 2: Role=MessageRole.TOOL, Content preview=Tool execution failed:
+Command blocked for safety: Pattern '&&' requires careful review...
+2026-06-12 13:59:57,983 - dgm_agent_pkg_069592d521de.fm_interface.providers.anthropic - INFO - Starting Anthropic API request (timeout: 60s, model: claude-sonnet-4-6)
+2026-06-12 14:00:01,893 - httpx - INFO - HTTP Request: POST https://api.anthropic.com/v1/messages "HTTP/1.1 200 OK"
+2026-06-12 14:00:01,895 - dgm_agent_pkg_069592d521de.fm_interface.providers.anthropic - INFO - Anthropic API request completed successfully in 3.91s
+2026-06-12 14:00:01,895 - dgm_agent_pkg_069592d521de.agent - INFO - API call completed. Tool calls: 1
+2026-06-12 14:00:01,895 - dgm_agent_pkg_069592d521de.agent - INFO - API usage: {'prompt_tokens': 2545, 'completion_tokens': 333, 'total_tokens': 2878}
+2026-06-12 14:00:01,895 - dgm_agent_pkg_069592d521de.agent - INFO - === AGENT RESPONSE (Step 3) ===
+2026-06-12 14:00:01,895 - dgm_agent_pkg_069592d521de.agent - INFO - No response generated
+2026-06-12 14:00:01,895 - dgm_agent_pkg_069592d521de.agent - INFO - === END RESPONSE ===
+2026-06-12 14:00:01,895 - dgm_agent_pkg_069592d521de.agent - INFO - Executing 1 tool calls
+2026-06-12 14:00:01,895 - dgm_agent_pkg_069592d521de.agent - INFO - === TOOL CALL 1 ===
+2026-06-12 14:00:01,895 - dgm_agent_pkg_069592d521de.agent - INFO - Tool: bash
+2026-06-12 14:00:01,896 - dgm_agent_pkg_069592d521de.agent - INFO - Parameters: {'command': 'python3 -c "\nfrom solution import reverse_list\n\n# Test case 1\nresult = reverse_list([1, 2, 3, 4, 5])\nprint(f\'Test 1: {result} -> Expected: [5, 4, 3, 2, 1] -> {\\"PASS\\" if result == [5, 4, 3, 2, 1] else \\"FAIL\\"}\')\n\n# Test case 2\nresult = reverse_list([\'a\', \'b\', \'c\'])\nprint(f\'Test 2: {result} -> Expected: [\\"c\\", \\"b\\", \\"a\\"] -> {\\"PASS\\" if result == [\\"c\\", \\"b\\", \\"a\\"] else \\"FAIL\\"}\')\n\n# Test case 3\nresult = reverse_list([])\nprint(f\'Test 3: {result} -> Expected: [] -> {\\"PASS\\" if result == [] else \\"FAIL\\"}\')\n\n# Test case 4\nresult = reverse_list([1])\nprint(f\'Test 4: {result} -> Expected: [1] -> {\\"PASS\\" if result == [1] else \\"FAIL\\"}\')\n"\n'}
+2026-06-12 14:00:01,944 - dgm_agent_pkg_069592d521de.agent - INFO - Tool Result Status: ToolExecutionStatus.SUCCESS
+2026-06-12 14:00:01,944 - dgm_agent_pkg_069592d521de.agent - INFO - Tool Result Output: Test 1: [5, 4, 3, 2, 1] -> Expected: [5, 4, 3, 2, 1] -> PASS
+Test 2: ['c', 'b', 'a'] -> Expected: ["c", "b", "a"] -> PASS
+Test 3: [] -> Expected: [] -> PASS
+Test 4: [1] -> Expected: [1] -> PASS
+...
+2026-06-12 14:00:01,944 - dgm_agent_pkg_069592d521de.agent - INFO - === END TOOL CALL 1 ===
+2026-06-12 14:00:01,944 - dgm_agent_pkg_069592d521de.agent - INFO - Step 4/5
+2026-06-12 14:00:01,944 - dgm_agent_pkg_069592d521de.agent - INFO - Making API call - Step 4
+2026-06-12 14:00:01,944 - dgm_agent_pkg_069592d521de.agent - INFO - Conversation history has 8 messages
+2026-06-12 14:00:01,944 - dgm_agent_pkg_069592d521de.agent - INFO - Recent message 1: Role=MessageRole.ASSISTANT, Content preview=No response generated...
+2026-06-12 14:00:01,944 - dgm_agent_pkg_069592d521de.agent - INFO - Recent message 2: Role=MessageRole.TOOL, Content preview=Tool execution successful:
+Test 1: [5, 4, 3, 2, 1] -> Expected: [5, 4, 3, 2, 1] -> PASS
+Test 2: ['c'...
+2026-06-12 14:00:01,944 - dgm_agent_pkg_069592d521de.fm_interface.providers.anthropic - INFO - Starting Anthropic API request (timeout: 60s, model: claude-sonnet-4-6)
+2026-06-12 14:00:06,063 - httpx - INFO - HTTP Request: POST https://api.anthropic.com/v1/messages "HTTP/1.1 200 OK"
+2026-06-12 14:00:06,066 - dgm_agent_pkg_069592d521de.fm_interface.providers.anthropic - INFO - Anthropic API request completed successfully in 4.12s
+2026-06-12 14:00:06,067 - dgm_agent_pkg_069592d521de.agent - INFO - API call completed. Tool calls: 0
+2026-06-12 14:00:06,067 - dgm_agent_pkg_069592d521de.agent - INFO - API usage: {'prompt_tokens': 3001, 'completion_tokens': 176, 'total_tokens': 3177}
+2026-06-12 14:00:06,067 - dgm_agent_pkg_069592d521de.agent - INFO - === AGENT RESPONSE (Step 4) ===
+2026-06-12 14:00:06,067 - dgm_agent_pkg_069592d521de.agent - INFO - All 4 test cases pass! Here's the final solution:
+
+```python
+def reverse_list(lst):
+    result = []
+    for i in range(len(lst) - 1, -1, -1):
+        result.append(lst[i])
+    return result
+```
+
+**How it works:**
+- Iterates through the input list indices **backwards** using `range(len(lst) - 1, -1, -1)` — starting from the last index down to `0`
+- Appends each element to a new `result` list in that reversed order
+- Returns the new reversed list
+- ✅ No `reverse()` method used
+- ✅ No `[::-1]` slicing used
+
+Task complete
+2026-06-12 14:00:06,067 - dgm_agent_pkg_069592d521de.agent - INFO - === END RESPONSE ===
+2026-06-12 14:00:06,067 - dgm_agent_pkg_069592d521de.agent - INFO - Task completion detected with primary indicator: 'task complete'
+2026-06-12 14:00:06,067 - dgm_agent_pkg_069592d521de.agent - INFO - _is_task_complete returned: True
+2026-06-12 14:00:06,067 - dgm_agent_pkg_069592d521de.agent - INFO - Task complete after Step 4
+2026-06-12 14:00:06,068 - dgm_agent_pkg_069592d521de.agent - INFO - Extracted code from markdown block: 128 characters
+2026-06-12 14:00:06,068 - dgm_agent_pkg_069592d521de.agent - INFO - Completed task solving with 9 total messages
+2026-06-12 14:00:06,266 - dgm_controller - INFO - list_processing score: 1.000
+2026-06-12 14:00:06,266 - dgm_controller - INFO - Modified agent total score: 1.000
+2026-06-12 14:00:06,276 - archive.agent_archive - INFO - Archive metadata saved
+2026-06-12 14:00:06,276 - archive.agent_archive - INFO - Added agent 08150f6d-25ca-4bce-93ef-3172cc3a5a0d to archive (gen 1, score: 1.00)
+2026-06-12 14:00:06,276 - dgm_controller - INFO - Added agent 08150f6d-25ca-4bce-93ef-3172cc3a5a0d to archive
+2026-06-12 14:00:06,276 - dgm_controller - INFO - 
+--- Progress Report ---
+2026-06-12 14:00:06,276 - dgm_controller - INFO - Generation: 1
+2026-06-12 14:00:06,276 - dgm_controller - INFO - Runtime: 0.8 minutes
+2026-06-12 14:00:06,276 - dgm_controller - INFO - Total agents created: 1
+2026-06-12 14:00:06,276 - dgm_controller - INFO - Successful improvements: 0
+2026-06-12 14:00:06,276 - dgm_controller - INFO - Archive size: 2
+2026-06-12 14:00:06,276 - dgm_controller - INFO - 
+Top agents:
+2026-06-12 14:00:06,276 - dgm_controller - INFO -   1. 686d489b-7bcb-4d8d-a007-d971ddafcfdd: 1.000
+2026-06-12 14:00:06,276 - dgm_controller - INFO -   2. 08150f6d-25ca-4bce-93ef-3172cc3a5a0d: 1.000
+2026-06-12 14:00:06,276 - dgm_controller - INFO - 
+==================================================
+2026-06-12 14:00:06,276 - dgm_controller - INFO - GENERATION 2
+2026-06-12 14:00:06,276 - dgm_controller - INFO - ==================================================
+2026-06-12 14:00:06,277 - dgm_controller - INFO - Selected parent: 08150f6d-25ca-4bce-93ef-3172cc3a5a0d (score: 1.000)
+2026-06-12 14:00:06,277 - dgm_controller - INFO - Attempting self-modification...
+2026-06-12 14:00:06,286 - agent.agent - INFO - Starting task solving steps for task: self_modify_08150f6d-25ca-4bce-93ef-3172cc3a5a0d_2
+2026-06-12 14:00:06,286 - agent.agent - INFO - Starting task solution with up to 5 steps for task self_modify_08150f6d-25ca-4bce-93ef-3172cc3a5a0d_2
+2026-06-12 14:00:06,286 - agent.agent - INFO - Step 1/5
+2026-06-12 14:00:06,286 - agent.agent - INFO - Making API call - Step 1
+2026-06-12 14:00:06,286 - agent.agent - INFO - Conversation history has 2 messages
+2026-06-12 14:00:06,286 - agent.fm_interface.providers.anthropic - INFO - Starting Anthropic API request (timeout: 60s, model: claude-sonnet-4-6)
+2026-06-12 14:00:09,043 - httpx - INFO - HTTP Request: POST https://api.anthropic.com/v1/messages "HTTP/1.1 200 OK"
+2026-06-12 14:00:09,046 - agent.fm_interface.providers.anthropic - INFO - Anthropic API request completed successfully in 2.76s
+2026-06-12 14:00:09,046 - agent.agent - INFO - API call completed. Tool calls: 2
+2026-06-12 14:00:09,047 - agent.agent - INFO - API usage: {'prompt_tokens': 2021, 'completion_tokens': 144, 'total_tokens': 2165}
+2026-06-12 14:00:09,047 - agent.agent - INFO - === AGENT RESPONSE (Step 1) ===
+2026-06-12 14:00:09,047 - agent.agent - INFO - I'll analyze the current agent code and make meaningful improvements to enhance benchmark performance.
+2026-06-12 14:00:09,047 - agent.agent - INFO - === END RESPONSE ===
+2026-06-12 14:00:09,047 - agent.agent - INFO - Executing 2 tool calls
+2026-06-12 14:00:09,047 - agent.agent - INFO - === TOOL CALL 1 ===
+2026-06-12 14:00:09,047 - agent.agent - INFO - Tool: bash
+2026-06-12 14:00:09,047 - agent.agent - INFO - Parameters: {'command': 'find . -type f -name "*.py" | head -50 && echo "---" && ls -la'}
+2026-06-12 14:00:09,047 - agent.agent - INFO - Tool Result Status: ToolExecutionStatus.ERROR
+2026-06-12 14:00:09,048 - agent.agent - INFO - Tool Result Output: None...
+2026-06-12 14:00:09,048 - agent.agent - INFO - Tool Result Error: Command blocked for safety: Pattern '&&' requires careful review
+2026-06-12 14:00:09,048 - agent.agent - INFO - === END TOOL CALL 1 ===
+2026-06-12 14:00:09,048 - agent.agent - INFO - === TOOL CALL 2 ===
+2026-06-12 14:00:09,048 - agent.agent - INFO - Tool: bash
+2026-06-12 14:00:09,048 - agent.agent - INFO - Parameters: {'command': 'cat agent.py 2>/dev/null || echo "agent.py not found"'}
+2026-06-12 14:00:09,049 - agent.agent - INFO - Tool Result Status: ToolExecutionStatus.ERROR
+2026-06-12 14:00:09,049 - agent.agent - INFO - Tool Result Output: None...
+2026-06-12 14:00:09,049 - agent.agent - INFO - Tool Result Error: Command blocked for safety: Pattern '>' requires careful review
+2026-06-12 14:00:09,049 - agent.agent - INFO - === END TOOL CALL 2 ===
+2026-06-12 14:00:09,049 - agent.agent - INFO - Step 2/5
+2026-06-12 14:00:09,049 - agent.agent - INFO - Making API call - Step 2
+2026-06-12 14:00:09,049 - agent.agent - INFO - Conversation history has 5 messages
+2026-06-12 14:00:09,050 - agent.agent - INFO - Recent message 1: Role=MessageRole.TOOL, Content preview=Tool execution failed:
+Command blocked for safety: Pattern '&&' requires careful review...
+2026-06-12 14:00:09,050 - agent.agent - INFO - Recent message 2: Role=MessageRole.TOOL, Content preview=Tool execution failed:
+Command blocked for safety: Pattern '>' requires careful review...
+2026-06-12 14:00:09,050 - agent.fm_interface.providers.anthropic - INFO - Starting Anthropic API request (timeout: 60s, model: claude-sonnet-4-6)
+2026-06-12 14:00:11,309 - httpx - INFO - HTTP Request: POST https://api.anthropic.com/v1/messages "HTTP/1.1 200 OK"
+2026-06-12 14:00:11,313 - agent.fm_interface.providers.anthropic - INFO - Anthropic API request completed successfully in 2.26s
+2026-06-12 14:00:11,313 - agent.agent - INFO - API call completed. Tool calls: 2
+2026-06-12 14:00:11,313 - agent.agent - INFO - API usage: {'prompt_tokens': 2257, 'completion_tokens': 97, 'total_tokens': 2354}
+2026-06-12 14:00:11,314 - agent.agent - INFO - === AGENT RESPONSE (Step 2) ===
+2026-06-12 14:00:11,314 - agent.agent - INFO - No response generated
+2026-06-12 14:00:11,314 - agent.agent - INFO - === END RESPONSE ===
+2026-06-12 14:00:11,314 - agent.agent - INFO - Executing 2 tool calls
+2026-06-12 14:00:11,314 - agent.agent - INFO - === TOOL CALL 1 ===
+2026-06-12 14:00:11,314 - agent.agent - INFO - Tool: bash
+2026-06-12 14:00:11,314 - agent.agent - INFO - Parameters: {'command': 'find . -type f -name "*.py"'}
+2026-06-12 14:00:11,335 - agent.agent - INFO - Tool Result Status: ToolExecutionStatus.SUCCESS
+2026-06-12 14:00:11,335 - agent.agent - INFO - Tool Result Output: ./tools/edit_tool.py
+./tools/bash_tool.py
+./tools/__init__.py
+./tools/base_tool.py
+./solution.py
+./fm_interface/api_handler.py
+./fm_interface/providers/test_anthropic_format.py
+./fm_interface/providers/__init__.py
+./fm_interface/providers/gemini.py
+./fm_interface/providers/anthropic.py
+./fm_interface/__init__.py
+./fm_interface/message_formatter.py
+./__init__.py
+./agent.py
+...
+2026-06-12 14:00:11,335 - agent.agent - INFO - === END TOOL CALL 1 ===
+2026-06-12 14:00:11,335 - agent.agent - INFO - === TOOL CALL 2 ===
+2026-06-12 14:00:11,335 - agent.agent - INFO - Tool: bash
+2026-06-12 14:00:11,335 - agent.agent - INFO - Parameters: {'command': 'ls -la'}
+2026-06-12 14:00:11,354 - agent.agent - INFO - Tool Result Status: ToolExecutionStatus.SUCCESS
+2026-06-12 14:00:11,355 - agent.agent - INFO - Tool Result Output: total 72
+drwxr-xr-x@ 7 cdossman  staff    224 Jun 12 13:59 .
+drwxr-xr-x@ 4 cdossman  staff    128 Jun 12 14:00 ..
+-rw-r--r--@ 1 cdossman  staff    293 Feb 15 17:06 __init__.py
+-rw-r--r--@ 1 cdossman  staff  26043 Jun 12 13:58 agent.py
+drwxr-xr-x@ 6 cdossman  staff    192 Jun 12 13:59 fm_interface
+-rw-r--r--@ 1 cdossman  staff    129 Jun 12 13:59 solution.py
+drwxr-xr-x@ 6 cdossman  staff    192 Jun 12 13:59 tools
+...
+2026-06-12 14:00:11,355 - agent.agent - INFO - === END TOOL CALL 2 ===
+2026-06-12 14:00:11,355 - agent.agent - INFO - Step 3/5
+2026-06-12 14:00:11,355 - agent.agent - INFO - Making API call - Step 3
+2026-06-12 14:00:11,355 - agent.agent - INFO - Conversation history has 8 messages
+2026-06-12 14:00:11,355 - agent.agent - INFO - Recent message 1: Role=MessageRole.TOOL, Content preview=Tool execution successful:
+./tools/edit_tool.py
+./tools/bash_tool.py
+./tools/__init__.py
+./tools/bas...
+2026-06-12 14:00:11,355 - agent.agent - INFO - Recent message 2: Role=MessageRole.TOOL, Content preview=Tool execution successful:
+total 72
+drwxr-xr-x@ 7 cdossman  staff    224 Jun 12 13:59 .
+drwxr-xr-x@ ...
+2026-06-12 14:00:11,355 - agent.fm_interface.providers.anthropic - INFO - Starting Anthropic API request (timeout: 60s, model: claude-sonnet-4-6)
+2026-06-12 14:00:13,597 - httpx - INFO - HTTP Request: POST https://api.anthropic.com/v1/messages "HTTP/1.1 200 OK"
+2026-06-12 14:00:13,599 - agent.fm_interface.providers.anthropic - INFO - Anthropic API request completed successfully in 2.24s
+2026-06-12 14:00:13,600 - agent.agent - INFO - API call completed. Tool calls: 2
+2026-06-12 14:00:13,600 - agent.agent - INFO - API usage: {'prompt_tokens': 2787, 'completion_tokens': 127, 'total_tokens': 2914}
+2026-06-12 14:00:13,600 - agent.agent - INFO - === AGENT RESPONSE (Step 3) ===
+2026-06-12 14:00:13,600 - agent.agent - INFO - No response generated
+2026-06-12 14:00:13,600 - agent.agent - INFO - === END RESPONSE ===
+2026-06-12 14:00:13,600 - agent.agent - INFO - Executing 2 tool calls
+2026-06-12 14:00:13,600 - agent.agent - INFO - === TOOL CALL 1 ===
+2026-06-12 14:00:13,600 - agent.agent - INFO - Tool: edit
+2026-06-12 14:00:13,600 - agent.agent - INFO - Parameters: {'action': 'read', 'file_path': 'agent.py'}
+2026-06-12 14:00:13,601 - agent.agent - INFO - Tool Result Status: ToolExecutionStatus.SUCCESS
+2026-06-12 14:00:13,601 - agent.agent - INFO - Tool Result Output: """
+Main DGM Agent implementation.
+
+This module contains the core Agent class that represents a self-modifying
+coding agent in the Darwin Gödel Machine system.
+"""
+
+import asyncio
+import json
+import logging
+import uuid
+from typing import Dict, Any, List, Optional, Union
+from dataclasses import dataclass, field
+from pathlib import Path
+import yaml
+import os
+
+logger = logging.getLogger(__name__)
+
+from .fm_interface.api_handler import (
+    ApiHandler, CompletionRequest, CompletionResponse, Message...
+2026-06-12 14:00:13,601 - agent.agent - INFO - === END TOOL CALL 1 ===
+2026-06-12 14:00:13,601 - agent.agent - INFO - === TOOL CALL 2 ===
+2026-06-12 14:00:13,601 - agent.agent - INFO - Tool: edit
+2026-06-12 14:00:13,601 - agent.agent - INFO - Parameters: {'action': 'read', 'file_path': 'solution.py'}
+2026-06-12 14:00:13,602 - agent.agent - INFO - Tool Result Status: ToolExecutionStatus.SUCCESS
+2026-06-12 14:00:13,602 - agent.agent - INFO - Tool Result Output: def reverse_list(lst):
+    result = []
+    for i in range(len(lst) - 1, -1, -1):
+        result.append(lst[i])
+    return result
+...
+2026-06-12 14:00:13,602 - agent.agent - INFO - === END TOOL CALL 2 ===
+2026-06-12 14:00:13,602 - agent.agent - INFO - Step 4/5
+2026-06-12 14:00:13,602 - agent.agent - INFO - Making API call - Step 4
+2026-06-12 14:00:13,602 - agent.agent - INFO - Conversation history has 11 messages
+2026-06-12 14:00:13,602 - agent.agent - INFO - Recent message 1: Role=MessageRole.TOOL, Content preview=Tool execution successful:
+"""
+Main DGM Agent implementation.
+
+This module contains the core Agent c...
+2026-06-12 14:00:13,602 - agent.agent - INFO - Recent message 2: Role=MessageRole.TOOL, Content preview=Tool execution successful:
+def reverse_list(lst):
+    result = []
+    for i in range(len(lst) - 1, -...
+2026-06-12 14:00:13,602 - agent.fm_interface.providers.anthropic - INFO - Starting Anthropic API request (timeout: 60s, model: claude-sonnet-4-6)
+2026-06-12 14:00:16,457 - httpx - INFO - HTTP Request: POST https://api.anthropic.com/v1/messages "HTTP/1.1 200 OK"
+2026-06-12 14:00:16,461 - agent.fm_interface.providers.anthropic - INFO - Anthropic API request completed successfully in 2.86s
+2026-06-12 14:00:16,461 - agent.agent - INFO - API call completed. Tool calls: 2
+2026-06-12 14:00:16,462 - agent.agent - INFO - API usage: {'prompt_tokens': 9313, 'completion_tokens': 139, 'total_tokens': 9452}
+2026-06-12 14:00:16,462 - agent.agent - INFO - === AGENT RESPONSE (Step 4) ===
+2026-06-12 14:00:16,462 - agent.agent - INFO - No response generated
+2026-06-12 14:00:16,462 - agent.agent - INFO - === END RESPONSE ===
+2026-06-12 14:00:16,462 - agent.agent - INFO - Executing 2 tool calls
+2026-06-12 14:00:16,462 - agent.agent - INFO - === TOOL CALL 1 ===
+2026-06-12 14:00:16,462 - agent.agent - INFO - Tool: edit
+2026-06-12 14:00:16,462 - agent.agent - INFO - Parameters: {'action': 'read', 'file_path': 'fm_interface/api_handler.py'}
+2026-06-12 14:00:16,464 - agent.agent - INFO - Tool Result Status: ToolExecutionStatus.SUCCESS
+2026-06-12 14:00:16,464 - agent.agent - INFO - Tool Result Output: """
+Abstract base class for Foundation Model API handlers.
+
+This module defines the interface that all FM provider implementations must follow,
+enabling the DGM system to work with different Foundation Models interchangeably.
+"""
+
+from abc import ABC, abstractmethod
+from typing import Dict, List, Any, Optional, Union
+from dataclasses import dataclass
+from enum import Enum
+
+
+class MessageRole(Enum):
+    """Standard roles for messages in conversations."""
+    SYSTEM = "system"
+    USER = "user"
+  ...
+2026-06-12 14:00:16,464 - agent.agent - INFO - === END TOOL CALL 1 ===
+2026-06-12 14:00:16,464 - agent.agent - INFO - === TOOL CALL 2 ===
+2026-06-12 14:00:16,464 - agent.agent - INFO - Tool: edit
+2026-06-12 14:00:16,464 - agent.agent - INFO - Parameters: {'action': 'read', 'file_path': 'fm_interface/message_formatter.py'}
+2026-06-12 14:00:16,465 - agent.agent - INFO - Tool Result Status: ToolExecutionStatus.SUCCESS
+2026-06-12 14:00:16,465 - agent.agent - INFO - Tool Result Output: """
+Message formatting utilities for Foundation Model interactions.
+
+This module provides utilities for transforming messages between different formats,
+handling context assembly, and managing conversation history for the DGM system.
+"""
+
+from typing import List, Dict, Any, Optional, Union
+from dataclasses import dataclass, field
+from enum import Enum
+
+from .api_handler import Message, MessageRole, ToolCall, ToolResult
+from ..tools.base_tool import ToolExecutionStatus
+
+
+class MessageContext(Enum...
+2026-06-12 14:00:16,465 - agent.agent - INFO - === END TOOL CALL 2 ===
+2026-06-12 14:00:16,465 - agent.agent - INFO - Step 5/5
+2026-06-12 14:00:16,465 - agent.agent - INFO - Making API call - Step 5
+2026-06-12 14:00:16,465 - agent.agent - INFO - Conversation history has 14 messages
+2026-06-12 14:00:16,465 - agent.agent - INFO - Recent message 1: Role=MessageRole.TOOL, Content preview=Tool execution successful:
+"""
+Abstract base class for Foundation Model API handlers.
+
+This module d...
+2026-06-12 14:00:16,465 - agent.agent - INFO - Recent message 2: Role=MessageRole.TOOL, Content preview=Tool execution successful:
+"""
+Message formatting utilities for Foundation Model interactions.
+
+This...
+2026-06-12 14:00:16,465 - agent.fm_interface.providers.anthropic - INFO - Starting Anthropic API request (timeout: 60s, model: claude-sonnet-4-6)
+2026-06-12 14:00:20,674 - httpx - INFO - HTTP Request: POST https://api.anthropic.com/v1/messages "HTTP/1.1 200 OK"
+2026-06-12 14:00:20,676 - agent.fm_interface.providers.anthropic - INFO - Anthropic API request completed successfully in 4.21s
+2026-06-12 14:00:20,676 - agent.agent - INFO - API call completed. Tool calls: 2
+2026-06-12 14:00:20,676 - agent.agent - INFO - API usage: {'prompt_tokens': 13671, 'completion_tokens': 139, 'total_tokens': 13810}
+2026-06-12 14:00:20,676 - agent.agent - INFO - === AGENT RESPONSE (Step 5) ===
+2026-06-12 14:00:20,676 - agent.agent - INFO - No response generated
+2026-06-12 14:00:20,677 - agent.agent - INFO - === END RESPONSE ===
+2026-06-12 14:00:20,677 - agent.agent - INFO - Executing 2 tool calls
+2026-06-12 14:00:20,677 - agent.agent - INFO - === TOOL CALL 1 ===
+2026-06-12 14:00:20,677 - agent.agent - INFO - Tool: edit
+2026-06-12 14:00:20,677 - agent.agent - INFO - Parameters: {'action': 'read', 'file_path': 'tools/base_tool.py'}
+2026-06-12 14:00:20,678 - agent.agent - INFO - Tool Result Status: ToolExecutionStatus.SUCCESS
+2026-06-12 14:00:20,678 - agent.agent - INFO - Tool Result Output: """
+Base tool interface for the DGM agent system.
+
+This module defines the abstract base class that all tools must implement,
+providing a consistent interface for tool execution and parameter validation.
+"""
+
+from abc import ABC, abstractmethod
+from typing import Dict, Any, Optional, List
+from dataclasses import dataclass
+from enum import Enum
+import json
+
+
+class ToolExecutionStatus(Enum):
+    """Status of tool execution."""
+    SUCCESS = "success"
+    ERROR = "error"
+    TIMEOUT = "timeout"
+   ...
+2026-06-12 14:00:20,678 - agent.agent - INFO - === END TOOL CALL 1 ===
+2026-06-12 14:00:20,678 - agent.agent - INFO - === TOOL CALL 2 ===
+2026-06-12 14:00:20,678 - agent.agent - INFO - Tool: edit
+2026-06-12 14:00:20,678 - agent.agent - INFO - Parameters: {'action': 'read', 'file_path': 'tools/bash_tool.py'}
+2026-06-12 14:00:20,679 - agent.agent - INFO - Tool Result Status: ToolExecutionStatus.SUCCESS
+2026-06-12 14:00:20,679 - agent.agent - INFO - Tool Result Output: """
+Bash tool implementation for executing shell commands.
+
+This tool allows the DGM agent to execute bash commands in a controlled manner,
+with safety restrictions and timeout handling.
+"""
+
+import asyncio
+import os
+import re
+import shlex
+import signal
+import subprocess
+from pathlib import Path
+from typing import Dict, Any, List
+import time
+
+from .base_tool import BaseTool, ToolResult, ToolExecutionStatus, ToolParameter
+
+
+class BashTool(BaseTool):
+    """
+    Tool for executing bash commands wi...
+2026-06-12 14:00:20,679 - agent.agent - INFO - === END TOOL CALL 2 ===
+2026-06-12 14:00:20,680 - agent.agent - WARNING - Reached max steps (5) without task completion
+2026-06-12 14:00:20,680 - agent.agent - INFO - Completed task solving with 17 total messages
+2026-06-12 14:00:20,680 - dgm_controller - INFO - No solution string provided; relying on in-place edits.
+2026-06-12 14:00:20,680 - dgm_controller - INFO - Validating modified agent...
+2026-06-12 14:00:20,716 - utils.agent_loader - INFO - Successfully loaded agent from /Volumes/Crucial X10/pcc-projects/canonical/projects/darwin-godel-machine/.dgm-live-runs/2026-06-12-proof/workspace/self_modify_08150f6d-25ca-4bce-93ef-3172cc3a5a0d_2/agent.py
+2026-06-12 14:00:20,716 - dgm_controller - INFO - Evaluating modified agent on benchmarks...
+2026-06-12 14:00:20,716 - dgm_controller - INFO - Running benchmark: list_processing
+2026-06-12 14:00:20,717 - utils.agent_loader - INFO - Successfully loaded agent from /Volumes/Crucial X10/pcc-projects/canonical/projects/darwin-godel-machine/.dgm-live-runs/2026-06-12-proof/workspace/self_modify_08150f6d-25ca-4bce-93ef-3172cc3a5a0d_2/agent.py
+2026-06-12 14:00:20,725 - dgm_agent_pkg_30b4d19caacc.agent - INFO - Starting task solving steps for task: benchmark_list_processing_1781287220
+2026-06-12 14:00:20,725 - dgm_agent_pkg_30b4d19caacc.agent - INFO - Starting task solution with up to 5 steps for task benchmark_list_processing_1781287220
+2026-06-12 14:00:20,725 - dgm_agent_pkg_30b4d19caacc.agent - INFO - Step 1/5
+2026-06-12 14:00:20,725 - dgm_agent_pkg_30b4d19caacc.agent - INFO - Making API call - Step 1
+2026-06-12 14:00:20,725 - dgm_agent_pkg_30b4d19caacc.agent - INFO - Conversation history has 2 messages
+2026-06-12 14:00:20,725 - dgm_agent_pkg_30b4d19caacc.fm_interface.providers.anthropic - INFO - Starting Anthropic API request (timeout: 60s, model: claude-sonnet-4-6)
+2026-06-12 14:00:26,340 - httpx - INFO - HTTP Request: POST https://api.anthropic.com/v1/messages "HTTP/1.1 200 OK"
+2026-06-12 14:00:26,343 - dgm_agent_pkg_30b4d19caacc.fm_interface.providers.anthropic - INFO - Anthropic API request completed successfully in 5.62s
+2026-06-12 14:00:26,343 - dgm_agent_pkg_30b4d19caacc.agent - INFO - API call completed. Tool calls: 1
+2026-06-12 14:00:26,343 - dgm_agent_pkg_30b4d19caacc.agent - INFO - API usage: {'prompt_tokens': 1944, 'completion_tokens': 193, 'total_tokens': 2137}
+2026-06-12 14:00:26,343 - dgm_agent_pkg_30b4d19caacc.agent - INFO - === AGENT RESPONSE (Step 1) ===
+2026-06-12 14:00:26,343 - dgm_agent_pkg_30b4d19caacc.agent - INFO - I'll implement the `reverse_list` function step by step.
+
+**Plan:**
+1. Write the function using a simple loop (no `reverse()` or `[::-1]`)
+2. Test against all official test cases
+2026-06-12 14:00:26,343 - dgm_agent_pkg_30b4d19caacc.agent - INFO - === END RESPONSE ===
+2026-06-12 14:00:26,343 - dgm_agent_pkg_30b4d19caacc.agent - INFO - Executing 1 tool calls
+2026-06-12 14:00:26,343 - dgm_agent_pkg_30b4d19caacc.agent - INFO - === TOOL CALL 1 ===
+2026-06-12 14:00:26,343 - dgm_agent_pkg_30b4d19caacc.agent - INFO - Tool: edit
+2026-06-12 14:00:26,343 - dgm_agent_pkg_30b4d19caacc.agent - INFO - Parameters: {'action': 'write', 'file_path': 'solution.py', 'content': 'def reverse_list(lst):\n    reversed_lst = []\n    for i in range(len(lst) - 1, -1, -1):\n        reversed_lst.append(lst[i])\n    return reversed_lst\n'}
+2026-06-12 14:00:26,344 - dgm_agent_pkg_30b4d19caacc.agent - INFO - Tool Result Status: ToolExecutionStatus.SUCCESS
+2026-06-12 14:00:26,345 - dgm_agent_pkg_30b4d19caacc.agent - INFO - Tool Result Output: Successfully wrote 147 characters to solution.py...
+2026-06-12 14:00:26,345 - dgm_agent_pkg_30b4d19caacc.agent - INFO - === END TOOL CALL 1 ===
+2026-06-12 14:00:26,345 - dgm_agent_pkg_30b4d19caacc.agent - INFO - Step 2/5
+2026-06-12 14:00:26,345 - dgm_agent_pkg_30b4d19caacc.agent - INFO - Making API call - Step 2
+2026-06-12 14:00:26,345 - dgm_agent_pkg_30b4d19caacc.agent - INFO - Conversation history has 4 messages
+2026-06-12 14:00:26,345 - dgm_agent_pkg_30b4d19caacc.agent - INFO - Recent message 1: Role=MessageRole.ASSISTANT, Content preview=I'll implement the `reverse_list` function step by step.
+
+**Plan:**
+1. Write the function using a si...
+2026-06-12 14:00:26,345 - dgm_agent_pkg_30b4d19caacc.agent - INFO - Recent message 2: Role=MessageRole.TOOL, Content preview=Tool execution successful:
+Successfully wrote 147 characters to solution.py...
+2026-06-12 14:00:26,345 - dgm_agent_pkg_30b4d19caacc.fm_interface.providers.anthropic - INFO - Starting Anthropic API request (timeout: 60s, model: claude-sonnet-4-6)
+2026-06-12 14:00:29,629 - httpx - INFO - HTTP Request: POST https://api.anthropic.com/v1/messages "HTTP/1.1 200 OK"
+2026-06-12 14:00:29,630 - dgm_agent_pkg_30b4d19caacc.fm_interface.providers.anthropic - INFO - Anthropic API request completed successfully in 3.29s
+2026-06-12 14:00:29,630 - dgm_agent_pkg_30b4d19caacc.agent - INFO - API call completed. Tool calls: 1
+2026-06-12 14:00:29,630 - dgm_agent_pkg_30b4d19caacc.agent - INFO - API usage: {'prompt_tokens': 2164, 'completion_tokens': 172, 'total_tokens': 2336}
+2026-06-12 14:00:29,630 - dgm_agent_pkg_30b4d19caacc.agent - INFO - === AGENT RESPONSE (Step 2) ===
+2026-06-12 14:00:29,631 - dgm_agent_pkg_30b4d19caacc.agent - INFO - No response generated
+2026-06-12 14:00:29,631 - dgm_agent_pkg_30b4d19caacc.agent - INFO - === END RESPONSE ===
+2026-06-12 14:00:29,631 - dgm_agent_pkg_30b4d19caacc.agent - INFO - Executing 1 tool calls
+2026-06-12 14:00:29,631 - dgm_agent_pkg_30b4d19caacc.agent - INFO - === TOOL CALL 1 ===
+2026-06-12 14:00:29,631 - dgm_agent_pkg_30b4d19caacc.agent - INFO - Tool: bash
+2026-06-12 14:00:29,631 - dgm_agent_pkg_30b4d19caacc.agent - INFO - Parameters: {'command': 'python3 -c "\nfrom solution import reverse_list\n\n# Official test cases\nprint(reverse_list([1, 2, 3, 4, 5]))   # Expected: [5, 4, 3, 2, 1]\nprint(reverse_list([\'a\', \'b\', \'c\']))   # Expected: [\'c\', \'b\', \'a\']\nprint(reverse_list([]))                # Expected: []\nprint(reverse_list([1]))               # Expected: [1]\n"\n'}
+2026-06-12 14:00:29,674 - dgm_agent_pkg_30b4d19caacc.agent - INFO - Tool Result Status: ToolExecutionStatus.SUCCESS
+2026-06-12 14:00:29,675 - dgm_agent_pkg_30b4d19caacc.agent - INFO - Tool Result Output: [5, 4, 3, 2, 1]
+['c', 'b', 'a']
+[]
+[1]
+...
+2026-06-12 14:00:29,675 - dgm_agent_pkg_30b4d19caacc.agent - INFO - === END TOOL CALL 1 ===
+2026-06-12 14:00:29,675 - dgm_agent_pkg_30b4d19caacc.agent - INFO - Step 3/5
+2026-06-12 14:00:29,675 - dgm_agent_pkg_30b4d19caacc.agent - INFO - Making API call - Step 3
+2026-06-12 14:00:29,675 - dgm_agent_pkg_30b4d19caacc.agent - INFO - Conversation history has 6 messages
+2026-06-12 14:00:29,675 - dgm_agent_pkg_30b4d19caacc.agent - INFO - Recent message 1: Role=MessageRole.ASSISTANT, Content preview=No response generated...
+2026-06-12 14:00:29,675 - dgm_agent_pkg_30b4d19caacc.agent - INFO - Recent message 2: Role=MessageRole.TOOL, Content preview=Tool execution successful:
+[5, 4, 3, 2, 1]
+['c', 'b', 'a']
+[]
+[1]
+...
+2026-06-12 14:00:29,675 - dgm_agent_pkg_30b4d19caacc.fm_interface.providers.anthropic - INFO - Starting Anthropic API request (timeout: 60s, model: claude-sonnet-4-6)
+2026-06-12 14:00:33,638 - httpx - INFO - HTTP Request: POST https://api.anthropic.com/v1/messages "HTTP/1.1 200 OK"
+2026-06-12 14:00:33,641 - dgm_agent_pkg_30b4d19caacc.fm_interface.providers.anthropic - INFO - Anthropic API request completed successfully in 3.97s
+2026-06-12 14:00:33,641 - dgm_agent_pkg_30b4d19caacc.agent - INFO - API call completed. Tool calls: 0
+2026-06-12 14:00:33,641 - dgm_agent_pkg_30b4d19caacc.agent - INFO - API usage: {'prompt_tokens': 2391, 'completion_tokens': 160, 'total_tokens': 2551}
+2026-06-12 14:00:33,641 - dgm_agent_pkg_30b4d19caacc.agent - INFO - === AGENT RESPONSE (Step 3) ===
+2026-06-12 14:00:33,641 - dgm_agent_pkg_30b4d19caacc.agent - INFO - All 4 official test cases pass. Here's the final solution:
+
+```python
+def reverse_list(lst):
+    reversed_lst = []
+    for i in range(len(lst) - 1, -1, -1):
+        reversed_lst.append(lst[i])
+    return reversed_lst
+```
+
+**How it works:**
+- Iterates from the last index (`len(lst) - 1`) down to `0` (inclusive), stepping by `-1`
+- Appends each element to a new list in that reverse order
+- Returns the new reversed list
+- No `reverse()` method or `[::-1]` slicing used ✅
+
+Task complete
+2026-06-12 14:00:33,641 - dgm_agent_pkg_30b4d19caacc.agent - INFO - === END RESPONSE ===
+2026-06-12 14:00:33,642 - dgm_agent_pkg_30b4d19caacc.agent - INFO - Task completion detected with primary indicator: 'task complete'
+2026-06-12 14:00:33,642 - dgm_agent_pkg_30b4d19caacc.agent - INFO - _is_task_complete returned: True
+2026-06-12 14:00:33,642 - dgm_agent_pkg_30b4d19caacc.agent - INFO - Task complete after Step 3
+2026-06-12 14:00:33,642 - dgm_agent_pkg_30b4d19caacc.agent - INFO - Extracted code from markdown block: 146 characters
+2026-06-12 14:00:33,642 - dgm_agent_pkg_30b4d19caacc.agent - INFO - Completed task solving with 7 total messages
+2026-06-12 14:00:33,826 - dgm_controller - INFO - list_processing score: 1.000
+2026-06-12 14:00:33,826 - dgm_controller - INFO - Modified agent total score: 1.000
+2026-06-12 14:00:33,833 - archive.agent_archive - INFO - Archive metadata saved
+2026-06-12 14:00:33,833 - archive.agent_archive - INFO - Added agent 321422b4-3747-4896-af61-c2060fcf6884 to archive (gen 2, score: 1.00)
+2026-06-12 14:00:33,833 - dgm_controller - INFO - Added agent 321422b4-3747-4896-af61-c2060fcf6884 to archive
+2026-06-12 14:00:33,833 - dgm_controller - INFO - 
+--- Progress Report ---
+2026-06-12 14:00:33,833 - dgm_controller - INFO - Generation: 2
+2026-06-12 14:00:33,833 - dgm_controller - INFO - Runtime: 1.2 minutes
+2026-06-12 14:00:33,833 - dgm_controller - INFO - Total agents created: 2
+2026-06-12 14:00:33,833 - dgm_controller - INFO - Successful improvements: 0
+2026-06-12 14:00:33,833 - dgm_controller - INFO - Archive size: 3
+2026-06-12 14:00:33,833 - dgm_controller - INFO - 
+Top agents:
+2026-06-12 14:00:33,833 - dgm_controller - INFO -   1. 686d489b-7bcb-4d8d-a007-d971ddafcfdd: 1.000
+2026-06-12 14:00:33,833 - dgm_controller - INFO -   2. 08150f6d-25ca-4bce-93ef-3172cc3a5a0d: 1.000
+2026-06-12 14:00:33,833 - dgm_controller - INFO -   3. 321422b4-3747-4896-af61-c2060fcf6884: 1.000
+2026-06-12 14:00:33,833 - dgm_controller - INFO - 
+==================================================
+2026-06-12 14:00:33,833 - dgm_controller - INFO - FINAL REPORT
+2026-06-12 14:00:33,833 - dgm_controller - INFO - ==================================================
+2026-06-12 14:00:33,833 - dgm_controller - INFO - Total runtime: 0.02 hours
+2026-06-12 14:00:33,833 - dgm_controller - INFO - Generations: 2
+2026-06-12 14:00:33,833 - dgm_controller - INFO - Agents created: 2
+2026-06-12 14:00:33,833 - dgm_controller - INFO - Improvements: 0 (0.0%)
+2026-06-12 14:00:33,833 - dgm_controller - INFO - 
+Top agent: 686d489b-7bcb-4d8d-a007-d971ddafcfdd
+2026-06-12 14:00:33,833 - dgm_controller - INFO - Top score: 1.000
+2026-06-12 14:00:33,833 - dgm_controller - INFO - 
+Full report saved to: .dgm-live-runs/2026-06-12-proof/results/dgm_report_20260612_140033.json
+2026-06-12 14:00:33,833 - __main__ - INFO - DGM run completed successfully!

--- a/tests/unit/test_agent.py
+++ b/tests/unit/test_agent.py
@@ -171,6 +171,32 @@ class TestAgentSolveTask:
         # Should not grow unboundedly from prior task
         assert len(self.agent.conversation_history) <= len_after_a + 10
 
+    @patch(
+        "agent.fm_interface.providers.anthropic.AnthropicHandler.get_completion",
+        new_callable=AsyncMock,
+    )
+    async def test_solve_task_respects_configured_max_iterations(self, mock_gc):
+        mock_gc.return_value = CompletionResponse(
+            content="I need to keep working.",
+            tool_calls=[
+                ToolCall(
+                    tool_name="missing_tool",
+                    parameters={},
+                    call_id="toolu_missing",
+                )
+            ],
+            finish_reason="tool_use",
+        )
+        cfg = _make_config(self.tmp)
+        cfg.max_iterations = 2
+        agent = Agent(cfg)
+
+        task = Task(task_id="limited", description="Keep trying")
+        result = await agent.solve_task(task)
+
+        assert result["success"] is True
+        assert mock_gc.await_count == 2
+
 
 # ---------------------------------------------------------------------------
 # Task dataclass

--- a/tests/unit/test_dgm_controller.py
+++ b/tests/unit/test_dgm_controller.py
@@ -136,3 +136,20 @@ class TestDGMControllerInit:
         cfg["custom_setting"] = "${MY_TEST_VAR}"
         ctrl = DGMController(config_or_path=cfg, workspace=str(tmp_path))
         assert ctrl.config["custom_setting"] == "expanded_value"
+
+    def test_redacts_sensitive_values_before_logging(self, tmp_path):
+        from dgm_controller import DGMController
+        cfg = _minimal_config(tmp_path)
+        cfg["nested"] = {
+            "api_token": "tok_live",
+            "items": [{"password": "pw_live"}, {"safe": "visible"}],
+        }
+
+        ctrl = DGMController(config_or_path=cfg, workspace=str(tmp_path))
+        redacted = ctrl._redact_sensitive_values(ctrl.config)
+
+        assert redacted["fm_providers"]["anthropic"]["api_key"] == "[REDACTED]"
+        assert redacted["fm_providers"]["anthropic"]["max_tokens"] == 128
+        assert redacted["nested"]["api_token"] == "[REDACTED]"
+        assert redacted["nested"]["items"][0]["password"] == "[REDACTED]"
+        assert redacted["nested"]["items"][1]["safe"] == "visible"

--- a/tests/unit/test_tools.py
+++ b/tests/unit/test_tools.py
@@ -122,6 +122,16 @@ class TestBashTool:
                 f"Expected blocked command to fail: {cmd}"
             )
 
+    async def test_command_environment_redacts_secret_like_variables(self, monkeypatch):
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test-secret")
+        monkeypatch.setenv("SAFE_PUBLIC_VALUE", "visible")
+        result = await self.tool.execute({
+            "command": "python3 -c 'import os\nprint(os.getenv(\"ANTHROPIC_API_KEY\"))\nprint(os.getenv(\"SAFE_PUBLIC_VALUE\"))'"
+        })
+        assert result.status == ToolExecutionStatus.SUCCESS
+        assert "sk-test-secret" not in result.output
+        assert "visible" in result.output
+
     def test_tool_name(self):
         assert self.tool.get_name() == "bash"
 


### PR DESCRIPTION
## What changed

- Added a bounded live-run config at `config/live_dgm_proof.yaml`.
- Captured a real Anthropic-backed 2-generation DGM run under `docs/live-runs/2026-06-12-proof/`.
- Recorded score progression, measured token usage, estimated spend, and the sanitized transcript.
- Made the live proof safe to document by:
  - honoring `AgentConfig.max_iterations` instead of the hard-coded 20-step loop,
  - passing the same max-step cap into evaluation agents,
  - redacting secret-like config values before logging,
  - removing credential-like environment variables from agent bash subprocesses.

## Proof result

Command run:

```bash
PATH="$PWD/.venv/bin:$PATH" python run_dgm.py \
  --config config/live_dgm_proof.yaml \
  --generations 2
```

Observed result:

- Real Anthropic API calls: 20 successful `POST https://api.anthropic.com/v1/messages` responses.
- Measured usage: 81,943 input tokens and 3,333 output tokens.
- Estimated spend at listed Sonnet 4.6 rates: $0.295824.
- Final archive size: 3 agents.
- Score progression on `list_processing`: generation 0 = 1.000, generation 1 = 1.000, generation 2 = 1.000.

Pricing references checked on 2026-06-12:

- https://platform.claude.com/docs/en/about-claude/pricing
- https://www.anthropic.com/claude/sonnet

## Caveats

- This proves real multi-generation DGM execution, not benchmark improvement; the base agent already scored 1.000 on the selected proof benchmark.
- This does not complete full Docker sandboxing. The live agent still ran on the host with the current tool restrictions.
- The runtime archive/report directory is intentionally ignored; the stable proof artifacts are the README and transcript.

## Validation

- `PATH="$PWD/.venv/bin:$PATH" python -m pytest tests/unit/test_dgm_controller.py tests/unit/test_tools.py tests/unit/test_agent.py` -> `53 passed, 1 warning`
- `PATH="$PWD/.venv/bin:$PATH" python -m pytest` -> `166 passed, 7 skipped, 2 warnings`
- Secret scan over staged proof files found no live key/token strings.

## Needs Chris

Review the caveats and decide whether this proof artifact should merge as the roadmap item 5 closeout, or whether you want a wider/default benchmark run before claiming it as the flagship demo.
