### PR TITLE
[codex] estimate live run cost gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,19 @@ current provider pricing:
 python scripts/verify_live_score_movement_plan.py
 ```
 
+As checked against Anthropic's official pricing page on 2026-06-15,
+`claude-sonnet-4-6` was listed at `$3 / MTok` input and `$15 / MTok` output.
+With a conservative 50,000 input-token assumption per model call, estimate the
+bounded rehearsal cost before asking for approval:
+
+```bash
+python scripts/estimate_live_run_cost.py \
+  --input-price-per-mtok 3 \
+  --output-price-per-mtok 15 \
+  --assumed-input-tokens-per-call 50000 \
+  --max-budget 5
+```
+
 After explicit approval, run it through the full-process sandbox runner:
 
 ```bash

--- a/config/live_score_movement.yaml
+++ b/config/live_score_movement.yaml
@@ -58,6 +58,12 @@ live_run:
   recommended_generations: 2
   cost_gate:
     check_current_provider_pricing_before_run: true
+    pricing_source: https://platform.claude.com/docs/en/about-claude/pricing
+    pricing_checked_at: 2026-06-15
+    input_price_per_mtok: 3
+    output_price_per_mtok: 15
+    assumed_input_tokens_per_call: 50000
+    max_estimated_cost_usd: 5
     max_generations_without_reapproval: 2
     max_agent_steps: 5
     max_output_tokens_per_call: 2048
@@ -66,6 +72,7 @@ live_run:
     - PATH="$PWD/.venv/bin:$PATH" python scripts/verify_demo_path.py
     - PATH="$PWD/.venv/bin:$PATH" python scripts/verify_sandbox_docker.py --require
     - PATH="$PWD/.venv/bin:$PATH" python scripts/verify_live_score_movement_plan.py
+    - PATH="$PWD/.venv/bin:$PATH" python scripts/estimate_live_run_cost.py --input-price-per-mtok 3 --output-price-per-mtok 15 --assumed-input-tokens-per-call 50000 --max-budget 5
   recommended_run:
     - PATH="$PWD/.venv/bin:$PATH" python scripts/run_dgm_in_sandbox.py --config config/live_score_movement.yaml --generations 2 --allow-network --env ANTHROPIC_API_KEY --audit-output .dgm-sandbox-runs/live-score-movement-audit.json
   post_run_scorecard:

