### PR TITLE
[codex] demonstrate benchmark score movement

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,21 @@ It contains HumanEval-style standalone function tasks with reference solutions
 verified by the integration test suite; add `humaneval_style` to
 `benchmarks.enabled` when you want the DGM loop to evaluate against it.
 
+To demonstrate benchmark score movement without API keys or model calls, compare
+the bundled weak and improved HumanEval-style demo solutions:
+
+```bash
+python scripts/compare_benchmark_solutions.py \
+  --benchmark humaneval_style \
+  --baseline docs/demo/humaneval_style_baseline.py \
+  --candidate docs/demo/humaneval_style_improved.py \
+  --output docs/demo/humaneval_score_movement.json
+```
+
+This local comparison should report a baseline score of `0.500`, a candidate
+score of `1.000`, and `delta=+0.500`. It verifies the benchmark harness and
+reporting path; it is not evidence of autonomous DGM self-improvement.
+
 ## 🧪 Running Experiments
 
 ### Basic Evolution Run

--- a/docs/demo/humaneval_score_movement.json
+++ b/docs/demo/humaneval_score_movement.json
@@ -1,0 +1,367 @@
+{
+  "baseline": {
+    "label": "baseline",
+    "passed": 10,
+    "path": "docs/demo/humaneval_style_baseline.py",
+    "score": 0.5,
+    "test_cases": [
+      {
+        "function_name": "has_close_pair",
+        "individual_results": [
+          {
+            "actual_output": "False",
+            "error": null,
+            "expected_output": "False",
+            "input": "[1.0, 2.0, 3.0], 0.5",
+            "success": true
+          },
+          {
+            "actual_output": "False",
+            "error": null,
+            "expected_output": "True",
+            "input": "[1.0, 2.0, 3.0], 1.1",
+            "success": false
+          },
+          {
+            "actual_output": "False",
+            "error": null,
+            "expected_output": "False",
+            "input": "[], 1.0",
+            "success": true
+          },
+          {
+            "actual_output": "False",
+            "error": null,
+            "expected_output": "False",
+            "input": "[5.0], 0.1",
+            "success": true
+          },
+          {
+            "actual_output": "False",
+            "error": null,
+            "expected_output": "True",
+            "input": "[-1.0, -1.4, 2.0], 0.5",
+            "success": false
+          }
+        ],
+        "passed": 3,
+        "success": false,
+        "total": 5
+      },
+      {
+        "function_name": "split_balanced_parens",
+        "individual_results": [
+          {
+            "actual_output": "[]",
+            "error": null,
+            "expected_output": "['(())', '()']",
+            "input": "'(())()'",
+            "success": false
+          },
+          {
+            "actual_output": "[]",
+            "error": null,
+            "expected_output": "['(()())', '(())']",
+            "input": "'(()())(())'",
+            "success": false
+          },
+          {
+            "actual_output": "[]",
+            "error": null,
+            "expected_output": "[]",
+            "input": "''",
+            "success": true
+          },
+          {
+            "actual_output": "[]",
+            "error": null,
+            "expected_output": "['()', '()', '()']",
+            "input": "'()()()'",
+            "success": false
+          },
+          {
+            "actual_output": "[]",
+            "error": null,
+            "expected_output": "['((()))']",
+            "input": "'((()))'",
+            "success": false
+          }
+        ],
+        "passed": 1,
+        "success": false,
+        "total": 5
+      },
+      {
+        "function_name": "rolling_minimum",
+        "individual_results": [
+          {
+            "actual_output": "[3, 2, 5, 1, 4]",
+            "error": null,
+            "expected_output": "[3, 2, 2, 1, 1]",
+            "input": "[3, 2, 5, 1, 4]",
+            "success": false
+          },
+          {
+            "actual_output": "[1, 2, 3]",
+            "error": null,
+            "expected_output": "[1, 1, 1]",
+            "input": "[1, 2, 3]",
+            "success": false
+          },
+          {
+            "actual_output": "[-1, -3, 0, -2]",
+            "error": null,
+            "expected_output": "[-1, -3, -3, -3]",
+            "input": "[-1, -3, 0, -2]",
+            "success": false
+          },
+          {
+            "actual_output": "[]",
+            "error": null,
+            "expected_output": "[]",
+            "input": "[]",
+            "success": true
+          },
+          {
+            "actual_output": "[5]",
+            "error": null,
+            "expected_output": "[5]",
+            "input": "[5]",
+            "success": true
+          }
+        ],
+        "passed": 2,
+        "success": false,
+        "total": 5
+      },
+      {
+        "function_name": "below_zero",
+        "individual_results": [
+          {
+            "actual_output": "False",
+            "error": null,
+            "expected_output": "True",
+            "input": "[1, 2, -4, 1]",
+            "success": false
+          },
+          {
+            "actual_output": "False",
+            "error": null,
+            "expected_output": "False",
+            "input": "[5, -3, -1]",
+            "success": true
+          },
+          {
+            "actual_output": "True",
+            "error": null,
+            "expected_output": "True",
+            "input": "[-1]",
+            "success": true
+          },
+          {
+            "actual_output": "False",
+            "error": null,
+            "expected_output": "False",
+            "input": "[]",
+            "success": true
+          },
+          {
+            "actual_output": "True",
+            "error": null,
+            "expected_output": "True",
+            "input": "[2, -2, -1]",
+            "success": true
+          }
+        ],
+        "passed": 4,
+        "success": false,
+        "total": 5
+      }
+    ],
+    "total": 20
+  },
+  "benchmark": "humaneval_style",
+  "benchmarks_dir": "config/benchmarks",
+  "candidate": {
+    "label": "candidate",
+    "passed": 20,
+    "path": "docs/demo/humaneval_style_improved.py",
+    "score": 1.0,
+    "test_cases": [
+      {
+        "function_name": "has_close_pair",
+        "individual_results": [
+          {
+            "actual_output": "False",
+            "error": null,
+            "expected_output": "False",
+            "input": "[1.0, 2.0, 3.0], 0.5",
+            "success": true
+          },
+          {
+            "actual_output": "True",
+            "error": null,
+            "expected_output": "True",
+            "input": "[1.0, 2.0, 3.0], 1.1",
+            "success": true
+          },
+          {
+            "actual_output": "False",
+            "error": null,
+            "expected_output": "False",
+            "input": "[], 1.0",
+            "success": true
+          },
+          {
+            "actual_output": "False",
+            "error": null,
+            "expected_output": "False",
+            "input": "[5.0], 0.1",
+            "success": true
+          },
+          {
+            "actual_output": "True",
+            "error": null,
+            "expected_output": "True",
+            "input": "[-1.0, -1.4, 2.0], 0.5",
+            "success": true
+          }
+        ],
+        "passed": 5,
+        "success": true,
+        "total": 5
+      },
+      {
+        "function_name": "split_balanced_parens",
+        "individual_results": [
+          {
+            "actual_output": "['(())', '()']",
+            "error": null,
+            "expected_output": "['(())', '()']",
+            "input": "'(())()'",
+            "success": true
+          },
+          {
+            "actual_output": "['(()())', '(())']",
+            "error": null,
+            "expected_output": "['(()())', '(())']",
+            "input": "'(()())(())'",
+            "success": true
+          },
+          {
+            "actual_output": "[]",
+            "error": null,
+            "expected_output": "[]",
+            "input": "''",
+            "success": true
+          },
+          {
+            "actual_output": "['()', '()', '()']",
+            "error": null,
+            "expected_output": "['()', '()', '()']",
+            "input": "'()()()'",
+            "success": true
+          },
+          {
+            "actual_output": "['((()))']",
+            "error": null,
+            "expected_output": "['((()))']",
+            "input": "'((()))'",
+            "success": true
+          }
+        ],
+        "passed": 5,
+        "success": true,
+        "total": 5
+      },
+      {
+        "function_name": "rolling_minimum",
+        "individual_results": [
+          {
+            "actual_output": "[3, 2, 2, 1, 1]",
+            "error": null,
+            "expected_output": "[3, 2, 2, 1, 1]",
+            "input": "[3, 2, 5, 1, 4]",
+            "success": true
+          },
+          {
+            "actual_output": "[1, 1, 1]",
+            "error": null,
+            "expected_output": "[1, 1, 1]",
+            "input": "[1, 2, 3]",
+            "success": true
+          },
+          {
+            "actual_output": "[-1, -3, -3, -3]",
+            "error": null,
+            "expected_output": "[-1, -3, -3, -3]",
+            "input": "[-1, -3, 0, -2]",
+            "success": true
+          },
+          {
+            "actual_output": "[]",
+            "error": null,
+            "expected_output": "[]",
+            "input": "[]",
+            "success": true
+          },
+          {
+            "actual_output": "[5]",
+            "error": null,
+            "expected_output": "[5]",
+            "input": "[5]",
+            "success": true
+          }
+        ],
+        "passed": 5,
+        "success": true,
+        "total": 5
+      },
+      {
+        "function_name": "below_zero",
+        "individual_results": [
+          {
+            "actual_output": "True",
+            "error": null,
+            "expected_output": "True",
+            "input": "[1, 2, -4, 1]",
+            "success": true
+          },
+          {
+            "actual_output": "False",
+            "error": null,
+            "expected_output": "False",
+            "input": "[5, -3, -1]",
+            "success": true
+          },
+          {
+            "actual_output": "True",
+            "error": null,
+            "expected_output": "True",
+            "input": "[-1]",
+            "success": true
+          },
+          {
+            "actual_output": "False",
+            "error": null,
+            "expected_output": "False",
+            "input": "[]",
+            "success": true
+          },
+          {
+            "actual_output": "True",
+            "error": null,
+            "expected_output": "True",
+            "input": "[2, -2, -1]",
+            "success": true
+          }
+        ],
+        "passed": 5,
+        "success": true,
+        "total": 5
+      }
+    ],
+    "total": 20
+  },
+  "delta": 0.5
+}

