### PR TITLE
[codex] allow sandbox runs to discard changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,7 +313,7 @@ Results are stored in the `results/` directory with detailed JSON reports.
 - **Human Oversight**: Optional pause points for review
 - **Comprehensive Logging**: Full audit trail of all changes
 
-> **Note**: the default `python run_dgm.py` path still runs orchestration and controller/archive logic on the host. Use `scripts/run_dgm_in_sandbox.py` to move the full DGM process into Docker. The runner stages the checkout through `~/.cache/dgm-sandbox` for Docker-mounted execution and syncs successful writes/deletes back to the host checkout; live provider runs require explicit network and secret pass-through. For untrusted evolution experiments, keep using your own container or VM boundary.
+> **Note**: the default `python run_dgm.py` path still runs orchestration and controller/archive logic on the host. Use `scripts/run_dgm_in_sandbox.py` to move the full DGM process into Docker. The runner stages the checkout through `~/.cache/dgm-sandbox` for Docker-mounted execution and syncs successful writes/deletes back to the host checkout unless `--discard-changes` is set; live provider runs require explicit network and secret pass-through. For untrusted evolution experiments, keep using your own container or VM boundary.
 
 ### Full-Process Docker Runner
 
@@ -332,6 +332,8 @@ named with `--env`. Network access is disabled unless `--allow-network` is set.
 The checkout is copied into a Docker-mountable cache workspace first, then
 successful non-ignored writes and deletes are synced back, so generated
 archives, results, workspaces, and logs still persist in the host checkout.
+Add `--discard-changes` to keep successful writes/deletes inside the staged
+workspace and remove them when the container run finishes.
 
 ## 🐛 Troubleshooting
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -36,12 +36,12 @@ cp .env.example .env
 
 ### Full-Process Docker Runner (opt-in)
 - Use `scripts/run_dgm_in_sandbox.py` when the controller/orchestration process itself should run inside Docker
-- The runner stages the repository through `~/.cache/dgm-sandbox` as the container workspace and syncs successful non-ignored writes and deletes back so archives, results, workspaces, and logs can persist in the host checkout
+- The runner stages the repository through `~/.cache/dgm-sandbox` as the container workspace and syncs successful non-ignored writes and deletes back so archives, results, workspaces, and logs can persist in the host checkout unless `--discard-changes` is set
 - Live provider calls require explicit `--allow-network` plus explicit `--env NAME` pass-through for each required secret; no credentials are passed by default
 
 ### Remaining Isolation Limits
 - The default `python run_dgm.py` path still executes model orchestration and archive/controller logic in the configured workspace on the host
-- The full-process Docker runner is still a staged-workspace boundary, not a disposable VM; successful non-ignored writes and deletes intentionally persist to the host checkout
+- The full-process Docker runner is still a staged-workspace boundary, not a disposable VM; successful non-ignored writes and deletes intentionally persist to the host checkout unless `--discard-changes` is set
 - Treat every evolution run as executing model-written code on your machine: run inside your own container or VM if that is not acceptable
 
 ### Input Validation

--- a/scripts/run_dgm_in_sandbox.py
+++ b/scripts/run_dgm_in_sandbox.py
@@ -88,6 +88,7 @@ async def run_sandboxed_dgm(
     allow_network: bool = False,
     network_mode: str = "bridge",
     timeout: Optional[int] = None,
+    sync_back: bool = True,
     manager: Optional[SandboxManager] = None,
 ) -> SandboxResult:
     """
@@ -113,6 +114,7 @@ async def run_sandboxed_dgm(
         environment=environment,
         network_mode=network_mode if allow_network else sandbox_config.network_mode,
         read_only=False,
+        sync_back=sync_back,
     )
 
 
@@ -138,6 +140,14 @@ def _build_parser() -> argparse.ArgumentParser:
         default="bridge",
         help="Docker network mode used only with --allow-network.",
     )
+    parser.add_argument(
+        "--discard-changes",
+        action="store_true",
+        help=(
+            "Run in the staged sandbox workspace but do not sync successful "
+            "writes/deletes back to the host checkout."
+        ),
+    )
     return parser
 
 
@@ -151,6 +161,7 @@ async def _main_async(args: argparse.Namespace) -> int:
             allow_network=args.allow_network,
             network_mode=args.network_mode,
             timeout=args.timeout,
+            sync_back=not args.discard_changes,
         )
     except SandboxRunError as exc:
         print(f"[fail] {exc}", file=sys.stderr)

--- a/tests/unit/test_run_dgm_in_sandbox.py
+++ b/tests/unit/test_run_dgm_in_sandbox.py
@@ -5,6 +5,7 @@ import pytest
 from sandbox.sandbox_manager import SandboxConfig, SandboxManager, SandboxResult
 from scripts.run_dgm_in_sandbox import (
     SandboxRunError,
+    _build_parser,
     build_dgm_command,
     collect_environment,
     load_sandbox_config,
@@ -62,6 +63,12 @@ sandbox:
     assert sandbox_config.memory_limit == "1g"
     assert sandbox_config.cpu_limit == "0.5"
     assert sandbox_config.timeout == 12
+
+
+def test_parser_exposes_discard_changes_flag():
+    args = _build_parser().parse_args(["--discard-changes"])
+
+    assert args.discard_changes is True
 
 
 def test_project_tree_copy_skips_local_caches(tmp_path):
@@ -149,8 +156,41 @@ async def test_run_sandboxed_dgm_invokes_project_command(tmp_path):
             "environment": {},
             "network_mode": "none",
             "read_only": False,
+            "sync_back": True,
         }
     ]
+
+
+@pytest.mark.asyncio
+async def test_run_sandboxed_dgm_can_discard_successful_changes(tmp_path):
+    project_root = tmp_path / "project"
+    config = project_root / "config" / "dgm_config.yaml"
+    config.parent.mkdir(parents=True)
+    config.write_text("sandbox:\n  network_mode: none\n", encoding="utf-8")
+
+    class FakeManager:
+        def __init__(self):
+            self.calls = []
+
+        def is_sandbox_ready(self):
+            return True
+
+        async def execute_project_command(self, **kwargs):
+            self.calls.append(kwargs)
+            return SandboxResult(success=True, output="ok\n", exit_code=0)
+
+    manager = FakeManager()
+    result = await run_sandboxed_dgm(
+        config_path=config,
+        generations=1,
+        project_root=project_root,
+        env_names=[],
+        sync_back=False,
+        manager=manager,
+    )
+
+    assert result.success is True
+    assert manager.calls[0]["sync_back"] is False
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Add `--discard-changes` to `scripts/run_dgm_in_sandbox.py` so a full-process sandbox run can keep successful writes/deletes inside the staged workspace instead of syncing them back to the host checkout.
- Thread the option through `run_sandboxed_dgm(..., sync_back=...)` and cover both parser behavior and the `SandboxManager.execute_project_command` call.
- Update README and SECURITY wording without overstating the boundary: this remains a staged-workspace Docker runner, not a disposable VM.

## Validation
- `PATH="$PWD/.venv/bin:$PATH" python -m pytest tests/unit/test_run_dgm_in_sandbox.py tests/integration/test_demo_path_verifier.py`
- `PATH="$PWD/.venv/bin:$PATH" python scripts/run_dgm_in_sandbox.py --help | rg -n "discard-changes|sync successful|Docker network"`
- `PATH="$PWD/.venv/bin:$PATH" python -m pytest`

Refs #1