### PR TITLE
[codex] add live-run scorecard gate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Data files
 *.json
+!docs/live-runs/**/scorecard.json
 *.csv
 *.tsv
 *.xlsx

--- a/README.md
+++ b/README.md
@@ -254,6 +254,22 @@ This local comparison should report a baseline score of `0.500`, a candidate
 score of `1.000`, and `delta=+0.500`. It verifies the benchmark harness and
 reporting path; it is not evidence of autonomous DGM self-improvement.
 
+For live DGM runs, summarize the generated archive metadata before claiming
+score movement:
+
+```bash
+python scripts/summarize_archive_scores.py \
+  --archive-metadata .dgm-live-runs/<run-id>/archive/archive_metadata.json \
+  --output docs/live-runs/<run-id>/scorecard.json \
+  --require-improvement
+```
+
+`--require-improvement` exits non-zero unless at least one valid child agent
+improves on its parent by average benchmark score. The committed
+`docs/live-runs/2026-06-12-proof/scorecard.json` intentionally records
+`has_improvement=false` for the first live proof because both child agents tied
+the already-perfect base score.
+
 ## 🧪 Running Experiments
 
 ### Basic Evolution Run

--- a/docs/live-runs/2026-06-12-proof/README.md
+++ b/docs/live-runs/2026-06-12-proof/README.md
@@ -13,6 +13,7 @@ PATH="$PWD/.venv/bin:$PATH" python run_dgm.py \
 ```
 
 The full captured transcript is in `transcript.txt`.
+The machine-readable scorecard is in `scorecard.json`.
 
 ## Scope
 
@@ -65,6 +66,7 @@ Final report summary:
 - Final archive size: 3
 - Successful improvements: 0
 - Top score: 1.000
+- Best parent-child average-score delta: 0.000
 
 ## Evidence Notes
 

--- a/docs/live-runs/2026-06-12-proof/scorecard.json
+++ b/docs/live-runs/2026-06-12-proof/scorecard.json
@@ -1,0 +1,65 @@
+{
+  "archive_metadata": ".dgm-live-runs/2026-06-12-proof/archive/archive_metadata.json",
+  "best_average_delta": 0.0,
+  "generation_best_scores": [
+    {
+      "agent_id": "686d489b-7bcb-4d8d-a007-d971ddafcfdd",
+      "average_score": 1.0,
+      "benchmark_scores": {
+        "list_processing": 1.0
+      },
+      "generation": 0
+    },
+    {
+      "agent_id": "08150f6d-25ca-4bce-93ef-3172cc3a5a0d",
+      "average_score": 1.0,
+      "benchmark_scores": {
+        "list_processing": 1.0
+      },
+      "generation": 1
+    },
+    {
+      "agent_id": "321422b4-3747-4896-af61-c2060fcf6884",
+      "average_score": 1.0,
+      "benchmark_scores": {
+        "list_processing": 1.0
+      },
+      "generation": 2
+    }
+  ],
+  "has_improvement": false,
+  "improvements": [],
+  "min_delta": 0.0,
+  "parent_child_deltas": [
+    {
+      "average_delta": 0.0,
+      "benchmark_deltas": {
+        "list_processing": 0.0
+      },
+      "child_average_score": 1.0,
+      "child_generation": 1,
+      "child_id": "08150f6d-25ca-4bce-93ef-3172cc3a5a0d",
+      "is_improvement": false,
+      "parent_average_score": 1.0,
+      "parent_generation": 0,
+      "parent_id": "686d489b-7bcb-4d8d-a007-d971ddafcfdd"
+    },
+    {
+      "average_delta": 0.0,
+      "benchmark_deltas": {
+        "list_processing": 0.0
+      },
+      "child_average_score": 1.0,
+      "child_generation": 2,
+      "child_id": "321422b4-3747-4896-af61-c2060fcf6884",
+      "is_improvement": false,
+      "parent_average_score": 1.0,
+      "parent_generation": 1,
+      "parent_id": "08150f6d-25ca-4bce-93ef-3172cc3a5a0d"
+    }
+  ],
+  "top_agent_id": "686d489b-7bcb-4d8d-a007-d971ddafcfdd",
+  "top_score": 1.0,
+  "total_agents": 3,
+  "valid_agents": 3
+}

--- a/scripts/summarize_archive_scores.py
+++ b/scripts/summarize_archive_scores.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+"""Summarize score movement from DGM archive metadata."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+
+class ScorecardError(RuntimeError):
+    """Raised when archive score metadata cannot be summarized."""
+
+
+def _load_archive_metadata(metadata_path: Path) -> dict[str, Any]:
+    try:
+        data = json.loads(metadata_path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise ScorecardError(f"Archive metadata not found: {metadata_path}") from exc
+    except json.JSONDecodeError as exc:
+        raise ScorecardError(f"Invalid archive metadata JSON: {metadata_path}: {exc}") from exc
+
+    agents = data.get("agents")
+    if not isinstance(agents, dict):
+        raise ScorecardError("Archive metadata must contain an agents object")
+    return data
+
+
+def _normalize_agent(agent_id: str, raw: dict[str, Any]) -> dict[str, Any]:
+    benchmark_scores = raw.get("benchmark_scores") or {}
+    if not isinstance(benchmark_scores, dict):
+        benchmark_scores = {}
+
+    return {
+        "agent_id": str(raw.get("agent_id") or agent_id),
+        "parent_id": raw.get("parent_id"),
+        "generation": int(raw.get("generation", 0)),
+        "average_score": float(raw.get("average_score", 0.0)),
+        "benchmark_scores": {
+            str(name): float(score) for name, score in benchmark_scores.items()
+        },
+        "is_valid": bool(raw.get("is_valid", False)),
+        "created_at": raw.get("created_at"),
+    }
+
+
+def _agent_sort_key(agent: dict[str, Any]) -> tuple[int, str, str]:
+    return (
+        agent["generation"],
+        str(agent.get("created_at") or ""),
+        agent["agent_id"],
+    )
+
+
+def _generation_best_scores(agents: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    best_by_generation: dict[int, dict[str, Any]] = {}
+    for agent in agents:
+        if not agent["is_valid"]:
+            continue
+        generation = agent["generation"]
+        current = best_by_generation.get(generation)
+        if current is None or agent["average_score"] > current["average_score"]:
+            best_by_generation[generation] = agent
+
+    return [
+        {
+            "generation": generation,
+            "agent_id": agent["agent_id"],
+            "average_score": agent["average_score"],
+            "benchmark_scores": agent["benchmark_scores"],
+        }
+        for generation, agent in sorted(best_by_generation.items())
+    ]
+
+
+def summarize_archive_scores(
+    metadata_path: Path,
+    *,
+    min_delta: float = 0.0,
+) -> dict[str, Any]:
+    """Build a score movement scorecard from archive metadata."""
+    data = _load_archive_metadata(metadata_path)
+    agents = [
+        _normalize_agent(agent_id, raw)
+        for agent_id, raw in data["agents"].items()
+        if isinstance(raw, dict)
+    ]
+    agents.sort(key=_agent_sort_key)
+    valid_agents = [agent for agent in agents if agent["is_valid"]]
+    valid_by_id = {agent["agent_id"]: agent for agent in valid_agents}
+
+    parent_child_deltas = []
+    for child in valid_agents:
+        parent_id = child.get("parent_id")
+        if parent_id not in valid_by_id:
+            continue
+
+        parent = valid_by_id[parent_id]
+        benchmark_deltas = {
+            name: child["benchmark_scores"][name] - parent["benchmark_scores"][name]
+            for name in sorted(
+                set(parent["benchmark_scores"]) & set(child["benchmark_scores"])
+            )
+        }
+        average_delta = child["average_score"] - parent["average_score"]
+        parent_child_deltas.append(
+            {
+                "parent_id": parent["agent_id"],
+                "child_id": child["agent_id"],
+                "parent_generation": parent["generation"],
+                "child_generation": child["generation"],
+                "parent_average_score": parent["average_score"],
+                "child_average_score": child["average_score"],
+                "average_delta": average_delta,
+                "benchmark_deltas": benchmark_deltas,
+                "is_improvement": average_delta > min_delta,
+            }
+        )
+
+    improvements = [
+        delta for delta in parent_child_deltas if delta["is_improvement"]
+    ]
+    best_delta = max(
+        (delta["average_delta"] for delta in parent_child_deltas),
+        default=0.0,
+    )
+    top_agent = (
+        max(valid_agents, key=lambda agent: agent["average_score"])
+        if valid_agents
+        else None
+    )
+
+    return {
+        "archive_metadata": str(metadata_path),
+        "total_agents": len(agents),
+        "valid_agents": len(valid_agents),
+        "top_score": top_agent["average_score"] if top_agent else 0.0,
+        "top_agent_id": top_agent["agent_id"] if top_agent else None,
+        "best_average_delta": best_delta,
+        "min_delta": min_delta,
+        "has_improvement": bool(improvements),
+        "generation_best_scores": _generation_best_scores(agents),
+        "parent_child_deltas": parent_child_deltas,
+        "improvements": improvements,
+    }
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--archive-metadata",
+        required=True,
+        help="Path to an archive_metadata.json file from a DGM run.",
+    )
+    parser.add_argument(
+        "--output",
+        help="Optional path to write the scorecard JSON.",
+    )
+    parser.add_argument(
+        "--min-delta",
+        type=float,
+        default=0.0,
+        help="Minimum average-score delta required to count as an improvement.",
+    )
+    parser.add_argument(
+        "--require-improvement",
+        action="store_true",
+        help="Exit non-zero unless at least one valid child improves on its parent.",
+    )
+    return parser
+
+
+def _write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _main(args: argparse.Namespace) -> int:
+    try:
+        report = summarize_archive_scores(
+            Path(args.archive_metadata),
+            min_delta=args.min_delta,
+        )
+        if args.output:
+            _write_json(Path(args.output), report)
+    except ScorecardError as exc:
+        print(f"[fail] {exc}", file=sys.stderr)
+        return 1
+
+    print(
+        "archive scorecard: "
+        f"agents={report['valid_agents']}/{report['total_agents']} "
+        f"top_score={report['top_score']:.3f} "
+        f"best_delta={report['best_average_delta']:+.3f} "
+        f"improvements={len(report['improvements'])}"
+    )
+
+    if args.require_improvement and not report["has_improvement"]:
+        print(
+            "[fail] no valid parent-child average-score improvement found",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+def main() -> int:
+    return _main(_build_parser().parse_args())
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/verify_demo_path.py
+++ b/scripts/verify_demo_path.py
@@ -130,12 +130,15 @@ async def _verify_score_movement(project_root: Path) -> dict[str, Any]:
 def _verify_live_run_docs(project_root: Path) -> dict[str, Any]:
     readme = project_root / "docs" / "live-runs" / "2026-06-12-proof" / "README.md"
     transcript = project_root / "docs" / "live-runs" / "2026-06-12-proof" / "transcript.txt"
+    scorecard = project_root / "docs" / "live-runs" / "2026-06-12-proof" / "scorecard.json"
     _check_file(readme, project_root)
     _check_file(transcript, project_root)
+    _check_file(scorecard, project_root)
 
     readme_text = readme.read_text(encoding="utf-8")
     _require("API calls: 20" in readme_text, "Live-run README is missing API-call evidence")
     _require("Top score: 1.000" in readme_text, "Live-run README is missing top score")
+    _require("Successful improvements: 0" in readme_text, "Live-run README is missing improvement count")
     _require(
         "does not prove benchmark improvement" in readme_text,
         "Live-run README must keep the benchmark-improvement caveat",
@@ -145,11 +148,32 @@ def _verify_live_run_docs(project_root: Path) -> dict[str, Any]:
     _require("POST https://api.anthropic.com/v1/messages" in transcript_text, "Transcript lacks live API evidence")
     _require("DGM run completed" in transcript_text, "Transcript lacks completion evidence")
 
+    scorecard_json = _load_json(scorecard)
+    _require(scorecard_json["total_agents"] == 3, "Live-run scorecard must record three agents")
+    _require(scorecard_json["valid_agents"] == 3, "Live-run scorecard must record three valid agents")
+    _require(scorecard_json["top_score"] == 1.0, "Live-run scorecard top score must be 1.0")
+    _require(
+        scorecard_json["best_average_delta"] == 0.0,
+        "Live-run scorecard must record zero average-score delta",
+    )
+    _require(
+        scorecard_json["has_improvement"] is False,
+        "Live-run scorecard must preserve the no-improvement caveat",
+    )
+    _require(
+        len(scorecard_json["generation_best_scores"]) == 3,
+        "Live-run scorecard must record three generations",
+    )
+
     return {
         "name": "live_run_docs",
         "status": "ok",
         "readme": str(readme.relative_to(project_root)),
         "transcript": str(transcript.relative_to(project_root)),
+        "scorecard": str(scorecard.relative_to(project_root)),
+        "top_score": scorecard_json["top_score"],
+        "best_average_delta": scorecard_json["best_average_delta"],
+        "has_improvement": scorecard_json["has_improvement"],
     }
 
 

--- a/tests/integration/test_demo_path_verifier.py
+++ b/tests/integration/test_demo_path_verifier.py
@@ -24,6 +24,12 @@ async def test_no_network_demo_path_verifier_passes():
     assert score_check["candidate_score"] == 1.0
     assert score_check["delta"] == 0.5
 
+    live_run_check = next(check for check in checks if check["name"] == "live_run_docs")
+    assert live_run_check["scorecard"] == "docs/live-runs/2026-06-12-proof/scorecard.json"
+    assert live_run_check["top_score"] == 1.0
+    assert live_run_check["best_average_delta"] == 0.0
+    assert live_run_check["has_improvement"] is False
+
     sandbox_check = next(check for check in checks if check["name"] == "sandbox_runner_cli")
     assert "--discard-changes" in sandbox_check["safe_flags"]
     assert "--audit-output" in sandbox_check["safe_flags"]

--- a/tests/unit/test_summarize_archive_scores.py
+++ b/tests/unit/test_summarize_archive_scores.py
@@ -1,0 +1,147 @@
+import json
+
+import pytest
+
+from scripts.summarize_archive_scores import (
+    _build_parser,
+    _main,
+    summarize_archive_scores,
+)
+
+
+def _write_archive_metadata(path, agents):
+    path.write_text(
+        json.dumps({"agents": agents, "last_updated": "2026-06-15T00:00:00"}),
+        encoding="utf-8",
+    )
+
+
+def test_summarize_archive_scores_finds_parent_child_improvement(tmp_path):
+    metadata = tmp_path / "archive_metadata.json"
+    _write_archive_metadata(
+        metadata,
+        {
+            "root": {
+                "agent_id": "root",
+                "parent_id": None,
+                "generation": 0,
+                "average_score": 0.5,
+                "benchmark_scores": {"humaneval_style": 0.5},
+                "is_valid": True,
+            },
+            "child": {
+                "agent_id": "child",
+                "parent_id": "root",
+                "generation": 1,
+                "average_score": 1.0,
+                "benchmark_scores": {"humaneval_style": 1.0},
+                "is_valid": True,
+            },
+        },
+    )
+
+    report = summarize_archive_scores(metadata)
+
+    assert report["total_agents"] == 2
+    assert report["valid_agents"] == 2
+    assert report["top_agent_id"] == "child"
+    assert report["top_score"] == pytest.approx(1.0)
+    assert report["best_average_delta"] == pytest.approx(0.5)
+    assert report["has_improvement"] is True
+    assert report["improvements"] == [report["parent_child_deltas"][0]]
+    assert report["parent_child_deltas"][0]["benchmark_deltas"] == {
+        "humaneval_style": 0.5
+    }
+    assert report["generation_best_scores"] == [
+        {
+            "generation": 0,
+            "agent_id": "root",
+            "average_score": 0.5,
+            "benchmark_scores": {"humaneval_style": 0.5},
+        },
+        {
+            "generation": 1,
+            "agent_id": "child",
+            "average_score": 1.0,
+            "benchmark_scores": {"humaneval_style": 1.0},
+        },
+    ]
+
+
+def test_require_improvement_fails_flat_archive(tmp_path, capsys):
+    metadata = tmp_path / "archive_metadata.json"
+    _write_archive_metadata(
+        metadata,
+        {
+            "root": {
+                "agent_id": "root",
+                "parent_id": None,
+                "generation": 0,
+                "average_score": 1.0,
+                "benchmark_scores": {"list_processing": 1.0},
+                "is_valid": True,
+            },
+            "child": {
+                "agent_id": "child",
+                "parent_id": "root",
+                "generation": 1,
+                "average_score": 1.0,
+                "benchmark_scores": {"list_processing": 1.0},
+                "is_valid": True,
+            },
+        },
+    )
+    args = _build_parser().parse_args([
+        "--archive-metadata",
+        str(metadata),
+        "--require-improvement",
+    ])
+
+    exit_code = _main(args)
+    captured = capsys.readouterr()
+
+    assert exit_code == 1
+    assert "best_delta=+0.000" in captured.out
+    assert "no valid parent-child average-score improvement" in captured.err
+
+
+def test_main_writes_scorecard_json(tmp_path, capsys):
+    metadata = tmp_path / "archive_metadata.json"
+    output = tmp_path / "scorecard.json"
+    _write_archive_metadata(
+        metadata,
+        {
+            "root": {
+                "agent_id": "root",
+                "parent_id": None,
+                "generation": 0,
+                "average_score": 0.5,
+                "benchmark_scores": {"humaneval_style": 0.5},
+                "is_valid": True,
+            },
+            "child": {
+                "agent_id": "child",
+                "parent_id": "root",
+                "generation": 1,
+                "average_score": 0.75,
+                "benchmark_scores": {"humaneval_style": 0.75},
+                "is_valid": True,
+            },
+        },
+    )
+    args = _build_parser().parse_args([
+        "--archive-metadata",
+        str(metadata),
+        "--output",
+        str(output),
+        "--require-improvement",
+    ])
+
+    exit_code = _main(args)
+    captured = capsys.readouterr()
+    scorecard = json.loads(output.read_text(encoding="utf-8"))
+
+    assert exit_code == 0
+    assert "best_delta=+0.250" in captured.out
+    assert scorecard["has_improvement"] is True
+    assert scorecard["best_average_delta"] == pytest.approx(0.25)


### PR DESCRIPTION
## Summary
- Add `scripts/summarize_archive_scores.py` to turn DGM archive metadata into a machine-readable scorecard.
- Add `--require-improvement` so future live-run score movement claims can fail closed unless a valid child improves on its parent by average benchmark score.
- Commit the first live proof scorecard with `has_improvement=false`, and verify that caveat through the no-network demo verifier.

## Validation
- `PATH="$PWD/.venv/bin:$PATH" python -m pytest tests/unit/test_summarize_archive_scores.py tests/integration/test_demo_path_verifier.py`
- `PATH="$PWD/.venv/bin:$PATH" python scripts/verify_demo_path.py`
- `PATH="$PWD/.venv/bin:$PATH" python scripts/verify_sandbox_docker.py --require`
- `PATH="$PWD/.venv/bin:$PATH" python -m pytest`