### PR TITLE
[codex] preserve live score-movement evidence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Data files
 *.json
 !docs/live-runs/**/scorecard.json
+!docs/live-runs/**/sandbox-audit.json
 *.csv
 *.tsv
 *.xlsx

--- a/docs/live-runs/live-score-movement/README.md
+++ b/docs/live-runs/live-score-movement/README.md
@@ -1,0 +1,47 @@
+# Live score-movement rehearsal
+
+Run date: 2026-06-15
+
+This was a bounded live DGM run for `config/live_score_movement.yaml`. It was
+intended to prove that the cost-gated, full-process Docker runner can execute a
+real provider-backed DGM cycle against `humaneval_style` and then fail closed if
+there is no parent-child score improvement.
+
+Preflight gates passed before the live call:
+
+- `python -m pytest`: 225 passed, 7 skipped
+- `python scripts/verify_demo_path.py`
+- `python scripts/verify_sandbox_docker.py --require`
+- `python scripts/verify_live_score_movement_plan.py`
+- `python scripts/estimate_live_run_cost.py --input-price-per-mtok 3 --output-price-per-mtok 15 --assumed-input-tokens-per-call 50000 --max-budget 5`
+
+The current Anthropic pricing check used Claude Sonnet 4.6 at `$3 / MTok`
+input and `$15 / MTok` output, producing the configured `$4.5180` estimate.
+
+The live command was:
+
+```bash
+PATH="$PWD/.venv/bin:$PATH" python scripts/run_dgm_in_sandbox.py --config config/live_score_movement.yaml --generations 2 --allow-network --env ANTHROPIC_API_KEY --audit-output .dgm-sandbox-runs/live-score-movement-audit.json
+```
+
+Observed live evidence:
+
+- The run executed in the full-process Docker sandbox with `network_mode=bridge`.
+- The sandbox audit recorded only `ANTHROPIC_API_KEY` as an environment variable
+  name and hid the value.
+- The run logged successful `POST https://api.anthropic.com/v1/messages`
+  responses from Anthropic.
+- The DGM controller completed two generations and wrote
+  `.dgm-live-runs/live-score-movement/results/dgm_report_20260615_154225.json`.
+
+Outcome:
+
+- The archive contained 3 valid agents.
+- Top score remained `1.000`.
+- Best parent-child average-score delta was `+0.000`.
+- `scripts/summarize_archive_scores.py --require-improvement` failed as
+  designed because `has_improvement` is `false`.
+
+This proves a fully live, sandboxed, provider-backed DGM run completed. It does
+not prove benchmark improvement. The configured benchmark still needs a live
+score-movement setup where the initial parent has measurable headroom.

--- a/docs/live-runs/live-score-movement/sandbox-audit.json
+++ b/docs/live-runs/live-score-movement/sandbox-audit.json
@@ -1,0 +1,15 @@
+{
+  "allow_network": true,
+  "config": "config/live_score_movement.yaml",
+  "env_names": [
+    "ANTHROPIC_API_KEY"
+  ],
+  "env_values": "hidden",
+  "generations": 2,
+  "network_mode": "bridge",
+  "stage_parent": "~/.cache/dgm-sandbox",
+  "stage_project": true,
+  "sync_back": true,
+  "sync_mode": "sync-back",
+  "timeout": 300
+}

--- a/docs/live-runs/live-score-movement/scorecard.json
+++ b/docs/live-runs/live-score-movement/scorecard.json
@@ -1,0 +1,57 @@
+{
+  "archive_metadata": ".dgm-live-runs/live-score-movement/archive/archive_metadata.json",
+  "best_average_delta": 0.0,
+  "generation_best_scores": [
+    {
+      "agent_id": "f47d2466-708d-44f4-86be-c16a61580204",
+      "average_score": 1.0,
+      "benchmark_scores": {
+        "humaneval_style": 1.0
+      },
+      "generation": 0
+    },
+    {
+      "agent_id": "84bb0743-82d1-462b-895b-9cae24dd5d4f",
+      "average_score": 1.0,
+      "benchmark_scores": {
+        "humaneval_style": 1.0
+      },
+      "generation": 1
+    }
+  ],
+  "has_improvement": false,
+  "improvements": [],
+  "min_delta": 0.0,
+  "parent_child_deltas": [
+    {
+      "average_delta": 0.0,
+      "benchmark_deltas": {
+        "humaneval_style": 0.0
+      },
+      "child_average_score": 1.0,
+      "child_generation": 1,
+      "child_id": "84bb0743-82d1-462b-895b-9cae24dd5d4f",
+      "is_improvement": false,
+      "parent_average_score": 1.0,
+      "parent_generation": 0,
+      "parent_id": "f47d2466-708d-44f4-86be-c16a61580204"
+    },
+    {
+      "average_delta": -1.0,
+      "benchmark_deltas": {
+        "humaneval_style": -1.0
+      },
+      "child_average_score": 0.0,
+      "child_generation": 1,
+      "child_id": "d73027b2-b348-4c3a-8b9a-fa90ffb29c05",
+      "is_improvement": false,
+      "parent_average_score": 1.0,
+      "parent_generation": 0,
+      "parent_id": "f47d2466-708d-44f4-86be-c16a61580204"
+    }
+  ],
+  "top_agent_id": "f47d2466-708d-44f4-86be-c16a61580204",
+  "top_score": 1.0,
+  "total_agents": 3,
+  "valid_agents": 3
+}

