### PR TITLE
[codex] persist sandbox audit artifact

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,8 @@ python scripts/verify_demo_path.py
 This checks benchmark loading, the HumanEval-style reference solution, the
 score-movement demo, the committed live-run proof, and the archive-lineage demo
 without API keys or model calls. It also checks that the full-process sandbox
-runner exposes the explicit network, secret pass-through, and discard-changes
-flags used for safer local runs.
+runner exposes the explicit network, secret pass-through, discard-changes, and
+optional audit-artifact flags used for safer local runs.
 
 4. **Configure API keys:**
 ```bash
@@ -342,6 +342,9 @@ workspace and remove them when the container run finishes.
 Before the container starts, the runner prints an audit summary to stderr with
 the effective network mode, requested environment variable names, sync mode,
 timeout, and staged-workspace cache parent. It never prints environment values.
+Add `--audit-output .dgm-sandbox-runs/audit.json` to also write the same
+non-secret audit summary as JSON inside the project root. The artifact records
+environment variable names only, never values.
 
 To smoke-test the real Docker mount/sync path without API keys or model calls:
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -39,6 +39,7 @@ cp .env.example .env
 - The runner stages the repository through `~/.cache/dgm-sandbox` as the container workspace and syncs successful non-ignored writes and deletes back so archives, results, workspaces, and logs can persist in the host checkout unless `--discard-changes` is set
 - Live provider calls require explicit `--allow-network` plus explicit `--env NAME` pass-through for each required secret; no credentials are passed by default, `--env` is rejected unless `--allow-network` is also set, and the runner forces Docker `network_mode: none` unless `--allow-network` is set
 - Before execution, the runner prints a non-secret audit summary with effective network mode, requested environment variable names, sync mode, timeout, and staged-workspace behavior; it does not print environment values
+- If `--audit-output PATH` is supplied, the runner writes the same non-secret audit summary as JSON inside the project root; the artifact records environment variable names only, not values
 
 ### Remaining Isolation Limits
 - The default `python run_dgm.py` path still executes model orchestration and archive/controller logic in the configured workspace on the host

--- a/scripts/run_dgm_in_sandbox.py
+++ b/scripts/run_dgm_in_sandbox.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import json
 import os
 import shlex
 import sys
@@ -150,6 +151,29 @@ def format_run_audit(audit: Mapping[str, Any]) -> str:
     ])
 
 
+def resolve_audit_output_path(
+    audit_output: Optional[str],
+    project_root: Path,
+) -> Optional[Path]:
+    """Resolve an optional audit artifact path inside the project root."""
+    if not audit_output:
+        return None
+    relative_output = _project_relative(Path(audit_output), project_root)
+    return project_root.resolve() / relative_output
+
+
+def write_run_audit(audit: Mapping[str, Any], output_path: Path) -> None:
+    """Write a non-secret audit artifact as JSON."""
+    try:
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(
+            json.dumps(dict(audit), indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+    except OSError as exc:
+        raise SandboxRunError(f"Could not write sandbox audit artifact: {exc}") from exc
+
+
 async def run_sandboxed_dgm(
     *,
     config_path: Path,
@@ -220,6 +244,13 @@ def _build_parser() -> argparse.ArgumentParser:
             "writes/deletes back to the host checkout."
         ),
     )
+    parser.add_argument(
+        "--audit-output",
+        help=(
+            "Optional project-relative path for a non-secret JSON audit artifact. "
+            "The artifact records flags and env variable names, not env values."
+        ),
+    )
     return parser
 
 
@@ -244,6 +275,13 @@ async def _main_async(args: argparse.Namespace) -> int:
             sandbox_config=sandbox_config,
         )
         print(format_run_audit(audit), file=sys.stderr)
+        audit_output = resolve_audit_output_path(args.audit_output, project_root)
+        if audit_output is not None:
+            write_run_audit(audit, audit_output)
+            print(
+                f"[audit] artifact={audit_output.relative_to(project_root)}",
+                file=sys.stderr,
+            )
         result = await run_sandboxed_dgm(
             config_path=config_path,
             generations=args.generations,

--- a/scripts/verify_demo_path.py
+++ b/scripts/verify_demo_path.py
@@ -30,8 +30,10 @@ from scripts.run_dgm_in_sandbox import (
     SandboxRunError,
     build_run_audit,
     format_run_audit,
+    resolve_audit_output_path,
     resolve_network_mode,
     validate_environment_pass_through,
+    write_run_audit,
 )
 
 
@@ -174,14 +176,22 @@ def _verify_sandbox_runner_cli(project_root: Path) -> dict[str, Any]:
         "--env",
         "ANTHROPIC_API_KEY",
         "--discard-changes",
+        "--audit-output",
+        ".dgm-sandbox-runs/audit.json",
     ])
 
     _require("--allow-network" in help_text, "Sandbox runner help missing --allow-network")
     _require("--env" in help_text, "Sandbox runner help missing --env")
     _require("--discard-changes" in help_text, "Sandbox runner help missing --discard-changes")
+    _require("--audit-output" in help_text, "Sandbox runner help missing --audit-output")
     _require(args.allow_network is True, "Sandbox runner parser did not accept --allow-network")
     _require(args.env == ["ANTHROPIC_API_KEY"], "Sandbox runner parser did not collect --env")
     _require(args.discard_changes is True, "Sandbox runner parser did not accept --discard-changes")
+    _require(
+        resolve_audit_output_path(args.audit_output, project_root)
+        == project_root / ".dgm-sandbox-runs" / "audit.json",
+        "Sandbox runner parser did not accept project-local --audit-output",
+    )
     _require(
         resolve_network_mode(False, "bridge") == "none",
         "Sandbox runner must keep network disabled without --allow-network",
@@ -199,31 +209,49 @@ def _verify_sandbox_runner_cli(project_root: Path) -> dict[str, Any]:
             "Sandbox runner must reject --env without explicit --allow-network"
         )
     validate_environment_pass_through(["ANTHROPIC_API_KEY"], allow_network=True)
-    audit_text = format_run_audit(
-        build_run_audit(
-            config_path=project_root / "config" / "dgm_config.yaml",
-            generations=1,
-            project_root=project_root,
-            env_names=["ANTHROPIC_API_KEY"],
-            allow_network=True,
-            network_mode="bridge",
-            timeout=7,
-            sync_back=False,
-            sandbox_config=SandboxConfig(timeout=300),
-        )
+    audit = build_run_audit(
+        config_path=project_root / "config" / "dgm_config.yaml",
+        generations=1,
+        project_root=project_root,
+        env_names=["ANTHROPIC_API_KEY"],
+        allow_network=True,
+        network_mode="bridge",
+        timeout=7,
+        sync_back=False,
+        sandbox_config=SandboxConfig(timeout=300),
     )
+    audit_text = format_run_audit(audit)
     _require("env_names=ANTHROPIC_API_KEY" in audit_text, "Sandbox audit missing env names")
     _require("env_values=hidden" in audit_text, "Sandbox audit must hide env values")
     _require("sync_mode=discard-changes" in audit_text, "Sandbox audit missing sync mode")
+
+    with tempfile.TemporaryDirectory(prefix="dgm-sandbox-audit-") as temp_dir:
+        artifact = Path(temp_dir) / "audit.json"
+        write_run_audit(audit, artifact)
+        artifact_text = artifact.read_text(encoding="utf-8")
+        artifact_json = json.loads(artifact_text)
+        _require(
+            artifact_json["env_names"] == ["ANTHROPIC_API_KEY"],
+            "Sandbox audit artifact missing env names",
+        )
+        _require(
+            artifact_json["env_values"] == "hidden",
+            "Sandbox audit artifact must hide env values",
+        )
+        _require(
+            "secret" not in artifact_text.lower(),
+            "Sandbox audit artifact must not contain secret values",
+        )
 
     return {
         "name": "sandbox_runner_cli",
         "status": "ok",
         "path": str(runner.relative_to(project_root)),
-        "safe_flags": ["--allow-network", "--env", "--discard-changes"],
+        "safe_flags": ["--allow-network", "--env", "--discard-changes", "--audit-output"],
         "network_default": "none",
         "env_requires_network": True,
         "audit_hides_env_values": True,
+        "audit_artifact_writable": True,
     }
 
 

--- a/tests/integration/test_demo_path_verifier.py
+++ b/tests/integration/test_demo_path_verifier.py
@@ -26,9 +26,11 @@ async def test_no_network_demo_path_verifier_passes():
 
     sandbox_check = next(check for check in checks if check["name"] == "sandbox_runner_cli")
     assert "--discard-changes" in sandbox_check["safe_flags"]
+    assert "--audit-output" in sandbox_check["safe_flags"]
     assert sandbox_check["network_default"] == "none"
     assert sandbox_check["env_requires_network"] is True
     assert sandbox_check["audit_hides_env_values"] is True
+    assert sandbox_check["audit_artifact_writable"] is True
 
     discard_check = next(
         check for check in checks if check["name"] == "sandbox_discard_changes_contract"

--- a/tests/unit/test_run_dgm_in_sandbox.py
+++ b/tests/unit/test_run_dgm_in_sandbox.py
@@ -1,3 +1,4 @@
+import json
 from pathlib import Path
 
 import pytest
@@ -12,9 +13,11 @@ from scripts.run_dgm_in_sandbox import (
     collect_environment,
     format_run_audit,
     load_sandbox_config,
+    resolve_audit_output_path,
     resolve_network_mode,
     run_sandboxed_dgm,
     validate_environment_pass_through,
+    write_run_audit,
 )
 
 
@@ -88,6 +91,41 @@ def test_run_audit_summarizes_flags_without_secret_values(tmp_path):
     assert "ANTHROPIC_API_KEY" in text
     assert "env_values=hidden" in text
     assert "secret" not in text.lower()
+
+
+def test_resolve_audit_output_path_stays_inside_project(tmp_path):
+    project_root = tmp_path / "project"
+    project_root.mkdir()
+
+    assert resolve_audit_output_path(None, project_root) is None
+    assert resolve_audit_output_path(
+        ".dgm-sandbox-runs/audit.json",
+        project_root,
+    ) == project_root.resolve() / ".dgm-sandbox-runs" / "audit.json"
+    assert resolve_audit_output_path(
+        str(project_root / "logs" / "audit.json"),
+        project_root,
+    ) == project_root.resolve() / "logs" / "audit.json"
+
+    with pytest.raises(SandboxRunError, match="outside project root"):
+        resolve_audit_output_path(tmp_path / "outside.json", project_root)
+
+
+def test_write_run_audit_writes_json_without_secret_values(tmp_path):
+    artifact = tmp_path / ".dgm-sandbox-runs" / "audit.json"
+    audit = {
+        "env_names": ["ANTHROPIC_API_KEY"],
+        "env_values": "hidden",
+        "network_mode": "bridge",
+    }
+
+    write_run_audit(audit, artifact)
+
+    artifact_text = artifact.read_text(encoding="utf-8")
+    written = json.loads(artifact_text)
+    assert written["env_names"] == ["ANTHROPIC_API_KEY"]
+    assert written["env_values"] == "hidden"
+    assert "secret-value" not in artifact_text
 
 
 def test_load_sandbox_config_reads_project_config(tmp_path):
@@ -457,10 +495,15 @@ async def test_main_prints_non_secret_audit(monkeypatch, tmp_path, capsys):
         "--env",
         "ANTHROPIC_API_KEY",
         "--discard-changes",
+        "--audit-output",
+        ".dgm-sandbox-runs/audit.json",
     ])
 
     exit_code = await _main_async(args)
     captured = capsys.readouterr()
+    audit_artifact = project_root / ".dgm-sandbox-runs" / "audit.json"
+    audit_text = audit_artifact.read_text(encoding="utf-8")
+    audit_json = json.loads(audit_text)
 
     assert exit_code == 0
     assert captured.out == "ok\n"
@@ -469,4 +512,9 @@ async def test_main_prints_non_secret_audit(monkeypatch, tmp_path, capsys):
     assert "env_names=ANTHROPIC_API_KEY" in captured.err
     assert "env_values=hidden" in captured.err
     assert "sync_mode=discard-changes" in captured.err
+    assert "[audit] artifact=.dgm-sandbox-runs/audit.json" in captured.err
     assert "secret-value" not in captured.err
+    assert audit_artifact.exists()
+    assert audit_json["env_names"] == ["ANTHROPIC_API_KEY"]
+    assert audit_json["env_values"] == "hidden"
+    assert "secret-value" not in audit_text


### PR DESCRIPTION
## Summary
- Add optional `--audit-output` support to `scripts/run_dgm_in_sandbox.py` for project-local JSON audit artifacts.
- Keep the artifact non-secret by recording environment variable names and `env_values: hidden`, never host env values.
- Extend the no-network demo verifier and docs so the repeatable setup path covers the new audit artifact behavior.

## Validation
- `PATH="$PWD/.venv/bin:$PATH" python -m pytest tests/unit/test_run_dgm_in_sandbox.py tests/integration/test_demo_path_verifier.py`
- `PATH="$PWD/.venv/bin:$PATH" python scripts/verify_demo_path.py`
- `PATH="$PWD/.venv/bin:$PATH" python scripts/verify_sandbox_docker.py --require`
- `PATH="$PWD/.venv/bin:$PATH" python -m pytest`