### PR TITLE
[codex] audit sandbox run settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,6 +339,10 @@ archives, results, workspaces, and logs still persist in the host checkout.
 Add `--discard-changes` to keep successful writes/deletes inside the staged
 workspace and remove them when the container run finishes.
 
+Before the container starts, the runner prints an audit summary to stderr with
+the effective network mode, requested environment variable names, sync mode,
+timeout, and staged-workspace cache parent. It never prints environment values.
+
 To smoke-test the real Docker mount/sync path without API keys or model calls:
 
 ```bash

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -38,6 +38,7 @@ cp .env.example .env
 - Use `scripts/run_dgm_in_sandbox.py` when the controller/orchestration process itself should run inside Docker
 - The runner stages the repository through `~/.cache/dgm-sandbox` as the container workspace and syncs successful non-ignored writes and deletes back so archives, results, workspaces, and logs can persist in the host checkout unless `--discard-changes` is set
 - Live provider calls require explicit `--allow-network` plus explicit `--env NAME` pass-through for each required secret; no credentials are passed by default, `--env` is rejected unless `--allow-network` is also set, and the runner forces Docker `network_mode: none` unless `--allow-network` is set
+- Before execution, the runner prints a non-secret audit summary with effective network mode, requested environment variable names, sync mode, timeout, and staged-workspace behavior; it does not print environment values
 
 ### Remaining Isolation Limits
 - The default `python run_dgm.py` path still executes model orchestration and archive/controller logic in the configured workspace on the host

--- a/scripts/run_dgm_in_sandbox.py
+++ b/scripts/run_dgm_in_sandbox.py
@@ -9,7 +9,7 @@ import os
 import shlex
 import sys
 from pathlib import Path
-from typing import List, Mapping, Optional
+from typing import Any, List, Mapping, Optional
 
 import yaml
 
@@ -98,6 +98,58 @@ def resolve_network_mode(allow_network: bool, requested_network_mode: str) -> st
     return requested_network_mode if allow_network else "none"
 
 
+def build_run_audit(
+    *,
+    config_path: Path,
+    generations: int,
+    project_root: Path,
+    env_names: List[str],
+    allow_network: bool,
+    network_mode: str,
+    timeout: Optional[int],
+    sync_back: bool,
+    sandbox_config: SandboxConfig,
+) -> dict[str, Any]:
+    """Build a non-secret audit summary for a full-process sandbox run."""
+    project_root = project_root.resolve()
+    config_label = str(_project_relative(config_path, project_root))
+    return {
+        "config": config_label,
+        "generations": generations,
+        "timeout": timeout or sandbox_config.timeout,
+        "allow_network": allow_network,
+        "network_mode": resolve_network_mode(allow_network, network_mode),
+        "env_names": list(env_names),
+        "env_values": "hidden",
+        "stage_project": True,
+        "stage_parent": "~/.cache/dgm-sandbox",
+        "sync_back": sync_back,
+        "sync_mode": "sync-back" if sync_back else "discard-changes",
+    }
+
+
+def format_run_audit(audit: Mapping[str, Any]) -> str:
+    """Format a non-secret audit summary for stderr."""
+    env_names = audit["env_names"]
+    env_label = ", ".join(env_names) if env_names else "(none)"
+    return "\n".join([
+        "[audit] full-process sandbox run",
+        (
+            f"[audit] config={audit['config']} generations={audit['generations']} "
+            f"timeout={audit['timeout']}"
+        ),
+        (
+            f"[audit] network_mode={audit['network_mode']} "
+            f"allow_network={str(audit['allow_network']).lower()}"
+        ),
+        f"[audit] env_names={env_label} env_values=hidden",
+        (
+            f"[audit] workspace=staged-copy stage_parent={audit['stage_parent']} "
+            f"sync_mode={audit['sync_mode']}"
+        ),
+    ])
+
+
 async def run_sandboxed_dgm(
     *,
     config_path: Path,
@@ -173,10 +225,29 @@ def _build_parser() -> argparse.ArgumentParser:
 
 async def _main_async(args: argparse.Namespace) -> int:
     try:
-        result = await run_sandboxed_dgm(
-            config_path=Path(args.config),
+        project_root = Path(args.project_root).resolve()
+        config_path = Path(args.config)
+        if not config_path.is_absolute():
+            config_path = project_root / config_path
+        config_path = config_path.resolve()
+        validate_environment_pass_through(args.env, args.allow_network)
+        sandbox_config = load_sandbox_config(config_path, timeout=args.timeout)
+        audit = build_run_audit(
+            config_path=config_path,
             generations=args.generations,
-            project_root=Path(args.project_root),
+            project_root=project_root,
+            env_names=args.env,
+            allow_network=args.allow_network,
+            network_mode=args.network_mode,
+            timeout=args.timeout,
+            sync_back=not args.discard_changes,
+            sandbox_config=sandbox_config,
+        )
+        print(format_run_audit(audit), file=sys.stderr)
+        result = await run_sandboxed_dgm(
+            config_path=config_path,
+            generations=args.generations,
+            project_root=project_root,
             env_names=args.env,
             allow_network=args.allow_network,
             network_mode=args.network_mode,

--- a/scripts/verify_demo_path.py
+++ b/scripts/verify_demo_path.py
@@ -28,6 +28,8 @@ from scripts.compare_benchmark_solutions import compare_solutions
 from scripts.run_dgm_in_sandbox import (
     _build_parser as build_sandbox_runner_parser,
     SandboxRunError,
+    build_run_audit,
+    format_run_audit,
     resolve_network_mode,
     validate_environment_pass_through,
 )
@@ -197,6 +199,22 @@ def _verify_sandbox_runner_cli(project_root: Path) -> dict[str, Any]:
             "Sandbox runner must reject --env without explicit --allow-network"
         )
     validate_environment_pass_through(["ANTHROPIC_API_KEY"], allow_network=True)
+    audit_text = format_run_audit(
+        build_run_audit(
+            config_path=project_root / "config" / "dgm_config.yaml",
+            generations=1,
+            project_root=project_root,
+            env_names=["ANTHROPIC_API_KEY"],
+            allow_network=True,
+            network_mode="bridge",
+            timeout=7,
+            sync_back=False,
+            sandbox_config=SandboxConfig(timeout=300),
+        )
+    )
+    _require("env_names=ANTHROPIC_API_KEY" in audit_text, "Sandbox audit missing env names")
+    _require("env_values=hidden" in audit_text, "Sandbox audit must hide env values")
+    _require("sync_mode=discard-changes" in audit_text, "Sandbox audit missing sync mode")
 
     return {
         "name": "sandbox_runner_cli",
@@ -205,6 +223,7 @@ def _verify_sandbox_runner_cli(project_root: Path) -> dict[str, Any]:
         "safe_flags": ["--allow-network", "--env", "--discard-changes"],
         "network_default": "none",
         "env_requires_network": True,
+        "audit_hides_env_values": True,
     }
 
 

--- a/tests/integration/test_demo_path_verifier.py
+++ b/tests/integration/test_demo_path_verifier.py
@@ -28,6 +28,7 @@ async def test_no_network_demo_path_verifier_passes():
     assert "--discard-changes" in sandbox_check["safe_flags"]
     assert sandbox_check["network_default"] == "none"
     assert sandbox_check["env_requires_network"] is True
+    assert sandbox_check["audit_hides_env_values"] is True
 
     discard_check = next(
         check for check in checks if check["name"] == "sandbox_discard_changes_contract"

--- a/tests/unit/test_run_dgm_in_sandbox.py
+++ b/tests/unit/test_run_dgm_in_sandbox.py
@@ -5,9 +5,12 @@ import pytest
 from sandbox.sandbox_manager import SandboxConfig, SandboxManager, SandboxResult
 from scripts.run_dgm_in_sandbox import (
     SandboxRunError,
+    _main_async,
     _build_parser,
+    build_run_audit,
     build_dgm_command,
     collect_environment,
+    format_run_audit,
     load_sandbox_config,
     resolve_network_mode,
     run_sandboxed_dgm,
@@ -57,6 +60,34 @@ def test_validate_environment_pass_through_requires_network_opt_in():
 def test_resolve_network_mode_requires_explicit_allow_network():
     assert resolve_network_mode(False, "bridge") == "none"
     assert resolve_network_mode(True, "bridge") == "bridge"
+
+
+def test_run_audit_summarizes_flags_without_secret_values(tmp_path):
+    project_root = tmp_path / "project"
+    config = project_root / "config" / "dgm_config.yaml"
+    config.parent.mkdir(parents=True)
+    config.write_text("sandbox: {}\n", encoding="utf-8")
+
+    audit = build_run_audit(
+        config_path=config,
+        generations=2,
+        project_root=project_root,
+        env_names=["ANTHROPIC_API_KEY"],
+        allow_network=True,
+        network_mode="bridge",
+        timeout=12,
+        sync_back=False,
+        sandbox_config=SandboxConfig(timeout=300),
+    )
+    text = format_run_audit(audit)
+
+    assert audit["config"] == "config/dgm_config.yaml"
+    assert audit["env_names"] == ["ANTHROPIC_API_KEY"]
+    assert audit["env_values"] == "hidden"
+    assert audit["sync_mode"] == "discard-changes"
+    assert "ANTHROPIC_API_KEY" in text
+    assert "env_values=hidden" in text
+    assert "secret" not in text.lower()
 
 
 def test_load_sandbox_config_reads_project_config(tmp_path):
@@ -399,3 +430,43 @@ async def test_run_sandboxed_dgm_requires_ready_sandbox(tmp_path):
             project_root=project_root,
             manager=NotReadyManager(),
         )
+
+
+@pytest.mark.asyncio
+async def test_main_prints_non_secret_audit(monkeypatch, tmp_path, capsys):
+    from scripts import run_dgm_in_sandbox as sandbox_cli
+
+    project_root = tmp_path / "project"
+    config = project_root / "config" / "dgm_config.yaml"
+    config.parent.mkdir(parents=True)
+    config.write_text("sandbox:\n  timeout: 30\n", encoding="utf-8")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "secret-value")
+
+    async def fake_run_sandboxed_dgm(**kwargs):
+        return SandboxResult(success=True, output="ok\n", exit_code=0)
+
+    monkeypatch.setattr(sandbox_cli, "run_sandboxed_dgm", fake_run_sandboxed_dgm)
+    args = _build_parser().parse_args([
+        "--project-root",
+        str(project_root),
+        "--config",
+        "config/dgm_config.yaml",
+        "--generations",
+        "1",
+        "--allow-network",
+        "--env",
+        "ANTHROPIC_API_KEY",
+        "--discard-changes",
+    ])
+
+    exit_code = await _main_async(args)
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    assert captured.out == "ok\n"
+    assert "[audit] full-process sandbox run" in captured.err
+    assert "network_mode=bridge" in captured.err
+    assert "env_names=ANTHROPIC_API_KEY" in captured.err
+    assert "env_values=hidden" in captured.err
+    assert "sync_mode=discard-changes" in captured.err
+    assert "secret-value" not in captured.err


### PR DESCRIPTION
## Summary
- Print a non-secret audit summary before full-process sandbox execution.
- Include effective network mode, requested env names only, sync/discard mode, timeout, and staged-workspace cache behavior.
- Verify the audit output hides environment values, and document the stderr audit in README/SECURITY.

## Validation
- `PATH="$PWD/.venv/bin:$PATH" python scripts/verify_demo_path.py`
- `PATH="$PWD/.venv/bin:$PATH" python scripts/verify_sandbox_docker.py --require`
- `PATH="$PWD/.venv/bin:$PATH" python -m pytest`