--- a/scripts/verify_demo_path.py
+++ b/scripts/verify_demo_path.py
@@ -178,6 +178,64 @@ def _verify_live_run_docs(project_root: Path) -> dict[str, Any]:
     }
 
 
+def _verify_live_score_movement_attempt_docs(project_root: Path) -> dict[str, Any]:
+    readme = project_root / "docs" / "live-runs" / "live-score-movement" / "README.md"
+    scorecard = project_root / "docs" / "live-runs" / "live-score-movement" / "scorecard.json"
+    audit = project_root / "docs" / "live-runs" / "live-score-movement" / "sandbox-audit.json"
+    _check_file(readme, project_root)
+    _check_file(scorecard, project_root)
+    _check_file(audit, project_root)
+
+    readme_text = readme.read_text(encoding="utf-8")
+    _require(
+        "not prove benchmark improvement" in readme_text,
+        "Live score-movement README must keep the benchmark-improvement caveat",
+    )
+    _require(
+        "fully live, sandboxed, provider-backed DGM run completed" in readme_text,
+        "Live score-movement README must record live run completion",
+    )
+
+    scorecard_json = _load_json(scorecard)
+    _require(scorecard_json["total_agents"] == 3, "Live scorecard must record three agents")
+    _require(scorecard_json["valid_agents"] == 3, "Live scorecard must record three valid agents")
+    _require(scorecard_json["top_score"] == 1.0, "Live scorecard top score must be 1.0")
+    _require(
+        scorecard_json["best_average_delta"] == 0.0,
+        "Live scorecard must record zero best average-score delta",
+    )
+    _require(
+        scorecard_json["has_improvement"] is False,
+        "Live scorecard must preserve the failed-improvement gate",
+    )
+
+    audit_text = audit.read_text(encoding="utf-8")
+    audit_json = json.loads(audit_text)
+    _require(audit_json["allow_network"] is True, "Live sandbox audit must record network opt-in")
+    _require(audit_json["network_mode"] == "bridge", "Live sandbox audit must record bridge network")
+    _require(
+        audit_json["env_names"] == ["ANTHROPIC_API_KEY"],
+        "Live sandbox audit must record provider env var name",
+    )
+    _require(audit_json["env_values"] == "hidden", "Live sandbox audit must hide env values")
+    _require(
+        "sk-" not in audit_text and "secret" not in audit_text.lower(),
+        "Live sandbox audit must not contain secret values",
+    )
+
+    return {
+        "name": "live_score_movement_attempt_docs",
+        "status": "ok",
+        "readme": str(readme.relative_to(project_root)),
+        "scorecard": str(scorecard.relative_to(project_root)),
+        "audit": str(audit.relative_to(project_root)),
+        "top_score": scorecard_json["top_score"],
+        "best_average_delta": scorecard_json["best_average_delta"],
+        "has_improvement": scorecard_json["has_improvement"],
+        "audit_hides_env_values": True,
+    }
+
+
 def _verify_archive_lineage(project_root: Path) -> dict[str, Any]:
     svg = project_root / "docs" / "archive-lineage-example.svg"
     _check_file(svg, project_root)
@@ -373,6 +431,7 @@ async def verify_demo_path(project_root: Path = PROJECT_ROOT) -> list[dict[str, 
     checks.append(await _verify_humaneval_reference(project_root))
     checks.append(await _verify_score_movement(project_root))
     checks.append(_verify_live_run_docs(project_root))
+    checks.append(_verify_live_score_movement_attempt_docs(project_root))
     checks.append(_verify_archive_lineage(project_root))
     checks.append(_verify_sandbox_runner_cli(project_root))
     checks.append(await _verify_sandbox_discard_changes_contract())


### PR DESCRIPTION
## Summary

- Record the 2026-06-15 bounded live score-movement run as a caveated artifact, including the generated scorecard and non-secret sandbox audit.
- Extend `scripts/verify_demo_path.py` so the new live artifact is checked without API keys and still records that the improvement gate failed.
- Keep `.gitignore` narrow enough to allow committed live-run scorecards and non-secret sandbox audit artifacts under `docs/live-runs/`.

## Why

The approved live run completed with real Anthropic API calls inside the full-process Docker sandbox, but the scorecard correctly failed `--require-improvement`: the top parent already scored `1.000`, one child tied it, and one child regressed. This PR keeps that proof honest without claiming benchmark improvement.

## Validation

- `PATH="$PWD/.venv/bin:$PATH" python scripts/verify_demo_path.py`
- `PATH="$PWD/.venv/bin:$PATH" python -m pytest`

Result: `225 passed, 7 skipped, 2 warnings`.