--- a/docs/demo/humaneval_style_baseline.py
+++ b/docs/demo/humaneval_style_baseline.py
@@ -1,0 +1,14 @@
+def has_close_pair(numbers, threshold):
+    return False
+
+
+def split_balanced_parens(text):
+    return []
+
+
+def rolling_minimum(numbers):
+    return numbers
+
+
+def below_zero(changes):
+    return sum(changes) < 0

--- a/docs/demo/humaneval_style_improved.py
+++ b/docs/demo/humaneval_style_improved.py
@@ -1,0 +1,43 @@
+def has_close_pair(numbers, threshold):
+    for i, left in enumerate(numbers):
+        for right in numbers[i + 1:]:
+            if abs(left - right) < threshold:
+                return True
+    return False
+
+
+def split_balanced_parens(text):
+    groups = []
+    depth = 0
+    start = None
+
+    for index, char in enumerate(text):
+        if char == "(":
+            if depth == 0:
+                start = index
+            depth += 1
+        elif char == ")":
+            depth -= 1
+            if depth == 0 and start is not None:
+                groups.append(text[start:index + 1])
+                start = None
+
+    return groups
+
+
+def rolling_minimum(numbers):
+    result = []
+    current = None
+    for value in numbers:
+        current = value if current is None else min(current, value)
+        result.append(current)
+    return result
+
+
+def below_zero(changes):
+    balance = 0
+    for change in changes:
+        balance += change
+        if balance < 0:
+            return True
+    return False

