### PR TITLE
[codex] run DGM process in sandbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,7 +313,7 @@ Results are stored in the `results/` directory with detailed JSON reports.
 - **Human Oversight**: Optional pause points for review
 - **Comprehensive Logging**: Full audit trail of all changes
 
-> **Note**: the default `python run_dgm.py` path still runs orchestration and controller/archive logic on the host. Use `scripts/run_dgm_in_sandbox.py` to move the full DGM process into Docker. The runner stages the checkout through `~/.cache/dgm-sandbox` for Docker-mounted execution and syncs successful writes back to the host checkout; live provider runs require explicit network and secret pass-through. For untrusted evolution experiments, keep using your own container or VM boundary.
+> **Note**: the default `python run_dgm.py` path still runs orchestration and controller/archive logic on the host. Use `scripts/run_dgm_in_sandbox.py` to move the full DGM process into Docker. The runner stages the checkout through `~/.cache/dgm-sandbox` for Docker-mounted execution and syncs successful writes/deletes back to the host checkout; live provider runs require explicit network and secret pass-through. For untrusted evolution experiments, keep using your own container or VM boundary.
 
 ### Full-Process Docker Runner
 
@@ -330,8 +330,8 @@ python scripts/run_dgm_in_sandbox.py \
 The runner does not pass credentials into the container unless each variable is
 named with `--env`. Network access is disabled unless `--allow-network` is set.
 The checkout is copied into a Docker-mountable cache workspace first, then
-successful writes are synced back, so generated archives, results, workspaces,
-and logs still persist in the host checkout.
+successful non-ignored writes and deletes are synced back, so generated
+archives, results, workspaces, and logs still persist in the host checkout.
 
 ## 🐛 Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -309,10 +309,29 @@ Results are stored in the `results/` directory with detailed JSON reports.
 - **Hard Timeouts**: Benchmark and tool subprocesses are killed (entire process group) on timeout
 - **Opt-in Docker Command Isolation**: With `evaluation.use_sandbox: true`, generated benchmark test scripts plus agent bash and edit tool operations run in one-shot Docker containers with image, memory, CPU, timeout, and network settings from `sandbox`
 - **Validation Checks**: Modified agents must parse, define a working Agent class, and pass a runtime load check before admission to the archive; with sandboxing enabled, the runtime load check runs in Docker
+- **Opt-in Full-Process Runner**: `scripts/run_dgm_in_sandbox.py` can run the `run_dgm.py` controller process inside Docker with the project mounted as the sandbox workspace
 - **Human Oversight**: Optional pause points for review
 - **Comprehensive Logging**: Full audit trail of all changes
 
-> **Note**: Docker isolation currently covers generated benchmark test scripts, agent bash/edit operations, and modified-agent runtime load checks. The model orchestration loop and archive/controller logic still execute in the configured host workspace with guards and timeouts, so run untrusted evolution experiments inside your own container or VM.
+> **Note**: the default `python run_dgm.py` path still runs orchestration and controller/archive logic on the host. Use `scripts/run_dgm_in_sandbox.py` to move the full DGM process into Docker. The runner stages the checkout through `~/.cache/dgm-sandbox` for Docker-mounted execution and syncs successful writes back to the host checkout; live provider runs require explicit network and secret pass-through. For untrusted evolution experiments, keep using your own container or VM boundary.
+
+### Full-Process Docker Runner
+
+To run the DGM controller process itself inside Docker:
+
+```bash
+python scripts/run_dgm_in_sandbox.py \
+  --config config/live_dgm_proof.yaml \
+  --generations 2 \
+  --allow-network \
+  --env ANTHROPIC_API_KEY
+```
+
+The runner does not pass credentials into the container unless each variable is
+named with `--env`. Network access is disabled unless `--allow-network` is set.
+The checkout is copied into a Docker-mountable cache workspace first, then
+successful writes are synced back, so generated archives, results, workspaces,
+and logs still persist in the host checkout.
 
 ## 🐛 Troubleshooting
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -34,8 +34,14 @@ cp .env.example .env
 - The sandbox image is built automatically when `sandbox.auto_build_image: true`
 - If Docker or the sandbox image is unavailable, benchmark execution, agent tool execution, and runtime load validation fall back to the direct host path rather than failing the default no-Docker workflow
 
