### PR TITLE
[codex] verify sandbox runner CLI flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,9 @@ python scripts/verify_demo_path.py
 
 This checks benchmark loading, the HumanEval-style reference solution, the
 score-movement demo, the committed live-run proof, and the archive-lineage demo
-without API keys or model calls.
+without API keys or model calls. It also checks that the full-process sandbox
+runner exposes the explicit network, secret pass-through, and discard-changes
+flags used for safer local runs.
 
 4. **Configure API keys:**
 ```bash

--- a/scripts/verify_demo_path.py
+++ b/scripts/verify_demo_path.py
@@ -23,6 +23,7 @@ warnings.filterwarnings(
 
 from evaluation.benchmark_runner import BenchmarkRunner
 from scripts.compare_benchmark_solutions import compare_solutions
+from scripts.run_dgm_in_sandbox import _build_parser as build_sandbox_runner_parser
 
 
 class VerificationError(RuntimeError):
@@ -154,6 +155,33 @@ def _verify_archive_lineage(project_root: Path) -> dict[str, Any]:
     }
 
 
+def _verify_sandbox_runner_cli(project_root: Path) -> dict[str, Any]:
+    runner = project_root / "scripts" / "run_dgm_in_sandbox.py"
+    _check_file(runner, project_root)
+    parser = build_sandbox_runner_parser()
+    help_text = parser.format_help()
+    args = parser.parse_args([
+        "--allow-network",
+        "--env",
+        "ANTHROPIC_API_KEY",
+        "--discard-changes",
+    ])
+
+    _require("--allow-network" in help_text, "Sandbox runner help missing --allow-network")
+    _require("--env" in help_text, "Sandbox runner help missing --env")
+    _require("--discard-changes" in help_text, "Sandbox runner help missing --discard-changes")
+    _require(args.allow_network is True, "Sandbox runner parser did not accept --allow-network")
+    _require(args.env == ["ANTHROPIC_API_KEY"], "Sandbox runner parser did not collect --env")
+    _require(args.discard_changes is True, "Sandbox runner parser did not accept --discard-changes")
+
+    return {
+        "name": "sandbox_runner_cli",
+        "status": "ok",
+        "path": str(runner.relative_to(project_root)),
+        "safe_flags": ["--allow-network", "--env", "--discard-changes"],
+    }
+
+
 async def verify_demo_path(project_root: Path = PROJECT_ROOT) -> list[dict[str, Any]]:
     """Run all no-network setup/demo verification checks."""
     project_root = project_root.resolve()
@@ -173,6 +201,7 @@ async def verify_demo_path(project_root: Path = PROJECT_ROOT) -> list[dict[str, 
     checks.append(await _verify_score_movement(project_root))
     checks.append(_verify_live_run_docs(project_root))
     checks.append(_verify_archive_lineage(project_root))
+    checks.append(_verify_sandbox_runner_cli(project_root))
     return checks
 
 

--- a/tests/integration/test_demo_path_verifier.py
+++ b/tests/integration/test_demo_path_verifier.py
@@ -16,8 +16,12 @@ async def test_no_network_demo_path_verifier_passes():
     assert "score_movement_demo" in names
     assert "live_run_docs" in names
     assert "archive_lineage_artifact" in names
+    assert "sandbox_runner_cli" in names
 
     score_check = next(check for check in checks if check["name"] == "score_movement_demo")
     assert score_check["baseline_score"] == 0.5
     assert score_check["candidate_score"] == 1.0
     assert score_check["delta"] == 0.5
+
+    sandbox_check = next(check for check in checks if check["name"] == "sandbox_runner_cli")
+    assert "--discard-changes" in sandbox_check["safe_flags"]


### PR DESCRIPTION
## Summary
- Extend `scripts/verify_demo_path.py` with a no-network `sandbox_runner_cli` check.
- Verify the full-process sandbox runner parser exposes `--allow-network`, `--env`, and `--discard-changes` without requiring Docker or provider credentials.
- Update the README verifier description and integration test coverage.

## Validation
- `PATH="$PWD/.venv/bin:$PATH" python -m pytest tests/integration/test_demo_path_verifier.py tests/unit/test_run_dgm_in_sandbox.py`
- `PATH="$PWD/.venv/bin:$PATH" python scripts/verify_demo_path.py`
- `PATH="$PWD/.venv/bin:$PATH" python -m pytest`