### PR TITLE
[codex] define WebUI roadmap

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,7 +47,7 @@ python run_dgm.py
 - Use GitHub Issues for bug reports and feature requests
 - Include steps to reproduce for bugs
 - Provide context and use cases for feature requests
-- For larger product-direction requests such as WebUI, web search, knowledge learning, or new tool ecosystems, open an issue with the intended workflow first so maintainers can scope it before implementation.
+- For larger product-direction requests such as WebUI, web search, knowledge learning, or new tool ecosystems, open an issue with the intended workflow first so maintainers can scope it before implementation. See `docs/webui-roadmap.md` for the current WebUI sequencing.
 
 ### Code Contributions
 1. Create a feature branch: `git checkout -b feature/your-feature-name`
@@ -104,6 +104,7 @@ We welcome contributions in these areas:
 - Enhanced safety and security measures
 - Performance optimizations
 - Integration with additional foundation models
+- Local WebUI work that follows `docs/webui-roadmap.md`
 
 ## 📝 Pull Request Process
 
@@ -144,6 +145,7 @@ This project aims to:
 - [Architecture Documentation](reference-design/)
 - [Memory Bank System](memory-bank/)
 - [Security Guidelines](SECURITY.md)
+- [WebUI Roadmap](docs/webui-roadmap.md)
 
 ## ❓ Questions?
 

--- a/README.md
+++ b/README.md
@@ -398,6 +398,7 @@ python -m pytest
 - **Architecture Overview**: `reference-design/dgm-mvp-architecture.md`
 - **FM Integration**: `reference-design/fm-interaction-layer.md`
 - **Tool Management**: `reference-design/tool-management.md`
+- **WebUI Roadmap**: `docs/webui-roadmap.md`
 - **Research Paper**: `dgm_research_paper.md`
 - **Memory Bank**: `memory-bank/` directory
 
@@ -424,7 +425,7 @@ The system has achieved:
 - **Advanced Benchmarks**: Integration with SWE-bench and HumanEval
 - **Multi-Agent Collaboration**: Cooperative improvement strategies
 - **Foundation Model Fine-tuning**: Custom model training integration
-- **Web Interface**: GUI for monitoring and controlling evolution
+- **Web Interface**: Local UI for verified setup, run monitoring, and archive browsing; see `docs/webui-roadmap.md`
 - **Advanced Novelty Metrics**: More sophisticated diversity measures
 - **Distributed Archive**: Scaling to larger agent populations
 

--- a/docs/webui-roadmap.md
+++ b/docs/webui-roadmap.md
@@ -13,7 +13,8 @@ execution boundary and benchmark story stay easy to verify.
 - The no-network path must keep working without API keys.
 - Live runs still require explicit provider credentials and budget awareness.
 - The full-process Docker runner is a staged-workspace boundary, not a
-  disposable VM.
+  disposable VM; use `--discard-changes` when a sandboxed run should avoid
+  syncing successful writes/deletes back to the host checkout.
 
 ## First Useful WebUI
 
@@ -52,6 +53,8 @@ Before a WebUI PR is mergeable, it should prove:
 - It can run `scripts/verify_demo_path.py` from the UI or expose that check.
 - It clearly distinguishes host CLI runs from sandboxed full-process runs.
 - It does not pass provider secrets to Docker unless explicitly requested.
+- It exposes whether sandboxed run output will sync back to the host checkout
+  or be discarded with `--discard-changes`.
 - It preserves README/SECURITY wording about staged-workspace limits.
 - It includes tests for any command construction or process launching logic.
 