+### Full-Process Docker Runner (opt-in)
+- Use `scripts/run_dgm_in_sandbox.py` when the controller/orchestration process itself should run inside Docker
+- The runner stages the repository through `~/.cache/dgm-sandbox` as the container workspace and syncs successful writes back so archives, results, workspaces, and logs can persist in the host checkout
+- Live provider calls require explicit `--allow-network` plus explicit `--env NAME` pass-through for each required secret; no credentials are passed by default
+
 ### Remaining Isolation Limits
-- The model orchestration loop and archive/controller logic still execute in the configured workspace on the host
+- The default `python run_dgm.py` path still executes model orchestration and archive/controller logic in the configured workspace on the host
+- The full-process Docker runner is still a staged-workspace boundary, not a disposable VM; successful writes intentionally persist to the host checkout
 - Treat every evolution run as executing model-written code on your machine: run inside your own container or VM if that is not acceptable
 
 ### Input Validation

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -36,12 +36,12 @@ cp .env.example .env
 
 ### Full-Process Docker Runner (opt-in)
 - Use `scripts/run_dgm_in_sandbox.py` when the controller/orchestration process itself should run inside Docker
-- The runner stages the repository through `~/.cache/dgm-sandbox` as the container workspace and syncs successful writes back so archives, results, workspaces, and logs can persist in the host checkout
+- The runner stages the repository through `~/.cache/dgm-sandbox` as the container workspace and syncs successful non-ignored writes and deletes back so archives, results, workspaces, and logs can persist in the host checkout
 - Live provider calls require explicit `--allow-network` plus explicit `--env NAME` pass-through for each required secret; no credentials are passed by default
 
 ### Remaining Isolation Limits
 - The default `python run_dgm.py` path still executes model orchestration and archive/controller logic in the configured workspace on the host
-- The full-process Docker runner is still a staged-workspace boundary, not a disposable VM; successful writes intentionally persist to the host checkout
+- The full-process Docker runner is still a staged-workspace boundary, not a disposable VM; successful non-ignored writes and deletes intentionally persist to the host checkout
 - Treat every evolution run as executing model-written code on your machine: run inside your own container or VM if that is not acceptable
 
 ### Input Validation

--- a/sandbox/sandbox_manager.py
+++ b/sandbox/sandbox_manager.py
@@ -7,6 +7,8 @@ package does not crash the entire program at startup. Callers can check
 
 import asyncio
 import os
+import shutil
+import tempfile
 import time
 from typing import Dict, Any, Optional, List
 from dataclasses import dataclass
@@ -141,7 +143,11 @@ class SandboxManager:
         command: str,
         agent_code_path: Optional[str] = None,
         workspace_path: Optional[str] = None,
