### PR TITLE
[codex] harden sandbox env pass-through

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,9 +330,10 @@ python scripts/run_dgm_in_sandbox.py \
 ```
 
 The runner does not pass credentials into the container unless each variable is
-named with `--env`. Network access is forced off unless `--allow-network` is set,
-even if the project config names a permissive Docker network mode. The checkout
-is copied into a Docker-mountable cache workspace first, then
+named with `--env`, and `--env` is rejected unless `--allow-network` is also set.
+Network access is forced off unless `--allow-network` is set, even if the project
+config names a permissive Docker network mode. The checkout is copied into a
+Docker-mountable cache workspace first, then
 successful non-ignored writes and deletes are synced back, so generated
 archives, results, workspaces, and logs still persist in the host checkout.
 Add `--discard-changes` to keep successful writes/deletes inside the staged

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -37,7 +37,7 @@ cp .env.example .env
 ### Full-Process Docker Runner (opt-in)
 - Use `scripts/run_dgm_in_sandbox.py` when the controller/orchestration process itself should run inside Docker
 - The runner stages the repository through `~/.cache/dgm-sandbox` as the container workspace and syncs successful non-ignored writes and deletes back so archives, results, workspaces, and logs can persist in the host checkout unless `--discard-changes` is set
-- Live provider calls require explicit `--allow-network` plus explicit `--env NAME` pass-through for each required secret; no credentials are passed by default, and the runner forces Docker `network_mode: none` unless `--allow-network` is set
+- Live provider calls require explicit `--allow-network` plus explicit `--env NAME` pass-through for each required secret; no credentials are passed by default, `--env` is rejected unless `--allow-network` is also set, and the runner forces Docker `network_mode: none` unless `--allow-network` is set
 
 ### Remaining Isolation Limits
 - The default `python run_dgm.py` path still executes model orchestration and archive/controller logic in the configured workspace on the host

--- a/scripts/run_dgm_in_sandbox.py
+++ b/scripts/run_dgm_in_sandbox.py
@@ -79,6 +79,15 @@ def collect_environment(
     return selected
 
 
+def validate_environment_pass_through(env_names: List[str], allow_network: bool) -> None:
+    """Require explicit network opt-in before passing host environment values."""
+    if env_names and not allow_network:
+        raise SandboxRunError(
+            "Refusing to pass environment variables without --allow-network; "
+            "rerun without --env or add --allow-network for live provider calls"
+        )
+
+
 def resolve_network_mode(allow_network: bool, requested_network_mode: str) -> str:
     """Resolve Docker networking for full-process runs.
 
@@ -110,6 +119,7 @@ async def run_sandboxed_dgm(
     config_path = (project_root / config_path).resolve() if not config_path.is_absolute() else config_path.resolve()
     project_root = project_root.resolve()
     command = build_dgm_command(config_path, generations, project_root)
+    validate_environment_pass_through(env_names or [], allow_network)
     environment = collect_environment(env_names or [])
     sandbox_config = load_sandbox_config(config_path, timeout=timeout)
     manager = manager or SandboxManager(sandbox_config)

--- a/scripts/verify_demo_path.py
+++ b/scripts/verify_demo_path.py
@@ -27,7 +27,9 @@ from sandbox.sandbox_manager import SandboxConfig, SandboxManager, SandboxResult
 from scripts.compare_benchmark_solutions import compare_solutions
 from scripts.run_dgm_in_sandbox import (
     _build_parser as build_sandbox_runner_parser,
+    SandboxRunError,
     resolve_network_mode,
+    validate_environment_pass_through,
 )
 
 
@@ -186,6 +188,15 @@ def _verify_sandbox_runner_cli(project_root: Path) -> dict[str, Any]:
         resolve_network_mode(True, "bridge") == "bridge",
         "Sandbox runner did not honor explicit --allow-network network mode",
     )
+    try:
+        validate_environment_pass_through(["ANTHROPIC_API_KEY"], allow_network=False)
+    except SandboxRunError:
+        pass
+    else:
+        raise VerificationError(
+            "Sandbox runner must reject --env without explicit --allow-network"
+        )
+    validate_environment_pass_through(["ANTHROPIC_API_KEY"], allow_network=True)
 
     return {
         "name": "sandbox_runner_cli",
@@ -193,6 +204,7 @@ def _verify_sandbox_runner_cli(project_root: Path) -> dict[str, Any]:
         "path": str(runner.relative_to(project_root)),
         "safe_flags": ["--allow-network", "--env", "--discard-changes"],
         "network_default": "none",
+        "env_requires_network": True,
     }
 
 

--- a/tests/integration/test_demo_path_verifier.py
+++ b/tests/integration/test_demo_path_verifier.py
@@ -27,6 +27,7 @@ async def test_no_network_demo_path_verifier_passes():
     sandbox_check = next(check for check in checks if check["name"] == "sandbox_runner_cli")
     assert "--discard-changes" in sandbox_check["safe_flags"]
     assert sandbox_check["network_default"] == "none"
+    assert sandbox_check["env_requires_network"] is True
 
     discard_check = next(
         check for check in checks if check["name"] == "sandbox_discard_changes_contract"

--- a/tests/unit/test_run_dgm_in_sandbox.py
+++ b/tests/unit/test_run_dgm_in_sandbox.py
@@ -11,6 +11,7 @@ from scripts.run_dgm_in_sandbox import (
     load_sandbox_config,
     resolve_network_mode,
     run_sandboxed_dgm,
+    validate_environment_pass_through,
 )
 
 
@@ -43,6 +44,14 @@ def test_collect_environment_requires_explicit_existing_values():
     }
     with pytest.raises(SandboxRunError, match="not set"):
         collect_environment(["GEMINI_API_KEY"], env)
+
+
+def test_validate_environment_pass_through_requires_network_opt_in():
+    validate_environment_pass_through([], allow_network=False)
+    validate_environment_pass_through(["ANTHROPIC_API_KEY"], allow_network=True)
+
+    with pytest.raises(SandboxRunError, match="without --allow-network"):
+        validate_environment_pass_through(["ANTHROPIC_API_KEY"], allow_network=False)
 
 
 def test_resolve_network_mode_requires_explicit_allow_network():
@@ -269,6 +278,74 @@ async def test_run_sandboxed_dgm_uses_requested_network_with_opt_in(tmp_path):
         manager=manager,
     )
 
+    assert manager.calls[0]["network_mode"] == "bridge"
+
+
+@pytest.mark.asyncio
+async def test_run_sandboxed_dgm_rejects_env_without_network_opt_in(tmp_path, monkeypatch):
+    project_root = tmp_path / "project"
+    config = project_root / "config" / "dgm_config.yaml"
+    config.parent.mkdir(parents=True)
+    config.write_text("sandbox:\n  network_mode: none\n", encoding="utf-8")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "secret")
+
+    class FakeManager:
+        def __init__(self):
+            self.calls = []
+
+        def is_sandbox_ready(self):
+            return True
+
+        async def execute_project_command(self, **kwargs):
+            self.calls.append(kwargs)
+            return SandboxResult(success=True, output="ok\n", exit_code=0)
+
+    manager = FakeManager()
+
+    with pytest.raises(SandboxRunError, match="without --allow-network"):
+        await run_sandboxed_dgm(
+            config_path=config,
+            generations=1,
+            project_root=project_root,
+            env_names=["ANTHROPIC_API_KEY"],
+            allow_network=False,
+            manager=manager,
+        )
+
+    assert manager.calls == []
+
+
+@pytest.mark.asyncio
+async def test_run_sandboxed_dgm_passes_env_with_network_opt_in(tmp_path, monkeypatch):
+    project_root = tmp_path / "project"
+    config = project_root / "config" / "dgm_config.yaml"
+    config.parent.mkdir(parents=True)
+    config.write_text("sandbox:\n  network_mode: none\n", encoding="utf-8")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "secret")
+
+    class FakeManager:
+        def __init__(self):
+            self.calls = []
+
+        def is_sandbox_ready(self):
+            return True
+
+        async def execute_project_command(self, **kwargs):
+            self.calls.append(kwargs)
+            return SandboxResult(success=True, output="ok\n", exit_code=0)
+
+    manager = FakeManager()
+    await run_sandboxed_dgm(
+        config_path=config,
+        generations=1,
+        project_root=project_root,
+        env_names=["ANTHROPIC_API_KEY"],
+        allow_network=True,
+        network_mode="bridge",
+        manager=manager,
+    )
+
+    assert manager.calls[0]["environment"] == {"ANTHROPIC_API_KEY": "secret"}
     assert manager.calls[0]["network_mode"] == "bridge"
 
 


### PR DESCRIPTION
## Summary
- Reject full-process sandbox `--env` pass-through unless `--allow-network` is also explicit.
- Prevent host secrets from entering a no-network container by accident.
- Extend unit and no-network verifier coverage, and align README/SECURITY wording with the enforced behavior.

## Validation
- `PATH="$PWD/.venv/bin:$PATH" python scripts/verify_demo_path.py`
- `PATH="$PWD/.venv/bin:$PATH" python scripts/verify_sandbox_docker.py --require`
- `PATH="$PWD/.venv/bin:$PATH" python -m pytest`
