### PR TITLE
[codex] harden sandbox network opt-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,8 +330,9 @@ python scripts/run_dgm_in_sandbox.py \
 ```
 
 The runner does not pass credentials into the container unless each variable is
-named with `--env`. Network access is disabled unless `--allow-network` is set.
-The checkout is copied into a Docker-mountable cache workspace first, then
+named with `--env`. Network access is forced off unless `--allow-network` is set,
+even if the project config names a permissive Docker network mode. The checkout
+is copied into a Docker-mountable cache workspace first, then
 successful non-ignored writes and deletes are synced back, so generated
 archives, results, workspaces, and logs still persist in the host checkout.
 Add `--discard-changes` to keep successful writes/deletes inside the staged

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -37,7 +37,7 @@ cp .env.example .env
 ### Full-Process Docker Runner (opt-in)
 - Use `scripts/run_dgm_in_sandbox.py` when the controller/orchestration process itself should run inside Docker
 - The runner stages the repository through `~/.cache/dgm-sandbox` as the container workspace and syncs successful non-ignored writes and deletes back so archives, results, workspaces, and logs can persist in the host checkout unless `--discard-changes` is set
-- Live provider calls require explicit `--allow-network` plus explicit `--env NAME` pass-through for each required secret; no credentials are passed by default
+- Live provider calls require explicit `--allow-network` plus explicit `--env NAME` pass-through for each required secret; no credentials are passed by default, and the runner forces Docker `network_mode: none` unless `--allow-network` is set
 
 ### Remaining Isolation Limits
 - The default `python run_dgm.py` path still executes model orchestration and archive/controller logic in the configured workspace on the host

--- a/scripts/run_dgm_in_sandbox.py
+++ b/scripts/run_dgm_in_sandbox.py
@@ -79,6 +79,16 @@ def collect_environment(
     return selected
 
 
+def resolve_network_mode(allow_network: bool, requested_network_mode: str) -> str:
+    """Resolve Docker networking for full-process runs.
+
+    The full-process runner keeps network access off unless the caller opts in
+    with ``--allow-network``. This prevents a permissive project config from
+    silently enabling live network access.
+    """
+    return requested_network_mode if allow_network else "none"
+
+
 async def run_sandboxed_dgm(
     *,
     config_path: Path,
@@ -112,7 +122,7 @@ async def run_sandboxed_dgm(
         project_path=str(project_root),
         timeout=timeout or sandbox_config.timeout,
         environment=environment,
-        network_mode=network_mode if allow_network else sandbox_config.network_mode,
+        network_mode=resolve_network_mode(allow_network, network_mode),
         read_only=False,
         sync_back=sync_back,
     )

--- a/scripts/verify_demo_path.py
+++ b/scripts/verify_demo_path.py
@@ -25,7 +25,10 @@ warnings.filterwarnings(
 from evaluation.benchmark_runner import BenchmarkRunner
 from sandbox.sandbox_manager import SandboxConfig, SandboxManager, SandboxResult
 from scripts.compare_benchmark_solutions import compare_solutions
-from scripts.run_dgm_in_sandbox import _build_parser as build_sandbox_runner_parser
+from scripts.run_dgm_in_sandbox import (
+    _build_parser as build_sandbox_runner_parser,
+    resolve_network_mode,
+)
 
 
 class VerificationError(RuntimeError):
@@ -175,12 +178,21 @@ def _verify_sandbox_runner_cli(project_root: Path) -> dict[str, Any]:
     _require(args.allow_network is True, "Sandbox runner parser did not accept --allow-network")
     _require(args.env == ["ANTHROPIC_API_KEY"], "Sandbox runner parser did not collect --env")
     _require(args.discard_changes is True, "Sandbox runner parser did not accept --discard-changes")
+    _require(
+        resolve_network_mode(False, "bridge") == "none",
+        "Sandbox runner must keep network disabled without --allow-network",
+    )
+    _require(
+        resolve_network_mode(True, "bridge") == "bridge",
+        "Sandbox runner did not honor explicit --allow-network network mode",
+    )
 
     return {
         "name": "sandbox_runner_cli",
         "status": "ok",
         "path": str(runner.relative_to(project_root)),
         "safe_flags": ["--allow-network", "--env", "--discard-changes"],
+        "network_default": "none",
     }
 
 

--- a/tests/integration/test_demo_path_verifier.py
+++ b/tests/integration/test_demo_path_verifier.py
@@ -26,6 +26,7 @@ async def test_no_network_demo_path_verifier_passes():
 
     sandbox_check = next(check for check in checks if check["name"] == "sandbox_runner_cli")
     assert "--discard-changes" in sandbox_check["safe_flags"]
+    assert sandbox_check["network_default"] == "none"
 
     discard_check = next(
         check for check in checks if check["name"] == "sandbox_discard_changes_contract"

--- a/tests/unit/test_run_dgm_in_sandbox.py
+++ b/tests/unit/test_run_dgm_in_sandbox.py
@@ -9,6 +9,7 @@ from scripts.run_dgm_in_sandbox import (
     build_dgm_command,
     collect_environment,
     load_sandbox_config,
+    resolve_network_mode,
     run_sandboxed_dgm,
 )
 
@@ -42,6 +43,11 @@ def test_collect_environment_requires_explicit_existing_values():
     }
     with pytest.raises(SandboxRunError, match="not set"):
         collect_environment(["GEMINI_API_KEY"], env)
+
+
+def test_resolve_network_mode_requires_explicit_allow_network():
+    assert resolve_network_mode(False, "bridge") == "none"
+    assert resolve_network_mode(True, "bridge") == "bridge"
 
 
 def test_load_sandbox_config_reads_project_config(tmp_path):
@@ -201,6 +207,69 @@ async def test_run_sandboxed_dgm_invokes_project_command(tmp_path):
             "sync_back": True,
         }
     ]
+
+
+@pytest.mark.asyncio
+async def test_run_sandboxed_dgm_ignores_configured_network_without_opt_in(tmp_path):
+    project_root = tmp_path / "project"
+    config = project_root / "config" / "dgm_config.yaml"
+    config.parent.mkdir(parents=True)
+    config.write_text("sandbox:\n  network_mode: bridge\n", encoding="utf-8")
+
+    class FakeManager:
+        def __init__(self):
+            self.calls = []
+
+        def is_sandbox_ready(self):
+            return True
+
+        async def execute_project_command(self, **kwargs):
+            self.calls.append(kwargs)
+            return SandboxResult(success=True, output="ok\n", exit_code=0)
+
+    manager = FakeManager()
+    await run_sandboxed_dgm(
+        config_path=config,
+        generations=1,
+        project_root=project_root,
+        env_names=[],
+        allow_network=False,
+        manager=manager,
+    )
+
+    assert manager.calls[0]["network_mode"] == "none"
+
+
+@pytest.mark.asyncio
+async def test_run_sandboxed_dgm_uses_requested_network_with_opt_in(tmp_path):
+    project_root = tmp_path / "project"
+    config = project_root / "config" / "dgm_config.yaml"
+    config.parent.mkdir(parents=True)
+    config.write_text("sandbox:\n  network_mode: none\n", encoding="utf-8")
+
+    class FakeManager:
+        def __init__(self):
+            self.calls = []
+
+        def is_sandbox_ready(self):
+            return True
+
+        async def execute_project_command(self, **kwargs):
+            self.calls.append(kwargs)
+            return SandboxResult(success=True, output="ok\n", exit_code=0)
+
+    manager = FakeManager()
+    await run_sandboxed_dgm(
+        config_path=config,
+        generations=1,
+        project_root=project_root,
+        env_names=[],
+        allow_network=True,
+        network_mode="bridge",
+        manager=manager,
+    )
+
+    assert manager.calls[0]["network_mode"] == "bridge"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Force the full-process sandbox runner to use Docker `network_mode: none` unless `--allow-network` is explicitly set.
- Prevent permissive project config from silently enabling network access for full-process sandbox runs.
- Extend unit and no-network verifier coverage, and align README/SECURITY wording with the enforced behavior.

## Validation
- `PATH="$PWD/.venv/bin:$PATH" python scripts/verify_demo_path.py`
- `PATH="$PWD/.venv/bin:$PATH" python scripts/verify_sandbox_docker.py --require`
- `PATH="$PWD/.venv/bin:$PATH" python -m pytest`