-        timeout: Optional[int] = None
+        timeout: Optional[int] = None,
+        environment: Optional[Dict[str, str]] = None,
+        network_mode: Optional[str] = None,
+        read_only_workspace: bool = False,
+        working_dir: Optional[str] = None,
     ) -> SandboxResult:
         """Execute a shell command inside a one-shot Docker container."""
         return await asyncio.to_thread(
@@ -150,6 +156,89 @@ class SandboxManager:
             agent_code_path,
             workspace_path,
             timeout,
+            environment,
+            network_mode,
+            read_only_workspace,
+            working_dir,
+        )
+
+    async def execute_project_command(
+        self,
+        command: str,
+        project_path: str,
+        timeout: Optional[int] = None,
+        environment: Optional[Dict[str, str]] = None,
+        network_mode: Optional[str] = None,
+        read_only: bool = False,
+        stage_project: bool = True,
+        sync_back: bool = True,
+    ) -> SandboxResult:
+        """
+        Execute a command with the whole project mounted as the workspace.
+
+        This is the full-process boundary used by wrapper scripts that want the
+        controller/orchestration process itself to run inside Docker. The mount
+        may still be writable, so callers must document any host sync boundary.
+        """
+        project = Path(project_path).expanduser().resolve()
+        if stage_project:
+            sandbox_temp_parent = Path.home() / ".cache" / "dgm-sandbox"
+            sandbox_temp_parent.mkdir(parents=True, exist_ok=True)
+            with tempfile.TemporaryDirectory(dir=str(sandbox_temp_parent)) as temp_dir:
+                staged_project = Path(temp_dir) / "project"
+                self._copy_project_tree(project, staged_project)
+                result = await self.execute_in_sandbox(
+                    command=command,
+                    workspace_path=str(staged_project),
+                    timeout=timeout,
+                    environment=environment,
+                    network_mode=network_mode,
+                    read_only_workspace=read_only,
+                    working_dir=self.config.working_dir,
+                )
+                if result.success and sync_back and not read_only:
+                    self._copy_project_tree(staged_project, project)
+                return result
+
+        return await self.execute_in_sandbox(
+            command=command,
+            workspace_path=str(project),
+            timeout=timeout,
+            environment=environment,
+            network_mode=network_mode,
+            read_only_workspace=read_only,
+            working_dir=self.config.working_dir,
+        )
+
+    @staticmethod
+    def _copy_project_tree(source: Path, destination: Path) -> None:
+        """Copy a project tree while skipping local caches and virtualenvs."""
+        source = source.resolve()
+        destination = destination.resolve()
+        if not source.exists():
+            destination.mkdir(parents=True, exist_ok=True)
+            return
+
+        def ignore(_dir: str, names: List[str]) -> set:
+            ignored_names = {
+                ".git",
+                ".pytest_cache",
+                ".mypy_cache",
+                ".ruff_cache",
+                ".venv",
+                "__pycache__",
+            }
+            return {
+                name
+                for name in names
+                if name in ignored_names or name.endswith((".pyc", ".pyo"))
+            }
+
+        shutil.copytree(
+            source,
+            destination,
+            dirs_exist_ok=True,
+            ignore=ignore,
         )
 
     async def create_sandbox_environment(self, agent_id: str) -> str:
@@ -251,6 +340,10 @@ class SandboxManager:
         agent_code_path: Optional[str],
         workspace_path: Optional[str],
         timeout: Optional[int],
+        environment: Optional[Dict[str, str]],
+        network_mode: Optional[str],
+        read_only_workspace: bool,
+        working_dir: Optional[str],
     ) -> SandboxResult:
         """Synchronous Docker execution body used via ``asyncio.to_thread``."""
         client = self._get_client()
@@ -263,7 +356,7 @@ class SandboxManager:
             workspace = Path(workspace_path).resolve()
             volumes[str(workspace)] = {
                 "bind": self.config.working_dir,
-                "mode": "rw",
+                "mode": "ro" if read_only_workspace else "rw",
             }
 
         if agent_code_path:
@@ -279,11 +372,12 @@ class SandboxManager:
                 image=self.config.image_name,
                 command=["/bin/bash", "-lc", command],
                 detach=True,
-                working_dir=self.config.working_dir,
+                working_dir=working_dir or self.config.working_dir,
                 volumes=volumes,
                 mem_limit=self.config.memory_limit,
                 nano_cpus=self._cpu_limit_to_nano_cpus(self.config.cpu_limit),
-                network_mode=self.config.network_mode,
+                network_mode=network_mode or self.config.network_mode,
+                environment=environment or None,
             )
             wait_result = container.wait(timeout=effective_timeout)
             exit_code = wait_result.get("StatusCode", 1)

--- a/sandbox/sandbox_manager.py
+++ b/sandbox/sandbox_manager.py
@@ -197,7 +197,7 @@ class SandboxManager:
                     working_dir=self.config.working_dir,
                 )
                 if result.success and sync_back and not read_only:
