### PR TITLE
[codex] add local WebUI status page

### DIFF
--- a/docs/webui-status.md
+++ b/docs/webui-status.md
@@ -4,6 +4,9 @@ The first WebUI surface is a generated, read-only HTML status page. It does not
 start a server, run agents, call model providers, or pass secrets into Docker.
 It only summarizes checked-in demo evidence, live-run proof artifacts, archive
 metadata, and exact local commands.
+For sandboxed runs, it surfaces a `--discard-changes` command so users can see
+how to avoid syncing successful staged-workspace writes back to the host
+checkout.
 
 Generate it with:
 
@@ -14,4 +17,3 @@ python scripts/generate_webui_status.py --output docs/webui-status.html
 Then open the generated HTML file locally. The page is intentionally static so
 the default test suite can verify it without API keys, network access, or a
 browser automation dependency.
-

--- a/docs/webui-status.md
+++ b/docs/webui-status.md
@@ -1,0 +1,17 @@
+# Local WebUI Status Page
+
+The first WebUI surface is a generated, read-only HTML status page. It does not
+start a server, run agents, call model providers, or pass secrets into Docker.
+It only summarizes checked-in demo evidence, live-run proof artifacts, archive
+metadata, and exact local commands.
+
+Generate it with:
+
+```bash
+python scripts/generate_webui_status.py --output docs/webui-status.html
+```
+
+Then open the generated HTML file locally. The page is intentionally static so
+the default test suite can verify it without API keys, network access, or a
+browser automation dependency.
+

