### PR TITLE
[codex] verify sandbox discard contract

### DIFF
--- a/scripts/verify_demo_path.py
+++ b/scripts/verify_demo_path.py
@@ -7,6 +7,7 @@ import argparse
 import asyncio
 import json
 import sys
+import tempfile
 import warnings
 from pathlib import Path
 from typing import Any
@@ -22,6 +23,7 @@ warnings.filterwarnings(
 )
 
 from evaluation.benchmark_runner import BenchmarkRunner
+from sandbox.sandbox_manager import SandboxConfig, SandboxManager, SandboxResult
 from scripts.compare_benchmark_solutions import compare_solutions
 from scripts.run_dgm_in_sandbox import _build_parser as build_sandbox_runner_parser
 
@@ -182,6 +184,80 @@ def _verify_sandbox_runner_cli(project_root: Path) -> dict[str, Any]:
     }
 
 
+async def _verify_sandbox_discard_changes_contract() -> dict[str, Any]:
+    class MutatingSandboxManager(SandboxManager):
+        async def execute_in_sandbox(self, *args: Any, **kwargs: Any) -> SandboxResult:
+            workspace = Path(kwargs["workspace_path"])
+            (workspace / "kept.txt").write_text("sandbox\n", encoding="utf-8")
+            (workspace / "created.txt").write_text("created\n", encoding="utf-8")
+            (workspace / "removed.txt").unlink()
+            return SandboxResult(success=True, output="mutated staged workspace\n", exit_code=0)
+
+    def seed_host_project(host_project: Path) -> None:
+        host_project.mkdir(parents=True)
+        (host_project / "kept.txt").write_text("host\n", encoding="utf-8")
+        (host_project / "removed.txt").write_text("remove me\n", encoding="utf-8")
+
+    with tempfile.TemporaryDirectory(prefix="dgm-sandbox-sync-contract-") as temp_dir:
+        host_project = Path(temp_dir) / "sync"
+        seed_host_project(host_project)
+        manager = MutatingSandboxManager(SandboxConfig())
+
+        result = await manager.execute_project_command(
+            command="mutate staged workspace",
+            project_path=str(host_project),
+            sync_back=True,
+        )
+
+        _require(result.success, "Sandbox sync-back contract did not complete")
+        _require(
+            (host_project / "kept.txt").read_text(encoding="utf-8") == "sandbox\n",
+            "Sandbox sync-back contract did not propagate staged file updates",
+        )
+        _require(
+            (host_project / "created.txt").read_text(encoding="utf-8") == "created\n",
+            "Sandbox sync-back contract did not propagate staged file creates",
+        )
+        _require(
+            not (host_project / "removed.txt").exists(),
+            "Sandbox sync-back contract did not propagate staged file deletes",
+        )
+
+    with tempfile.TemporaryDirectory(prefix="dgm-sandbox-discard-contract-") as temp_dir:
+        host_project = Path(temp_dir) / "discard"
+        seed_host_project(host_project)
+        manager = MutatingSandboxManager(SandboxConfig())
+
+        result = await manager.execute_project_command(
+            command="mutate staged workspace",
+            project_path=str(host_project),
+            sync_back=False,
+        )
+
+        _require(result.success, "Sandbox discard-changes contract did not complete")
+        _require(
+            (host_project / "kept.txt").read_text(encoding="utf-8") == "host\n",
+            "Sandbox discard-changes contract leaked staged file updates",
+        )
+        _require(
+            not (host_project / "created.txt").exists(),
+            "Sandbox discard-changes contract leaked staged file creates",
+        )
+        _require(
+            (host_project / "removed.txt").read_text(encoding="utf-8") == "remove me\n",
+            "Sandbox discard-changes contract leaked staged file deletes",
+        )
+
+    return {
+        "name": "sandbox_discard_changes_contract",
+        "status": "ok",
+        "proves": [
+            "sync_back_true_mirrors_staged_writes",
+            "sync_back_false_preserves_host_checkout",
+        ],
+    }
+
+
 async def verify_demo_path(project_root: Path = PROJECT_ROOT) -> list[dict[str, Any]]:
     """Run all no-network setup/demo verification checks."""
     project_root = project_root.resolve()