-                    self._copy_project_tree(staged_project, project)
+                    self._sync_project_tree(staged_project, project)
                 return result
 
         return await self.execute_in_sandbox(
@@ -220,19 +220,7 @@ class SandboxManager:
             return
 
         def ignore(_dir: str, names: List[str]) -> set:
-            ignored_names = {
-                ".git",
-                ".pytest_cache",
-                ".mypy_cache",
-                ".ruff_cache",
-                ".venv",
-                "__pycache__",
-            }
-            return {
-                name
-                for name in names
-                if name in ignored_names or name.endswith((".pyc", ".pyo"))
-            }
+            return SandboxManager._ignored_project_names(names)
 
         shutil.copytree(
             source,
@@ -240,6 +228,63 @@ class SandboxManager:
             dirs_exist_ok=True,
             ignore=ignore,
         )
+
+    @staticmethod
+    def _ignored_project_names(names: List[str]) -> set:
+        """Return project-local names that should not stage or sync back."""
+        ignored_names = {
+            ".git",
+            ".pytest_cache",
+            ".mypy_cache",
+            ".ruff_cache",
+            ".venv",
+            "__pycache__",
+        }
+        return {
+            name
+            for name in names
+            if name in ignored_names or name.endswith((".pyc", ".pyo"))
+        }
+
+    @staticmethod
+    def _sync_project_tree(source: Path, destination: Path) -> None:
+        """
+        Mirror a staged project tree back to the host checkout.
+
+        Ignored local state is preserved. Non-ignored files removed inside the
+        staged project are removed from the destination before copying updated
+        files back.
+        """
+        source = source.resolve()
+        destination = destination.resolve()
+        if not source.exists():
+            destination.mkdir(parents=True, exist_ok=True)
+            return
+
+        destination.mkdir(parents=True, exist_ok=True)
+        ignored = SandboxManager._ignored_project_names([
+            child.name for child in destination.iterdir()
+        ])
+
+        for dest_child in list(destination.iterdir()):
+            if dest_child.name in ignored:
+                continue
+            source_child = source / dest_child.name
+            if not source_child.exists():
+                if dest_child.is_dir():
+                    shutil.rmtree(dest_child)
+                else:
+                    dest_child.unlink()
+                continue
+            if dest_child.is_dir() and source_child.is_dir():
+                SandboxManager._sync_project_tree(source_child, dest_child)
+            elif dest_child.is_dir() != source_child.is_dir():
+                if dest_child.is_dir():
+                    shutil.rmtree(dest_child)
+                else:
+                    dest_child.unlink()
+
+        SandboxManager._copy_project_tree(source, destination)
 
     async def create_sandbox_environment(self, agent_id: str) -> str:
         """Create a stopped container and return its id."""

--- a/scripts/run_dgm_in_sandbox.py
+++ b/scripts/run_dgm_in_sandbox.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+"""Run the DGM controller process inside the Docker sandbox."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import os
+import shlex
+import sys
+from pathlib import Path
+from typing import List, Mapping, Optional
+
+import yaml
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from sandbox.sandbox_manager import SandboxConfig, SandboxManager, SandboxResult
+
+
+class SandboxRunError(RuntimeError):
+    """Raised when the sandboxed DGM runner cannot start safely."""
+
+
+def _project_relative(path: Path, project_root: Path) -> Path:
+    path = path.expanduser()
+    if not path.is_absolute():
+        path = project_root / path
+    try:
+        return path.resolve().relative_to(project_root.resolve())
+    except ValueError as exc:
+        raise SandboxRunError(
+            f"{path} is outside project root {project_root}; mount it through config first"
+        ) from exc
+
+
+def build_dgm_command(config_path: Path, generations: int, project_root: Path) -> str:
+    """Build the command executed inside the mounted project workspace."""
+    relative_config = _project_relative(config_path, project_root)
+    return (
+        "python run_dgm.py "
+        f"--config {shlex.quote(str(relative_config))} "
+        f"--generations {generations}"
+    )
+
+
+def load_sandbox_config(config_path: Path, timeout: Optional[int] = None) -> SandboxConfig:
+    """Load SandboxConfig fields from a DGM YAML config."""
+    data = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
+    sandbox_data = data.get("sandbox", {})
+    kwargs = {
+        key: value
+        for key, value in sandbox_data.items()
+        if key in SandboxConfig.__dataclass_fields__
+    }
+    if timeout is not None:
+        kwargs["timeout"] = timeout
+    return SandboxConfig(**kwargs)
+
+
+def collect_environment(
+    names: List[str],
+    environ: Mapping[str, str] = os.environ,
+) -> dict[str, str]:
+    """Collect explicitly requested environment variables for the container."""
+    selected: dict[str, str] = {}
+    missing = []
+    for name in names:
+        if name not in environ or environ[name] == "":
+            missing.append(name)
+        else:
+            selected[name] = environ[name]
+    if missing:
+        raise SandboxRunError(
+            "Requested environment variables are not set: " + ", ".join(sorted(missing))
+        )
+    return selected
+
+
+async def run_sandboxed_dgm(
+    *,
+    config_path: Path,
+    generations: int,
+    project_root: Path = PROJECT_ROOT,
+    env_names: Optional[List[str]] = None,
+    allow_network: bool = False,
+    network_mode: str = "bridge",
+    timeout: Optional[int] = None,
+    manager: Optional[SandboxManager] = None,
+) -> SandboxResult:
+    """
+    Run ``run_dgm.py`` as a whole process inside Docker.
+
+    The project is mounted as the sandbox workspace. Live provider calls require
+    both ``allow_network=True`` and explicit ``env_names`` for provider secrets.
+    """
+    config_path = (project_root / config_path).resolve() if not config_path.is_absolute() else config_path.resolve()
+    project_root = project_root.resolve()
+    command = build_dgm_command(config_path, generations, project_root)
+    environment = collect_environment(env_names or [])
+    sandbox_config = load_sandbox_config(config_path, timeout=timeout)
+    manager = manager or SandboxManager(sandbox_config)
+
+    if not manager.is_sandbox_ready():
+        raise SandboxRunError("Docker sandbox is not ready; cannot run full DGM process")
+
+    return await manager.execute_project_command(
+        command=command,
+        project_path=str(project_root),
+        timeout=timeout or sandbox_config.timeout,
+        environment=environment,
+        network_mode=network_mode if allow_network else sandbox_config.network_mode,
+        read_only=False,
+    )
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--config", default="config/dgm_config.yaml")
+    parser.add_argument("--generations", type=int, default=3)
+    parser.add_argument("--project-root", default=str(PROJECT_ROOT))
+    parser.add_argument("--timeout", type=int, help="Container timeout in seconds.")
+    parser.add_argument(
+        "--env",
+        action="append",
+        default=[],
+        help="Environment variable name to pass into the container. Repeat as needed.",
+    )
+    parser.add_argument(
+        "--allow-network",
+        action="store_true",
+        help="Allow container network access for live provider calls.",
+    )
+    parser.add_argument(
+        "--network-mode",
+        default="bridge",
+        help="Docker network mode used only with --allow-network.",
+    )
+    return parser
+
+
+async def _main_async(args: argparse.Namespace) -> int:
+    try:
+        result = await run_sandboxed_dgm(
+            config_path=Path(args.config),
+            generations=args.generations,
+            project_root=Path(args.project_root),
+            env_names=args.env,
+            allow_network=args.allow_network,
+            network_mode=args.network_mode,
+            timeout=args.timeout,
+        )
+    except SandboxRunError as exc:
+        print(f"[fail] {exc}", file=sys.stderr)
+        return 1
+
+    if result.output:
+        print(result.output, end="" if result.output.endswith("\n") else "\n")
+    if result.error:
+        print(result.error, file=sys.stderr, end="" if result.error.endswith("\n") else "\n")
+    return 0 if result.success else result.exit_code or 1
+
+
+def main() -> int:
+    parser = _build_parser()
+    return asyncio.run(_main_async(parser.parse_args()))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_run_dgm_in_sandbox.py
+++ b/tests/unit/test_run_dgm_in_sandbox.py
@@ -1,0 +1,142 @@
+from pathlib import Path
+
+import pytest
+
+from sandbox.sandbox_manager import SandboxConfig, SandboxManager, SandboxResult
+from scripts.run_dgm_in_sandbox import (
+    SandboxRunError,
+    build_dgm_command,
+    collect_environment,
+    load_sandbox_config,
+    run_sandboxed_dgm,
+)
+
+
+def test_build_dgm_command_uses_project_relative_config(tmp_path):
+    project_root = tmp_path / "project"
+    config = project_root / "config" / "dgm_config.yaml"
+    config.parent.mkdir(parents=True)
+    config.write_text("sandbox: {}\n")
+
+    command = build_dgm_command(config, generations=2, project_root=project_root)
+
+    assert command == "python run_dgm.py --config config/dgm_config.yaml --generations 2"
+
+
+def test_build_dgm_command_rejects_config_outside_project(tmp_path):
+    project_root = tmp_path / "project"
+    outside_config = tmp_path / "dgm_config.yaml"
+    project_root.mkdir()
+    outside_config.write_text("sandbox: {}\n")
+
+    with pytest.raises(SandboxRunError, match="outside project root"):
+        build_dgm_command(outside_config, generations=1, project_root=project_root)
+
+
+def test_collect_environment_requires_explicit_existing_values():
+    env = {"ANTHROPIC_API_KEY": "secret"}
+
+    assert collect_environment(["ANTHROPIC_API_KEY"], env) == {
+        "ANTHROPIC_API_KEY": "secret"
+    }
+    with pytest.raises(SandboxRunError, match="not set"):
+        collect_environment(["GEMINI_API_KEY"], env)
+
+
+def test_load_sandbox_config_reads_project_config(tmp_path):
+    config = tmp_path / "dgm_config.yaml"
+    config.write_text(
+        """
+sandbox:
+  image_name: custom-image
+  memory_limit: 1g
+  cpu_limit: "0.5"
+  network_mode: none
+""",
+        encoding="utf-8",
+    )
+
+    sandbox_config = load_sandbox_config(config, timeout=12)
+
+    assert sandbox_config.image_name == "custom-image"
+    assert sandbox_config.memory_limit == "1g"
+    assert sandbox_config.cpu_limit == "0.5"
+    assert sandbox_config.timeout == 12
+
+
+def test_project_tree_copy_skips_local_caches(tmp_path):
+    source = tmp_path / "source"
+    destination = tmp_path / "destination"
+    source.mkdir()
+    (source / "run_dgm.py").write_text("print('ok')\n")
+    (source / ".venv").mkdir()
+    (source / ".venv" / "ignored.py").write_text("ignored\n")
+    (source / "__pycache__").mkdir()
+    (source / "__pycache__" / "ignored.pyc").write_text("ignored\n")
+
+    SandboxManager._copy_project_tree(source, destination)
+
+    assert (destination / "run_dgm.py").exists()
+    assert not (destination / ".venv").exists()
+    assert not (destination / "__pycache__").exists()
+
+
+@pytest.mark.asyncio
+async def test_run_sandboxed_dgm_invokes_project_command(tmp_path):
+    project_root = tmp_path / "project"
+    config = project_root / "config" / "dgm_config.yaml"
+    config.parent.mkdir(parents=True)
+    config.write_text("sandbox:\n  network_mode: none\n", encoding="utf-8")
+
+    class FakeManager:
+        def __init__(self):
+            self.calls = []
+            self.config = SandboxConfig(working_dir="/home/dgm_agent/workspace")
+
+        def is_sandbox_ready(self):
+            return True
+
+        async def execute_project_command(self, **kwargs):
+            self.calls.append(kwargs)
+            return SandboxResult(success=True, output="ok\n", exit_code=0)
+
+    manager = FakeManager()
+    result = await run_sandboxed_dgm(
+        config_path=config,
+        generations=2,
+        project_root=project_root,
+        env_names=[],
+        manager=manager,
+    )
+
+    assert result.success is True
+    assert manager.calls == [
+        {
+            "command": "python run_dgm.py --config config/dgm_config.yaml --generations 2",
+            "project_path": str(project_root.resolve()),
+            "timeout": 300,
+            "environment": {},
+            "network_mode": "none",
+            "read_only": False,
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_run_sandboxed_dgm_requires_ready_sandbox(tmp_path):
+    project_root = tmp_path / "project"
+    config = project_root / "config" / "dgm_config.yaml"
+    config.parent.mkdir(parents=True)
+    config.write_text("sandbox: {}\n", encoding="utf-8")
+
+    class NotReadyManager:
+        def is_sandbox_ready(self):
+            return False
+
+    with pytest.raises(SandboxRunError, match="not ready"):
+        await run_sandboxed_dgm(
+            config_path=config,
+            generations=1,
+            project_root=project_root,
+            manager=NotReadyManager(),
+        )

--- a/tests/unit/test_run_dgm_in_sandbox.py
+++ b/tests/unit/test_run_dgm_in_sandbox.py
@@ -81,6 +81,37 @@ def test_project_tree_copy_skips_local_caches(tmp_path):
     assert not (destination / "__pycache__").exists()
 
 
+def test_project_tree_sync_propagates_deletes_and_preserves_ignored(tmp_path):
+    staged = tmp_path / "staged"
+    host = tmp_path / "host"
+    staged.mkdir()
+    host.mkdir()
+
+    (staged / "kept.txt").write_text("updated\n")
+    (staged / "new.txt").write_text("new\n")
+    (staged / "nested").mkdir()
+    (staged / "nested" / "inside.txt").write_text("inside\n")
+
+    (host / "kept.txt").write_text("old\n")
+    (host / "removed.txt").write_text("remove me\n")
+    (host / "nested").mkdir()
+    (host / "nested" / "old.txt").write_text("remove me\n")
+    (host / ".git").mkdir()
+    (host / ".git" / "HEAD").write_text("preserve\n")
+    (host / ".venv").mkdir()
+    (host / ".venv" / "local.py").write_text("preserve\n")
+
+    SandboxManager._sync_project_tree(staged, host)
+
+    assert (host / "kept.txt").read_text() == "updated\n"
+    assert (host / "new.txt").read_text() == "new\n"
+    assert not (host / "removed.txt").exists()
+    assert not (host / "nested" / "old.txt").exists()
+    assert (host / "nested" / "inside.txt").read_text() == "inside\n"
+    assert (host / ".git" / "HEAD").read_text() == "preserve\n"
+    assert (host / ".venv" / "local.py").read_text() == "preserve\n"
+
+
 @pytest.mark.asyncio
 async def test_run_sandboxed_dgm_invokes_project_command(tmp_path):
     project_root = tmp_path / "project"


### PR DESCRIPTION
## Summary

- Add `scripts/run_dgm_in_sandbox.py`, an opt-in wrapper that runs the whole `run_dgm.py` controller process inside Docker.
- Extend `SandboxManager` with `execute_project_command`, including staged project copy-through via `~/.cache/dgm-sandbox`, explicit environment pass-through, optional network mode, and successful sync-back.
- Mirror successful non-ignored writes and deletes back to the host checkout while preserving local ignored state like `.git`, `.venv`, caches, and bytecode.
- Document the new full-process runner in README and SECURITY without claiming a complete disposable VM boundary.

## Why

PR #4 isolated generated benchmark tests, agent bash/edit operations, self-modification solution writes, and runtime validation. The remaining sandbox gap was the host-side model orchestration/controller/archive process. This PR adds a focused full-process runner so live DGM runs can move that process boundary into Docker when explicitly requested.

## Boundary

- Default `python run_dgm.py` still runs on the host.
- `scripts/run_dgm_in_sandbox.py` stages the checkout into a Docker-mountable cache workspace, runs `run_dgm.py` in the sandbox image, then syncs successful non-ignored writes and deletes back.
- No credentials are passed unless named with `--env`.
- Network stays disabled unless `--allow-network` is set.
- This is still a staged-workspace boundary, not a disposable VM; generated outputs intentionally persist to the host checkout.

## Validation

- Main baseline before this PR: `PATH="$PWD/.venv/bin:$PATH" python -m pytest` -> `190 passed, 7 skipped, 2 warnings`
- Focused tests: `PATH="$PWD/.venv/bin:$PATH" python -m pytest tests/unit/test_run_dgm_in_sandbox.py tests/unit/test_evaluation.py::TestSandboxManager` -> `10 passed, 1 warning`
- Live Docker sync smoke: staged project command wrote `new.txt`, updated `kept.txt`, deleted `delete_me.txt`, and preserved `.git/HEAD`
- Live Docker project-command smoke: `python scripts/verify_demo_path.py` ran inside the staged project container with `project_command True exit=0`
- Full suite: `PATH="$PWD/.venv/bin:$PATH" python -m pytest` -> `198 passed, 7 skipped, 2 warnings`