--- a/scripts/generate_webui_status.py
+++ b/scripts/generate_webui_status.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+"""Generate the read-only local WebUI status page."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from webui.status_page import main
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/verify_demo_path.py
+++ b/scripts/verify_demo_path.py
@@ -36,6 +36,7 @@ from scripts.run_dgm_in_sandbox import (
     write_run_audit,
 )
 from scripts.verify_live_score_movement_plan import verify_live_score_movement_plan
+from webui.status_page import build_status_model, render_status_page
 
 
 class VerificationError(RuntimeError):
@@ -354,6 +355,26 @@ async def _verify_sandbox_discard_changes_contract() -> dict[str, Any]:
     }
 
 
+def _verify_webui_status_page(project_root: Path) -> dict[str, Any]:
+    model = build_status_model(project_root)
+    html = render_status_page(model)
+    _require("DGM Local Status" in html, "WebUI status page is missing title")
+    _require(
+        "python scripts/verify_demo_path.py" in html,
+        "WebUI status page must surface the no-network verifier command",
+    )
+    _require(
+        "python scripts/run_dgm_in_sandbox.py --help" in html,
+        "WebUI status page must surface the sandboxed runner command",
+    )
+    return {
+        "name": "webui_status_page",
+        "status": "ok",
+        "agents": len(model.agents),
+        "artifacts": len(model.artifacts),
+    }
+
+
 async def verify_demo_path(project_root: Path = PROJECT_ROOT) -> list[dict[str, Any]]:
     """Run all no-network setup/demo verification checks."""
     project_root = project_root.resolve()
@@ -382,6 +403,7 @@ async def verify_demo_path(project_root: Path = PROJECT_ROOT) -> list[dict[str, 
             project_root=project_root,
         )
     )
+    checks.append(_verify_webui_status_page(project_root))
     return checks
 
 

--- a/tests/unit/test_webui_status_page.py
+++ b/tests/unit/test_webui_status_page.py
@@ -102,6 +102,7 @@ def test_render_status_page_includes_lineage_artifacts_and_commands(tmp_path):
     assert "docs/live-runs/2026-06-12-proof" in html
     assert "python scripts/verify_demo_path.py" in html
     assert "python scripts/run_dgm_in_sandbox.py --help" in html
+    assert "python scripts/run_dgm_in_sandbox.py --config config/dgm_config.yaml --generations 1 --discard-changes" in html
 
 
 def test_render_status_page_handles_missing_archive_without_creating_it(tmp_path):

--- a/tests/unit/test_webui_status_page.py
+++ b/tests/unit/test_webui_status_page.py
@@ -136,3 +136,26 @@ def test_status_page_cli_resolves_relative_output_under_project_root(tmp_path):
 
     assert result == 0
     assert (tmp_path / "docs" / "status.html").exists()
+
+
+def test_status_page_cli_resolves_relative_archive_under_project_root(tmp_path, monkeypatch):
+    _write_project_files(tmp_path)
+    _write_archive(tmp_path)
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    monkeypatch.chdir(outside)
+
+    output = tmp_path / "status.html"
+    result = main(
+        [
+            "--project-root",
+            str(tmp_path),
+            "--archive-dir",
+            "archive/agents",
+            "--output",
+            str(output),
+        ]
+    )
+
+    assert result == 0
+    assert "root-agent" in output.read_text(encoding="utf-8")

--- a/tests/unit/test_webui_status_page.py
+++ b/tests/unit/test_webui_status_page.py
@@ -1,0 +1,138 @@
+import json
+from pathlib import Path
+
+from archive.agent_archive import ArchivedAgent
+from webui.status_page import (
+    build_status_model,
+    main,
+    render_status_page,
+)
+
+
+def _write_project_files(project_root: Path) -> None:
+    (project_root / "docs" / "demo").mkdir(parents=True)
+    (project_root / "docs" / "live-runs" / "2026-06-12-proof").mkdir(parents=True)
+    (project_root / "docs" / "archive-lineage-example.svg").write_text(
+        '<svg aria-label="DGM archive lineage"></svg>',
+        encoding="utf-8",
+    )
+    (project_root / "docs" / "demo" / "humaneval_score_movement.json").write_text(
+        json.dumps(
+            {
+                "benchmark": "humaneval_style",
+                "baseline": {"score": 0.5},
+                "candidate": {"score": 1.0},
+                "delta": 0.5,
+            }
+        ),
+        encoding="utf-8",
+    )
+    (project_root / "docs" / "live-runs" / "2026-06-12-proof" / "README.md").write_text(
+        "live run",
+        encoding="utf-8",
+    )
+    (project_root / "docs" / "live-runs" / "2026-06-12-proof" / "transcript.txt").write_text(
+        "transcript",
+        encoding="utf-8",
+    )
+    (project_root / "config").mkdir()
+    (project_root / "config" / "dgm_config.yaml").write_text("archive: {}\n", encoding="utf-8")
+    (project_root / "scripts").mkdir()
+    (project_root / "scripts" / "verify_demo_path.py").write_text("# verifier\n", encoding="utf-8")
+    (project_root / "scripts" / "run_dgm_in_sandbox.py").write_text("# sandbox\n", encoding="utf-8")
+    (project_root / "README.md").write_text("# DGM\n", encoding="utf-8")
+
+
+def _write_archive(project_root: Path) -> None:
+    archive_dir = project_root / "archive" / "agents"
+    archive_dir.mkdir(parents=True)
+    root = ArchivedAgent(
+        agent_id="root-agent",
+        parent_id=None,
+        generation=0,
+        source_path="/tmp/root-agent",
+        created_at="2026-06-12T00:00:00",
+        benchmark_scores={"bench": 0.4},
+        average_score=0.4,
+        is_valid=True,
+        metadata={},
+    )
+    child = ArchivedAgent(
+        agent_id="child-agent",
+        parent_id="root-agent",
+        generation=1,
+        source_path="/tmp/child-agent",
+        created_at="2026-06-12T00:00:01",
+        benchmark_scores={"bench": 0.8},
+        average_score=0.8,
+        is_valid=True,
+        metadata={},
+    )
+    (archive_dir / "archive_metadata.json").write_text(
+        json.dumps({"agents": {root.agent_id: root.to_dict(), child.agent_id: child.to_dict()}}),
+        encoding="utf-8",
+    )
+
+
+def test_build_status_model_reads_archive_and_artifacts(tmp_path):
+    _write_project_files(tmp_path)
+    _write_archive(tmp_path)
+
+    model = build_status_model(tmp_path)
+
+    assert len(model.agents) == 2
+    assert model.archive_warning is None
+    assert model.score_movement.exists is True
+    assert model.score_movement.delta == 0.5
+    assert "docs/live-runs/2026-06-12-proof" in model.live_runs
+    assert all(artifact.exists for artifact in model.artifacts)
+
+
+def test_render_status_page_includes_lineage_artifacts_and_commands(tmp_path):
+    _write_project_files(tmp_path)
+    _write_archive(tmp_path)
+    model = build_status_model(tmp_path)
+
+    html = render_status_page(model)
+
+    assert "<!doctype html>" in html
+    assert "DGM Local Status" in html
+    assert "agent root-ag" in html
+    assert "humaneval_style: 0.500 to 1.000 (0.500 delta)" in html
+    assert "docs/live-runs/2026-06-12-proof" in html
+    assert "python scripts/verify_demo_path.py" in html
+    assert "python scripts/run_dgm_in_sandbox.py --help" in html
+
+
+def test_render_status_page_handles_missing_archive_without_creating_it(tmp_path):
+    _write_project_files(tmp_path)
+
+    model = build_status_model(tmp_path)
+    html = render_status_page(model)
+
+    assert model.agents == []
+    assert model.archive_warning is not None
+    assert "No archived agents found." in html
+    assert not (tmp_path / "archive" / "agents").exists()
+
+
+def test_status_page_cli_writes_html(tmp_path):
+    _write_project_files(tmp_path)
+    _write_archive(tmp_path)
+    output = tmp_path / "status.html"
+
+    result = main(["--project-root", str(tmp_path), "--output", str(output)])
+
+    assert result == 0
+    assert output.exists()
+    assert "DGM Local Status" in output.read_text(encoding="utf-8")
+
+
+def test_status_page_cli_resolves_relative_output_under_project_root(tmp_path):
+    _write_project_files(tmp_path)
+    _write_archive(tmp_path)
+
+    result = main(["--project-root", str(tmp_path), "--output", "docs/status.html"])
+
+    assert result == 0
+    assert (tmp_path / "docs" / "status.html").exists()

--- a/webui/__init__.py
+++ b/webui/__init__.py
@@ -1,0 +1,2 @@
+"""Local WebUI helpers for DGM."""
+

--- a/webui/status_page.py
+++ b/webui/status_page.py
@@ -1,0 +1,534 @@
+"""Generate a read-only local DGM status page."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from html import escape
+from pathlib import Path
+
+from archive.agent_archive import ArchivedAgent
+from archive.lineage_visualizer import render_archive_lineage_svg
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+
+
+@dataclass(frozen=True)
+class ArtifactStatus:
+    """Status for an artifact surfaced by the local WebUI."""
+
+    label: str
+    path: str
+    exists: bool
+    detail: str = ""
+
+
+@dataclass(frozen=True)
+class ScoreMovementStatus:
+    """Checked-in no-network score movement evidence."""
+
+    exists: bool
+    benchmark: str = ""
+    baseline_score: float | None = None
+    candidate_score: float | None = None
+    delta: float | None = None
+    detail: str = ""
+
+
+@dataclass(frozen=True)
+class WebUIStatusModel:
+    """Data needed to render the local status page."""
+
+    project_root: Path
+    archive_dir: Path
+    generated_at: str
+    agents: list[ArchivedAgent]
+    archive_warning: str | None
+    artifacts: list[ArtifactStatus]
+    score_movement: ScoreMovementStatus
+    live_runs: list[str]
+    commands: list[str]
+
+
+def _relative_label(path: Path, project_root: Path) -> str:
+    try:
+        return path.relative_to(project_root).as_posix()
+    except ValueError:
+        return path.as_posix()
+
+
+def _load_archived_agents(archive_dir: Path) -> tuple[list[ArchivedAgent], str | None]:
+    """Load archive metadata without creating or modifying archive directories."""
+    metadata_path = archive_dir / "archive_metadata.json"
+    if not metadata_path.exists():
+        return [], f"No archive metadata found at {metadata_path}"
+
+    try:
+        data = json.loads(metadata_path.read_text(encoding="utf-8"))
+        agents = [
+            ArchivedAgent.from_dict(agent_data)
+            for agent_data in data.get("agents", {}).values()
+        ]
+    except (OSError, json.JSONDecodeError, TypeError) as exc:
+        return [], f"Could not load archive metadata: {exc}"
+
+    return agents, None
+
+
+def _artifact(path: Path, project_root: Path, label: str, detail: str = "") -> ArtifactStatus:
+    return ArtifactStatus(
+        label=label,
+        path=_relative_label(path, project_root),
+        exists=path.is_file(),
+        detail=detail,
+    )
+
+
+def _load_score_movement(project_root: Path) -> ScoreMovementStatus:
+    score_path = project_root / "docs" / "demo" / "humaneval_score_movement.json"
+    if not score_path.exists():
+        return ScoreMovementStatus(False, detail="Missing checked-in score movement JSON")
+
+    try:
+        data = json.loads(score_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        return ScoreMovementStatus(False, detail=f"Could not read score movement JSON: {exc}")
+
+    baseline = data.get("baseline", {}).get("score")
+    candidate = data.get("candidate", {}).get("score")
+    delta = data.get("delta")
+    return ScoreMovementStatus(
+        exists=True,
+        benchmark=str(data.get("benchmark", "")),
+        baseline_score=baseline if isinstance(baseline, (int, float)) else None,
+        candidate_score=candidate if isinstance(candidate, (int, float)) else None,
+        delta=delta if isinstance(delta, (int, float)) else None,
+        detail=_relative_label(score_path, project_root),
+    )
+
+
+def _live_run_labels(project_root: Path) -> list[str]:
+    live_runs_dir = project_root / "docs" / "live-runs"
+    if not live_runs_dir.exists():
+        return []
+    return [
+        _relative_label(path, project_root)
+        for path in sorted(live_runs_dir.iterdir())
+        if path.is_dir()
+    ]
+
+
+def build_status_model(
+    project_root: Path = PROJECT_ROOT,
+    archive_dir: Path | None = None,
+) -> WebUIStatusModel:
+    """Collect read-only status for the local WebUI page."""
+    project_root = project_root.resolve()
+    archive_dir = (archive_dir or project_root / "archive" / "agents").resolve()
+    agents, archive_warning = _load_archived_agents(archive_dir)
+    live_runs = _live_run_labels(project_root)
+
+    artifacts = [
+        _artifact(project_root / "README.md", project_root, "README"),
+        _artifact(project_root / "config" / "dgm_config.yaml", project_root, "Default DGM config"),
+        _artifact(project_root / "scripts" / "verify_demo_path.py", project_root, "No-network verifier"),
+        _artifact(project_root / "scripts" / "run_dgm_in_sandbox.py", project_root, "Sandboxed DGM runner"),
+        _artifact(project_root / "docs" / "demo" / "humaneval_score_movement.json", project_root, "Score movement evidence"),
+        _artifact(project_root / "docs" / "archive-lineage-example.svg", project_root, "Archive lineage example"),
+        _artifact(
+            project_root / "docs" / "live-runs" / "2026-06-12-proof" / "README.md",
+            project_root,
+            "Live-run proof notes",
+        ),
+        _artifact(
+            project_root / "docs" / "live-runs" / "2026-06-12-proof" / "transcript.txt",
+            project_root,
+            "Live-run proof transcript",
+        ),
+    ]
+
+    commands = [
+        "python scripts/verify_demo_path.py",
+        "python scripts/generate_webui_status.py --output docs/webui-status.html",
+        "python scripts/run_dgm_in_sandbox.py --help",
+    ]
+
+    return WebUIStatusModel(
+        project_root=project_root,
+        archive_dir=archive_dir,
+        generated_at=datetime.now(timezone.utc).isoformat(timespec="seconds"),
+        agents=agents,
+        archive_warning=archive_warning,
+        artifacts=artifacts,
+        score_movement=_load_score_movement(project_root),
+        live_runs=live_runs,
+        commands=commands,
+    )
+
+
+def _format_score(score: float | None) -> str:
+    if score is None:
+        return "unknown"
+    return f"{score:.3f}"
+
+
+def _archive_stats(model: WebUIStatusModel) -> dict[str, str]:
+    valid_agents = [agent for agent in model.agents if agent.is_valid]
+    scores = [agent.average_score for agent in valid_agents]
+    return {
+        "Total agents": str(len(model.agents)),
+        "Valid agents": str(len(valid_agents)),
+        "Best score": _format_score(max(scores) if scores else None),
+        "Max generation": str(max((agent.generation for agent in model.agents), default=0)),
+    }
+
+
+def _render_metric_cards(model: WebUIStatusModel) -> str:
+    stats = _archive_stats(model)
+    cards = []
+    for label, value in stats.items():
+        cards.append(
+            '<section class="metric">'
+            f"<span>{escape(label)}</span>"
+            f"<strong>{escape(value)}</strong>"
+            "</section>"
+        )
+    return "\n".join(cards)
+
+
+def _render_artifacts(model: WebUIStatusModel) -> str:
+    rows = []
+    for artifact in model.artifacts:
+        status = "present" if artifact.exists else "missing"
+        rows.append(
+            "<tr>"
+            f"<td>{escape(artifact.label)}</td>"
+            f"<td><code>{escape(artifact.path)}</code></td>"
+            f'<td><span class="status {status}">{status}</span></td>'
+            f"<td>{escape(artifact.detail)}</td>"
+            "</tr>"
+        )
+    return "\n".join(rows)
+
+
+def _render_agent_rows(model: WebUIStatusModel) -> str:
+    sorted_agents = sorted(
+        model.agents,
+        key=lambda agent: (agent.generation, agent.created_at, agent.agent_id),
+    )
+    if not sorted_agents:
+        return '<tr><td colspan="6">No archived agents found.</td></tr>'
+
+    rows = []
+    for agent in sorted_agents:
+        rows.append(
+            "<tr>"
+            f"<td><code>{escape(agent.agent_id)}</code></td>"
+            f"<td><code>{escape(agent.parent_id or 'root')}</code></td>"
+            f"<td>{agent.generation}</td>"
+            f"<td>{escape(_format_score(agent.average_score))}</td>"
+            f'<td><span class="status {"present" if agent.is_valid else "missing"}">'
+            f"{'valid' if agent.is_valid else 'invalid'}</span></td>"
+            f"<td>{escape(agent.created_at)}</td>"
+            "</tr>"
+        )
+    return "\n".join(rows)
+
+
+def _render_live_runs(model: WebUIStatusModel) -> str:
+    if not model.live_runs:
+        return "<li>No live-run proof directories found.</li>"
+    return "\n".join(f"<li><code>{escape(label)}</code></li>" for label in model.live_runs)
+
+
+def _render_commands(model: WebUIStatusModel) -> str:
+    return "\n".join(f"<li><code>{escape(command)}</code></li>" for command in model.commands)
+
+
+def render_status_page(model: WebUIStatusModel) -> str:
+    """Render a standalone HTML status page."""
+    lineage_svg = render_archive_lineage_svg(model.agents)
+    score = model.score_movement
+    archive_warning = (
+        f'<p class="notice">{escape(model.archive_warning)}</p>'
+        if model.archive_warning
+        else ""
+    )
+    score_detail = (
+        f"{escape(score.benchmark)}: {_format_score(score.baseline_score)} to "
+        f"{_format_score(score.candidate_score)} ({_format_score(score.delta)} delta)"
+        if score.exists
+        else escape(score.detail)
+    )
+
+    return f"""<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>DGM Local Status</title>
+  <style>
+    :root {{
+      color-scheme: light;
+      --bg: #f6f7f9;
+      --panel: #ffffff;
+      --ink: #172033;
+      --muted: #5f6b7a;
+      --line: #d8dee8;
+      --ok-bg: #e7f7ed;
+      --ok: #146c43;
+      --warn-bg: #fff3d8;
+      --warn: #8a5a00;
+      --accent: #1f6feb;
+    }}
+    * {{ box-sizing: border-box; }}
+    body {{
+      margin: 0;
+      background: var(--bg);
+      color: var(--ink);
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      line-height: 1.5;
+    }}
+    main {{
+      max-width: 1180px;
+      margin: 0 auto;
+      padding: 28px;
+    }}
+    header {{
+      display: flex;
+      justify-content: space-between;
+      gap: 24px;
+      align-items: flex-start;
+      margin-bottom: 24px;
+    }}
+    h1, h2 {{
+      margin: 0;
+      letter-spacing: 0;
+    }}
+    h1 {{ font-size: 34px; }}
+    h2 {{ font-size: 20px; margin-bottom: 14px; }}
+    p {{ margin: 6px 0 0; color: var(--muted); }}
+    code {{
+      font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+      font-size: 13px;
+      overflow-wrap: anywhere;
+    }}
+    .section {{
+      background: var(--panel);
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      padding: 18px;
+      margin-bottom: 18px;
+    }}
+    .metrics {{
+      display: grid;
+      grid-template-columns: repeat(4, minmax(0, 1fr));
+      gap: 12px;
+      margin-bottom: 18px;
+    }}
+    .metric {{
+      background: var(--panel);
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      padding: 14px;
+    }}
+    .metric span {{
+      display: block;
+      color: var(--muted);
+      font-size: 13px;
+    }}
+    .metric strong {{
+      display: block;
+      margin-top: 4px;
+      font-size: 24px;
+    }}
+    table {{
+      width: 100%;
+      border-collapse: collapse;
+      table-layout: fixed;
+    }}
+    th, td {{
+      border-bottom: 1px solid var(--line);
+      padding: 9px 8px;
+      text-align: left;
+      vertical-align: top;
+      overflow-wrap: anywhere;
+    }}
+    th {{
+      color: var(--muted);
+      font-size: 12px;
+      text-transform: uppercase;
+    }}
+    .status {{
+      display: inline-block;
+      border-radius: 999px;
+      padding: 2px 8px;
+      font-size: 12px;
+      font-weight: 600;
+    }}
+    .present {{
+      background: var(--ok-bg);
+      color: var(--ok);
+    }}
+    .missing {{
+      background: var(--warn-bg);
+      color: var(--warn);
+    }}
+    .notice {{
+      color: var(--warn);
+      background: var(--warn-bg);
+      border-radius: 6px;
+      padding: 10px 12px;
+      margin: 12px 0 0;
+    }}
+    .lineage {{
+      overflow-x: auto;
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      padding: 12px;
+      background: #fff;
+    }}
+    .lineage svg {{
+      max-width: 100%;
+      height: auto;
+    }}
+    .two-col {{
+      display: grid;
+      grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+      gap: 18px;
+    }}
+    ul {{
+      margin: 10px 0 0;
+      padding-left: 20px;
+    }}
+    @media (max-width: 760px) {{
+      main {{ padding: 18px; }}
+      header, .two-col {{ display: block; }}
+      .metrics {{ grid-template-columns: repeat(2, minmax(0, 1fr)); }}
+      h1 {{ font-size: 28px; }}
+    }}
+  </style>
+</head>
+<body>
+  <main>
+    <header>
+      <div>
+        <h1>DGM Local Status</h1>
+        <p>Read-only view of archive, demo evidence, and safe local commands.</p>
+      </div>
+      <p><code>{escape(_relative_label(model.project_root, model.project_root)) or "."}</code><br>
+      generated {escape(model.generated_at)}</p>
+    </header>
+
+    <div class="metrics">
+      {_render_metric_cards(model)}
+    </div>
+
+    <section class="section">
+      <h2>Score Movement Evidence</h2>
+      <p>{score_detail}</p>
+    </section>
+
+    <section class="section">
+      <h2>Archive Lineage</h2>
+      {archive_warning}
+      <div class="lineage">{lineage_svg}</div>
+    </section>
+
+    <section class="section">
+      <h2>Archived Agents</h2>
+      <table>
+        <thead>
+          <tr>
+            <th>Agent</th>
+            <th>Parent</th>
+            <th>Generation</th>
+            <th>Score</th>
+            <th>State</th>
+            <th>Created</th>
+          </tr>
+        </thead>
+        <tbody>
+          {_render_agent_rows(model)}
+        </tbody>
+      </table>
+    </section>
+
+    <section class="section">
+      <h2>Artifacts</h2>
+      <table>
+        <thead>
+          <tr>
+            <th>Artifact</th>
+            <th>Path</th>
+            <th>Status</th>
+            <th>Detail</th>
+          </tr>
+        </thead>
+        <tbody>
+          {_render_artifacts(model)}
+        </tbody>
+      </table>
+    </section>
+
+    <div class="two-col">
+      <section class="section">
+        <h2>Live Runs</h2>
+        <ul>
+          {_render_live_runs(model)}
+        </ul>
+      </section>
+      <section class="section">
+        <h2>Exact Commands</h2>
+        <ul>
+          {_render_commands(model)}
+        </ul>
+      </section>
+    </div>
+  </main>
+</body>
+</html>
+"""
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--project-root",
+        default=str(PROJECT_ROOT),
+        help="Repository root to inspect.",
+    )
+    parser.add_argument(
+        "--archive-dir",
+        help="Archive directory containing archive_metadata.json. Defaults to archive/agents.",
+    )
+    parser.add_argument(
+        "--output",
+        default="docs/webui-status.html",
+        help="HTML output path.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    project_root = Path(args.project_root).resolve()
+    archive_dir = Path(args.archive_dir) if args.archive_dir else None
+    model = build_status_model(project_root=project_root, archive_dir=archive_dir)
+    html = render_status_page(model)
+
+    output_path = Path(args.output)
+    if not output_path.is_absolute():
+        output_path = project_root / output_path
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(html, encoding="utf-8")
+    print(f"Wrote local WebUI status page to {output_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/webui/status_page.py
+++ b/webui/status_page.py
@@ -154,6 +154,7 @@ def build_status_model(
         "python scripts/verify_demo_path.py",
         "python scripts/generate_webui_status.py --output docs/webui-status.html",
         "python scripts/run_dgm_in_sandbox.py --help",
+        "python scripts/run_dgm_in_sandbox.py --config config/dgm_config.yaml --generations 1 --discard-changes",
     ]
 
     return WebUIStatusModel(

--- a/webui/status_page.py
+++ b/webui/status_page.py
@@ -518,6 +518,8 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
     project_root = Path(args.project_root).resolve()
     archive_dir = Path(args.archive_dir) if args.archive_dir else None
+    if archive_dir is not None and not archive_dir.is_absolute():
+        archive_dir = project_root / archive_dir
     model = build_status_model(project_root=project_root, archive_dir=archive_dir)
     html = render_status_page(model)
 


### PR DESCRIPTION
## Summary
- Add a generated, read-only local HTML status page for archive state, demo evidence, live-run proof artifacts, and exact safe commands.
- Add `scripts/generate_webui_status.py` so users can generate the page without starting a server, running agents, calling providers, or passing secrets into Docker.
- Surface both sandbox help and a `--discard-changes` staged-run command so users can see how to avoid syncing successful sandbox writes back to the host checkout.
- Wire the status page into `scripts/verify_demo_path.py` and add unit coverage for archive loading, missing-archive behavior, rendering, and CLI output.

## Review gate
This should remain draft until #16 is approved or merged because it is the first product-facing WebUI surface. It is intentionally read-only and local-only.

## Validation
- `PATH="$PWD/.venv/bin:$PATH" python -m pytest tests/unit/test_webui_status_page.py tests/integration/test_demo_path_verifier.py`
- `PATH="$PWD/.venv/bin:$PATH" python scripts/generate_webui_status.py --output /tmp/.../status.html`
- `PATH="$PWD/.venv/bin:$PATH" python scripts/verify_demo_path.py`
- `PATH="$PWD/.venv/bin:$PATH" python -m pytest`

Refs #1