@@ -202,6 +278,7 @@ async def verify_demo_path(project_root: Path = PROJECT_ROOT) -> list[dict[str, 
     checks.append(_verify_live_run_docs(project_root))
     checks.append(_verify_archive_lineage(project_root))
     checks.append(_verify_sandbox_runner_cli(project_root))
+    checks.append(await _verify_sandbox_discard_changes_contract())
     return checks
 
 

--- a/tests/integration/test_demo_path_verifier.py
+++ b/tests/integration/test_demo_path_verifier.py
@@ -17,6 +17,7 @@ async def test_no_network_demo_path_verifier_passes():
     assert "live_run_docs" in names
     assert "archive_lineage_artifact" in names
     assert "sandbox_runner_cli" in names
+    assert "sandbox_discard_changes_contract" in names
 
     score_check = next(check for check in checks if check["name"] == "score_movement_demo")
     assert score_check["baseline_score"] == 0.5
@@ -25,3 +26,8 @@ async def test_no_network_demo_path_verifier_passes():
 
     sandbox_check = next(check for check in checks if check["name"] == "sandbox_runner_cli")
     assert "--discard-changes" in sandbox_check["safe_flags"]
+
+    discard_check = next(
+        check for check in checks if check["name"] == "sandbox_discard_changes_contract"
+    )
+    assert "sync_back_false_preserves_host_checkout" in discard_check["proves"]

--- a/tests/unit/test_run_dgm_in_sandbox.py
+++ b/tests/unit/test_run_dgm_in_sandbox.py
@@ -120,6 +120,48 @@ def test_project_tree_sync_propagates_deletes_and_preserves_ignored(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_execute_project_command_can_discard_staged_changes(tmp_path):
+    class MutatingSandboxManager(SandboxManager):
+        async def execute_in_sandbox(self, *args, **kwargs):
+            workspace = Path(kwargs["workspace_path"])
+            (workspace / "kept.txt").write_text("sandbox\n")
+            (workspace / "created.txt").write_text("created\n")
+            (workspace / "removed.txt").unlink()
+            return SandboxResult(success=True, output="mutated\n", exit_code=0)
+
+    def seed_host_project(host: Path) -> None:
+        host.mkdir()
+        (host / "kept.txt").write_text("host\n")
+        (host / "removed.txt").write_text("remove me\n")
+
+    synced = tmp_path / "synced"
+    seed_host_project(synced)
+    sync_result = await MutatingSandboxManager(SandboxConfig()).execute_project_command(
+        command="mutate staged workspace",
+        project_path=str(synced),
+        sync_back=True,
+    )
+
+    assert sync_result.success is True
+    assert (synced / "kept.txt").read_text() == "sandbox\n"
+    assert (synced / "created.txt").read_text() == "created\n"
+    assert not (synced / "removed.txt").exists()
+
+    discarded = tmp_path / "discarded"
+    seed_host_project(discarded)
+    discard_result = await MutatingSandboxManager(SandboxConfig()).execute_project_command(
+        command="mutate staged workspace",
+        project_path=str(discarded),
+        sync_back=False,
+    )
+
+    assert discard_result.success is True
+    assert (discarded / "kept.txt").read_text() == "host\n"
+    assert not (discarded / "created.txt").exists()
+    assert (discarded / "removed.txt").read_text() == "remove me\n"
+
+
+@pytest.mark.asyncio
 async def test_run_sandboxed_dgm_invokes_project_command(tmp_path):
     project_root = tmp_path / "project"
     config = project_root / "config" / "dgm_config.yaml"


### PR DESCRIPTION
## Summary
- Add a no-network verifier check that exercises the full-process sandbox staging contract with a fake sandbox manager.
- Prove both sides of the boundary: normal sync-back mirrors staged writes/deletes, while discard mode preserves the host checkout.
- Cover the manager path with a unit test so `sync_back=False` cannot silently regress.

## Validation
- `PATH="$PWD/.venv/bin:$PATH" python scripts/verify_demo_path.py`
- `PATH="$PWD/.venv/bin:$PATH" python -m pytest`
