### PR TITLE
[codex] refresh contributor safety docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Thank you for your interest in contributing to the Darwin Gödel Machine project
 
 ### Prerequisites
 - Python 3.8+
-- Docker is optional. The current opt-in Docker path isolates generated benchmark test scripts, agent bash/edit tool operations, and modified-agent runtime load checks; use your own container or VM for untrusted evolution runs.
+- Docker is optional. The current opt-in Docker paths isolate generated benchmark test scripts, agent bash/edit tool operations, modified-agent runtime load checks, and full-process DGM runs when explicitly invoked; use your own container or VM for untrusted evolution runs.
 - API keys for foundation models (Claude, Gemini, or OpenAI) are needed for live DGM runs, not for the default test suite.
 
 ### Setup
@@ -78,7 +78,7 @@ python run_dgm.py
 ### Security
 - Never commit API keys or secrets
 - Follow security guidelines in SECURITY.md
-- Treat model-written code as untrusted. The built-in Docker path does not yet isolate the model orchestration loop or controller/archive logic.
+- Treat model-written code as untrusted. Use the opt-in full-process Docker runner when model orchestration and controller/archive logic should run in Docker; it is still a staged-workspace boundary, not a disposable VM, and sync-back can be disabled with `--discard-changes`.
 - Report security issues privately via GitHub Security tab
 
 ## 🏗️ Architecture

--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ tail -f dgm_run.log
 
 ### Testing Components
 ```bash
-# Run the full test suite (155 tests, no API keys needed)
+# Run the full test suite (no API keys needed)
 python -m pytest
 
 # Verify the no-network demo/setup path


### PR DESCRIPTION
## Summary
- Remove the stale fixed test-count claim from README now that the suite count changes as verifier coverage grows.
- Align CONTRIBUTING with the current opt-in full-process Docker runner instead of saying orchestration is not isolated yet.
- Keep the staged-workspace and non-disposable-VM caveats explicit, including `--discard-changes` for sync-back control.

## Validation
- `PATH="$PWD/.venv/bin:$PATH" python scripts/verify_demo_path.py`
- `PATH="$PWD/.venv/bin:$PATH" python -m pytest`