--- a/scripts/estimate_live_run_cost.py
+++ b/scripts/estimate_live_run_cost.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+"""Estimate a bounded live DGM run cost from config and current token prices."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+
+
+class CostEstimateError(RuntimeError):
+    """Raised when a live-run cost estimate cannot be computed safely."""
+
+
+def _load_yaml(path: Path) -> dict[str, Any]:
+    try:
+        data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    except FileNotFoundError as exc:
+        raise CostEstimateError(f"Missing config: {path}") from exc
+    except yaml.YAMLError as exc:
+        raise CostEstimateError(f"Invalid YAML in {path}: {exc}") from exc
+
+    if not isinstance(data, dict):
+        raise CostEstimateError(f"Config must be a mapping: {path}")
+    return data
+
+
+def _require_positive(name: str, value: float) -> None:
+    if value <= 0:
+        raise CostEstimateError(f"{name} must be greater than zero")
+
+
+def estimate_live_run_cost(
+    *,
+    config_path: Path,
+    input_price_per_mtok: float,
+    output_price_per_mtok: float,
+    assumed_input_tokens_per_call: int,
+    max_budget: float | None = None,
+) -> dict[str, Any]:
+    """Estimate the bounded cost ceiling for a planned live DGM run.
+
+    The DGM benchmark runner asks the agent to solve each enabled benchmark once;
+    benchmark YAML test cases validate that solution locally and do not add model
+    calls. A full run initializes the base agent once, then each generation runs
+    one self-modification task plus one child evaluation pass.
+    """
+    _require_positive("input_price_per_mtok", input_price_per_mtok)
+    _require_positive("output_price_per_mtok", output_price_per_mtok)
+    _require_positive("assumed_input_tokens_per_call", assumed_input_tokens_per_call)
+
+    config = _load_yaml(config_path)
+    primary = config.get("fm_providers", {}).get("primary")
+    provider = config.get("fm_providers", {}).get(primary, {})
+    if not provider:
+        raise CostEstimateError("Config must define the primary provider settings")
+
+    enabled_benchmarks = config.get("benchmarks", {}).get("enabled", [])
+    if not enabled_benchmarks:
+        raise CostEstimateError("Config must enable at least one benchmark")
+
+    live_run = config.get("live_run", {})
+    generations = live_run.get("recommended_generations")
+    if generations is None:
+        raise CostEstimateError("Config live_run must define recommended_generations")
+
+    max_steps = int(config.get("agents", {}).get("max_steps", 0))
+    output_tokens_per_call = int(provider.get("max_tokens", 0))
+    benchmark_count = len(enabled_benchmarks)
+    _require_positive("recommended_generations", int(generations))
+    _require_positive("agents.max_steps", max_steps)
+    _require_positive("provider.max_tokens", output_tokens_per_call)
+
+    base_evaluation_requests = benchmark_count * max_steps
+    requests_per_generation = max_steps + (benchmark_count * max_steps)
+    request_ceiling = base_evaluation_requests + (
+        int(generations) * requests_per_generation
+    )
+    input_token_ceiling = request_ceiling * assumed_input_tokens_per_call
+    output_token_ceiling = request_ceiling * output_tokens_per_call
+    input_cost = input_token_ceiling / 1_000_000 * input_price_per_mtok
+    output_cost = output_token_ceiling / 1_000_000 * output_price_per_mtok
+    total_cost = input_cost + output_cost
+
+    return {
+        "config": str(config_path),
+        "model": provider.get("model"),
+        "provider": primary,
+        "enabled_benchmarks": list(enabled_benchmarks),
+        "benchmark_count": benchmark_count,
+        "generations": int(generations),
+        "max_agent_steps": max_steps,
+        "request_ceiling": request_ceiling,
+        "base_evaluation_request_ceiling": base_evaluation_requests,
+        "requests_per_generation_ceiling": requests_per_generation,
+        "assumed_input_tokens_per_call": assumed_input_tokens_per_call,
+        "max_output_tokens_per_call": output_tokens_per_call,
+        "input_token_ceiling": input_token_ceiling,
+        "output_token_ceiling": output_token_ceiling,
+        "input_price_per_mtok": input_price_per_mtok,
+        "output_price_per_mtok": output_price_per_mtok,
+        "estimated_input_cost_usd": input_cost,
+        "estimated_output_cost_usd": output_cost,
+        "estimated_total_cost_usd": total_cost,
+        "max_budget_usd": max_budget,
+        "within_budget": max_budget is None or total_cost <= max_budget,
+    }
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--config",
+        default=str(PROJECT_ROOT / "config" / "live_score_movement.yaml"),
+        help="Live-run config to estimate.",
+    )
+    parser.add_argument(
+        "--input-price-per-mtok",
+        type=float,
+        required=True,
+        help="Current provider input price in USD per million tokens.",
+    )
+    parser.add_argument(
+        "--output-price-per-mtok",
+        type=float,
+        required=True,
+        help="Current provider output price in USD per million tokens.",
+    )
+    parser.add_argument(
+        "--assumed-input-tokens-per-call",
+        type=int,
+        default=50_000,
+        help="Conservative input-token assumption for each model call.",
+    )
+    parser.add_argument(
+        "--max-budget",
+        type=float,
+        help="Optional USD ceiling; exits non-zero if the estimate exceeds it.",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Print machine-readable JSON.",
+    )
+    return parser
+
+
+def _main(args: argparse.Namespace) -> int:
+    try:
+        estimate = estimate_live_run_cost(
+            config_path=Path(args.config),
+            input_price_per_mtok=args.input_price_per_mtok,
+            output_price_per_mtok=args.output_price_per_mtok,
+            assumed_input_tokens_per_call=args.assumed_input_tokens_per_call,
+            max_budget=args.max_budget,
+        )
+    except CostEstimateError as exc:
+        if args.json:
+            print(json.dumps({"status": "failed", "error": str(exc)}, indent=2))
+        else:
+            print(f"[fail] {exc}", file=sys.stderr)
+        return 1
+
+    if args.json:
+        print(
+            json.dumps(
+                {"status": "ok", "estimate": estimate},
+                indent=2,
+                sort_keys=True,
+            )
+        )
+    else:
+        print(
+            "live run cost estimate: "
+            f"requests<={estimate['request_ceiling']} "
+            f"input_tokens<={estimate['input_token_ceiling']} "
+            f"output_tokens<={estimate['output_token_ceiling']} "
+            f"total=${estimate['estimated_total_cost_usd']:.4f}"
+        )
+
+    if not estimate["within_budget"]:
+        print(
+            "[fail] estimated total exceeds max budget "
+            f"(${estimate['max_budget_usd']:.2f})",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+def main() -> int:
+    return _main(_build_parser().parse_args())
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/verify_live_score_movement_plan.py
+++ b/scripts/verify_live_score_movement_plan.py
@@ -13,6 +13,10 @@ import yaml
 
 
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from scripts.estimate_live_run_cost import estimate_live_run_cost
 
 
 class LiveRunPlanError(RuntimeError):
@@ -125,6 +129,13 @@ def verify_live_score_movement_plan(
         "Cost gate must require current provider pricing check before run",
     )
     _require(
+        str(cost_gate.get("pricing_source", "")).startswith(
+            "https://platform.claude.com/docs/"
+        ),
+        "Cost gate must record the official Anthropic pricing source",
+    )
+    _require(cost_gate.get("pricing_checked_at"), "Cost gate must record pricing check date")
+    _require(
         cost_gate.get("max_generations_without_reapproval") == 2,
         "Cost gate must cap generations at 2 without reapproval",
     )
@@ -134,6 +145,14 @@ def verify_live_score_movement_plan(
         "Cost gate output-token cap must match provider max_tokens",
     )
     _require(cost_gate.get("max_enabled_benchmarks") == len(enabled), "Cost gate benchmark count must match config")
+    cost_estimate = estimate_live_run_cost(
+        config_path=config_path,
+        input_price_per_mtok=float(cost_gate.get("input_price_per_mtok", 0)),
+        output_price_per_mtok=float(cost_gate.get("output_price_per_mtok", 0)),
+        assumed_input_tokens_per_call=int(cost_gate.get("assumed_input_tokens_per_call", 0)),
+        max_budget=float(cost_gate.get("max_estimated_cost_usd", 0)),
+    )
+    _require(cost_estimate["within_budget"], "Configured live-run cost estimate exceeds budget")
 
     preflight = live_run.get("required_preflight", [])
     _require(
@@ -147,6 +166,10 @@ def verify_live_score_movement_plan(
     _require(
         any("scripts/verify_live_score_movement_plan.py" in command for command in preflight),
         "Preflight must include this live score-movement plan verifier",
+    )
+    _require(
+        any("scripts/estimate_live_run_cost.py" in command for command in preflight),
+        "Preflight must include live-run cost estimate",
     )
 
     recommended_run = " ".join(live_run.get("recommended_run", []))
@@ -182,6 +205,15 @@ def verify_live_score_movement_plan(
         "requires_current_pricing_check": True,
         "requires_full_process_sandbox": True,
         "requires_scorecard_improvement": True,
+        "pricing_checked_at": str(cost_gate["pricing_checked_at"]),
+        "input_price_per_mtok": cost_estimate["input_price_per_mtok"],
+        "output_price_per_mtok": cost_estimate["output_price_per_mtok"],
+        "assumed_input_tokens_per_call": cost_estimate["assumed_input_tokens_per_call"],
+        "request_ceiling": cost_estimate["request_ceiling"],
+        "input_token_ceiling": cost_estimate["input_token_ceiling"],
+        "output_token_ceiling": cost_estimate["output_token_ceiling"],
+        "estimated_total_cost_usd": cost_estimate["estimated_total_cost_usd"],
+        "max_estimated_cost_usd": cost_estimate["max_budget_usd"],
     }
 
 

--- a/tests/integration/test_demo_path_verifier.py
+++ b/tests/integration/test_demo_path_verifier.py
@@ -53,3 +53,6 @@ async def test_no_network_demo_path_verifier_passes():
     assert live_plan_check["requires_current_pricing_check"] is True
     assert live_plan_check["requires_full_process_sandbox"] is True
     assert live_plan_check["requires_scorecard_improvement"] is True
+    assert live_plan_check["request_ceiling"] == 25
+    assert live_plan_check["estimated_total_cost_usd"] == pytest.approx(4.518)
+    assert live_plan_check["max_estimated_cost_usd"] == 5

--- a/tests/unit/test_estimate_live_run_cost.py
+++ b/tests/unit/test_estimate_live_run_cost.py
@@ -1,0 +1,86 @@
+from pathlib import Path
+
+import pytest
+
+from scripts.estimate_live_run_cost import (
+    CostEstimateError,
+    _build_parser,
+    _main,
+    estimate_live_run_cost,
+)
+
+
+def test_estimate_live_score_movement_cost_from_config():
+    project_root = Path(__file__).resolve().parents[2]
+
+    estimate = estimate_live_run_cost(
+        config_path=project_root / "config" / "live_score_movement.yaml",
+        input_price_per_mtok=3,
+        output_price_per_mtok=15,
+        assumed_input_tokens_per_call=50_000,
+        max_budget=5,
+    )
+
+    assert estimate["model"] == "claude-sonnet-4-6"
+    assert estimate["enabled_benchmarks"] == ["humaneval_style"]
+    assert estimate["benchmark_count"] == 1
+    assert estimate["generations"] == 2
+    assert estimate["max_agent_steps"] == 5
+    assert estimate["request_ceiling"] == 25
+    assert estimate["base_evaluation_request_ceiling"] == 5
+    assert estimate["requests_per_generation_ceiling"] == 10
+    assert estimate["input_token_ceiling"] == 1_250_000
+    assert estimate["output_token_ceiling"] == 51_200
+    assert estimate["estimated_total_cost_usd"] == pytest.approx(4.518)
+    assert estimate["within_budget"] is True
+
+
+def test_estimate_live_run_cost_rejects_zero_price():
+    project_root = Path(__file__).resolve().parents[2]
+
+    with pytest.raises(CostEstimateError, match="input_price_per_mtok"):
+        estimate_live_run_cost(
+            config_path=project_root / "config" / "live_score_movement.yaml",
+            input_price_per_mtok=0,
+            output_price_per_mtok=15,
+            assumed_input_tokens_per_call=50_000,
+        )
+
+
+def test_estimate_live_run_cost_cli_fails_over_budget(capsys):
+    args = _build_parser().parse_args([
+        "--input-price-per-mtok",
+        "3",
+        "--output-price-per-mtok",
+        "15",
+        "--assumed-input-tokens-per-call",
+        "50000",
+        "--max-budget",
+        "1",
+    ])
+
+    exit_code = _main(args)
+    captured = capsys.readouterr()
+
+    assert exit_code == 1
+    assert "total=$4.5180" in captured.out
+    assert "exceeds max budget" in captured.err
+
+
+def test_estimate_live_run_cost_cli_json(capsys):
+    args = _build_parser().parse_args([
+        "--input-price-per-mtok",
+        "3",
+        "--output-price-per-mtok",
+        "15",
+        "--assumed-input-tokens-per-call",
+        "50000",
+        "--json",
+    ])
+
+    exit_code = _main(args)
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    assert '"status": "ok"' in captured.out
+    assert '"request_ceiling": 25' in captured.out

--- a/tests/unit/test_verify_live_score_movement_plan.py
+++ b/tests/unit/test_verify_live_score_movement_plan.py
@@ -41,6 +41,15 @@ def test_live_score_movement_plan_verifies_default_config():
     assert report["requires_current_pricing_check"] is True
     assert report["requires_full_process_sandbox"] is True
     assert report["requires_scorecard_improvement"] is True
+    assert report["pricing_checked_at"] == "2026-06-15"
+    assert report["input_price_per_mtok"] == 3
+    assert report["output_price_per_mtok"] == 15
+    assert report["assumed_input_tokens_per_call"] == 50_000
+    assert report["request_ceiling"] == 25
+    assert report["input_token_ceiling"] == 1_250_000
+    assert report["output_token_ceiling"] == 51_200
+    assert report["estimated_total_cost_usd"] == pytest.approx(4.518)
+    assert report["max_estimated_cost_usd"] == 5
 
 
 def test_live_score_movement_plan_rejects_unapproved_run(tmp_path):


### PR DESCRIPTION
## Summary
- Add `scripts/estimate_live_run_cost.py` to compute the bounded live-run request, input-token, output-token, and USD estimate from `config/live_score_movement.yaml`.
- Record the 2026-06-15 official Anthropic pricing check for `claude-sonnet-4-6` and wire the estimate into the live score-movement preflight.
- Extend the plan verifier and demo-path tests so the approval request has a repeatable no-network spend ceiling before any API calls.

## Pricing check
- Source: https://platform.claude.com/docs/en/about-claude/pricing
- Rates used: `$3 / MTok` input, `$15 / MTok` output for `claude-sonnet-4-6`
- Estimate: 25 request ceiling, 1,250,000 assumed input tokens, 51,200 output-token ceiling, `$4.5180` total at 50,000 assumed input tokens/request

## Validation
- `PATH="$PWD/.venv/bin:$PATH" python scripts/estimate_live_run_cost.py --input-price-per-mtok 3 --output-price-per-mtok 15 --assumed-input-tokens-per-call 50000 --max-budget 5`
- `PATH="$PWD/.venv/bin:$PATH" python scripts/verify_live_score_movement_plan.py`
- `PATH="$PWD/.venv/bin:$PATH" python scripts/verify_demo_path.py`
- `PATH="$PWD/.venv/bin:$PATH" python scripts/verify_sandbox_docker.py --require`
- `PATH="$PWD/.venv/bin:$PATH" python -m pytest`