--- a/docs/webui-roadmap.md
+++ b/docs/webui-roadmap.md
@@ -1,0 +1,82 @@
+# WebUI Roadmap
+
+This project should not start with a broad product UI. The core DGM loop now
+has live-run proof, no-network demo verification, command-level Docker
+isolation, and an opt-in full-process Docker runner. A WebUI can build on that
+foundation, but it should remain a thin local control surface until the
+execution boundary and benchmark story stay easy to verify.
+
+## Current Position
+
+- The default CLI remains the source of truth: `run_dgm.py`,
+  `scripts/verify_demo_path.py`, and `scripts/run_dgm_in_sandbox.py`.
+- The no-network path must keep working without API keys.
+- Live runs still require explicit provider credentials and budget awareness.
+- The full-process Docker runner is a staged-workspace boundary, not a
+  disposable VM.
+
+## First Useful WebUI
+
+The first WebUI should be local-only and focused on observability, not new
+agent capabilities:
+
+1. Configure a bounded run from existing YAML files.
+2. Start a no-network verifier or a sandboxed DGM run.
+3. Stream logs and show run status.
+4. Browse archive agents, lineage, benchmark scores, and result artifacts.
+5. Surface the exact command that the UI is running.
+
+The UI should call existing scripts or library entrypoints instead of creating
+a second execution path. Any generated run output should remain in the same
+archive/results/workspace directories used by the CLI.
+
+## Not First
+
+These requests are reasonable, but they should wait until the local run UI is
+boring and reliable:
+
+- Web search during agent runs.
+- Knowledge learning or long-term memory products.
+- New tool ecosystems or plugin marketplaces.
+- Multi-user hosted service behavior.
+- Remote execution or queueing.
+
+Each of those expands the security boundary and should come with separate
+design notes, tests, and opt-in configuration.
+
+## Safety Requirements
+
+Before a WebUI PR is mergeable, it should prove:
+
+- It does not require API keys for the default test suite.
+- It can run `scripts/verify_demo_path.py` from the UI or expose that check.
+- It clearly distinguishes host CLI runs from sandboxed full-process runs.
+- It does not pass provider secrets to Docker unless explicitly requested.
+- It preserves README/SECURITY wording about staged-workspace limits.
+- It includes tests for any command construction or process launching logic.
+
+## Suggested Milestones
+
+1. Local read-only status page for archive, results, and live-run proof docs.
+2. Local controls for `scripts/verify_demo_path.py`.
+3. Local controls for bounded sandboxed runs via
+   `scripts/run_dgm_in_sandbox.py`.
+4. Archive lineage and score progression browsing.
+5. Optional live provider run setup with explicit cost and credential gates.
+
+## Draft Issue Response
+
+Thanks for the feedback. A WebUI is a good direction, especially for making
+installation, verification, run monitoring, and archive browsing easier.
+
+The current plan is to keep the WebUI behind the safety and repeatability work:
+live-run proof, Docker command isolation, the full-process Docker runner, and
+the no-network verifier. The first WebUI should be local-only and should wrap
+the existing CLI/scripts rather than invent a new execution path. It should
+start with run configuration, log/status viewing, benchmark results, and
+archive/lineage browsing.
+
+Web search, knowledge learning, and broader tool extension are useful ideas,
+but they expand the security boundary. Those should be separate follow-up
+designs after the local WebUI can reliably show and run the existing verified
+paths.


### PR DESCRIPTION
## Summary
- Add `docs/webui-roadmap.md` to define the first WebUI as a local-only setup, verification, run-monitoring, and archive-browsing surface.
- Keep web search, knowledge learning, tool ecosystems, hosted behavior, and remote execution out of the first WebUI milestone until separate safety designs exist.
- Link README and CONTRIBUTING to the roadmap and align contributing security wording with the full-process Docker runner and `--discard-changes` sync-back option.

## Review gate
This is intentionally a draft PR because it sets product direction for issue #1. It should be undrafted and merged only after Chris approves the WebUI sequencing and the proposed issue response.

## Validation
- `PATH="$PWD/.venv/bin:$PATH" python scripts/verify_demo_path.py`
- `PATH="$PWD/.venv/bin:$PATH" python -m pytest`

Refs #1