--- a/scripts/compare_benchmark_solutions.py
+++ b/scripts/compare_benchmark_solutions.py
@@ -1,0 +1,156 @@
+"""Compare two local solution files on a configured benchmark."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+import warnings
+from pathlib import Path
+from typing import Any
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+warnings.filterwarnings(
+    "ignore",
+    category=FutureWarning,
+    module=r"agent\.fm_interface\.providers\.gemini",
+)
+
+from evaluation.benchmark_runner import BenchmarkRunner, BenchmarkTask
+
+
+async def score_solution(
+    runner: BenchmarkRunner,
+    benchmark: BenchmarkTask,
+    solution_path: Path,
+    label: str,
+) -> dict[str, Any]:
+    """Run one solution file through every test case in a benchmark."""
+    solution = solution_path.read_text()
+    test_results = []
+
+    for test_case in benchmark.test_cases:
+        result = await runner._run_test_case(solution, test_case, benchmark)
+        result["function_name"] = test_case.get("function_name", "solve")
+        test_results.append(result)
+
+    score = runner._calculate_score({"test_results": test_results}, benchmark)
+    passed = sum(result.get("passed", 0) for result in test_results)
+    total = sum(result.get("total", 0) for result in test_results)
+
+    return {
+        "label": label,
+        "path": str(solution_path),
+        "score": score,
+        "passed": passed,
+        "total": total,
+        "test_cases": test_results,
+    }
+
+
+async def compare_solutions(
+    *,
+    benchmarks_dir: Path,
+    benchmark_name: str,
+    baseline_path: Path,
+    candidate_path: Path,
+    baseline_label: str = "baseline",
+    candidate_label: str = "candidate",
+) -> dict[str, Any]:
+    """Compare baseline and candidate solution files on one benchmark."""
+    runner = BenchmarkRunner(benchmarks_dir=str(benchmarks_dir), use_sandbox=False)
+    if benchmark_name not in runner.benchmarks:
+        known = ", ".join(sorted(runner.benchmarks)) or "(none loaded)"
+        raise ValueError(f"Unknown benchmark {benchmark_name!r}. Known benchmarks: {known}")
+
+    benchmark = runner.benchmarks[benchmark_name]
+    baseline = await score_solution(runner, benchmark, baseline_path, baseline_label)
+    candidate = await score_solution(runner, benchmark, candidate_path, candidate_label)
+
+    return {
+        "benchmark": benchmark_name,
+        "benchmarks_dir": str(benchmarks_dir),
+        "baseline": baseline,
+        "candidate": candidate,
+        "delta": candidate["score"] - baseline["score"],
+    }
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Compare two local solution files on a DGM benchmark."
+    )
+    parser.add_argument("--benchmark", required=True, help="Benchmark name to run.")
+    parser.add_argument(
+        "--benchmarks-dir",
+        default="config/benchmarks",
+        help="Directory containing benchmark YAML files.",
+    )
+    parser.add_argument(
+        "--baseline",
+        required=True,
+        help="Path to the weaker or previous solution file.",
+    )
+    parser.add_argument(
+        "--candidate",
+        required=True,
+        help="Path to the improved or reference solution file.",
+    )
+    parser.add_argument(
+        "--baseline-label",
+        default="baseline",
+        help="Label for the baseline solution in the report.",
+    )
+    parser.add_argument(
+        "--candidate-label",
+        default="candidate",
+        help="Label for the candidate solution in the report.",
+    )
+    parser.add_argument(
+        "--output",
+        help="Optional path to write the JSON report.",
+    )
+    return parser
+
+
+async def _main_async(args: argparse.Namespace) -> dict[str, Any]:
+    report = await compare_solutions(
+        benchmarks_dir=Path(args.benchmarks_dir),
+        benchmark_name=args.benchmark,
+        baseline_path=Path(args.baseline),
+        candidate_path=Path(args.candidate),
+        baseline_label=args.baseline_label,
+        candidate_label=args.candidate_label,
+    )
+
+    if args.output:
+        output_path = Path(args.output)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n")
+
+    baseline = report["baseline"]
+    candidate = report["candidate"]
+    print(
+        f"{report['benchmark']}: "
+        f"{baseline['label']}={baseline['score']:.3f} "
+        f"({baseline['passed']}/{baseline['total']}), "
+        f"{candidate['label']}={candidate['score']:.3f} "
+        f"({candidate['passed']}/{candidate['total']}), "
+        f"delta={report['delta']:+.3f}"
+    )
+
+    return report
+
+
+def main() -> None:
+    parser = _build_parser()
+    args = parser.parse_args()
+    asyncio.run(_main_async(args))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/integration/test_benchmark_score_movement_demo.py
+++ b/tests/integration/test_benchmark_score_movement_demo.py
@@ -1,0 +1,26 @@
+from pathlib import Path
+
+import pytest
+
+from scripts.compare_benchmark_solutions import compare_solutions
+
+
+@pytest.mark.asyncio
+async def test_demo_solutions_show_score_movement():
+    project_root = Path(__file__).resolve().parents[2]
+
+    report = await compare_solutions(
+        benchmarks_dir=project_root / "config" / "benchmarks",
+        benchmark_name="humaneval_style",
+        baseline_path=project_root / "docs" / "demo" / "humaneval_style_baseline.py",
+        candidate_path=project_root / "docs" / "demo" / "humaneval_style_improved.py",
+    )
+
+    assert report["benchmark"] == "humaneval_style"
+    assert report["baseline"]["score"] == pytest.approx(0.5)
+    assert report["candidate"]["score"] == pytest.approx(1.0)
+    assert report["delta"] == pytest.approx(0.5)
+    assert report["baseline"]["passed"] == 10
+    assert report["baseline"]["total"] == 20
+    assert report["candidate"]["passed"] == 20
+    assert report["candidate"]["total"] == 20


### PR DESCRIPTION
## Summary

- Add a local benchmark solution comparison CLI that uses the existing `BenchmarkRunner` path.
- Add HumanEval-style weak and improved demo solution files plus a checked-in JSON report.
- Document the no-network score movement command while explicitly saying it is not evidence of autonomous DGM self-improvement.

## Result

The bundled demo reports:

```text
humaneval_style: baseline=0.500 (10/20), candidate=1.000 (20/20), delta=+0.500
```

## Validation

- `PATH="$PWD/.venv/bin:$PATH" python scripts/compare_benchmark_solutions.py --benchmark humaneval_style --baseline docs/demo/humaneval_style_baseline.py --candidate docs/demo/humaneval_style_improved.py --output docs/demo/humaneval_score_movement.json`
- `PATH="$PWD/.venv/bin:$PATH" python -m pytest tests/integration/test_benchmark_score_movement_demo.py tests/integration/test_benchmark_evaluation.py`
- `PATH="$PWD/.venv/bin:$PATH" python -m pytest`
