### PR TITLE
[codex] add live headroom benchmark gate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.json
 !docs/live-runs/**/scorecard.json
 !docs/live-runs/**/sandbox-audit.json
+!docs/demo/*score_movement.json
 *.csv
 *.tsv
 *.xlsx

--- a/README.md
+++ b/README.md
@@ -239,6 +239,11 @@ It contains HumanEval-style standalone function tasks with reference solutions
 verified by the integration test suite; add `humaneval_style` to
 `benchmarks.enabled` when you want the DGM loop to evaluate against it.
 
+For live score-movement rehearsals, see
+`config/benchmarks/humaneval_headroom.yaml`. It uses public prompt examples plus
+additional hidden evaluation cases so the benchmark can show measurable
+headroom instead of handing every scored input/output pair to the agent.
+
 To demonstrate benchmark score movement without API keys or model calls, compare
 the bundled weak and improved HumanEval-style demo solutions:
 
@@ -253,6 +258,20 @@ python scripts/compare_benchmark_solutions.py \
 This local comparison should report a baseline score of `0.500`, a candidate
 score of `1.000`, and `delta=+0.500`. It verifies the benchmark harness and
 reporting path; it is not evidence of autonomous DGM self-improvement.
+
+The planned live rehearsal uses the hidden-case headroom benchmark. Its
+no-network headroom check is:
+
+```bash
+python scripts/compare_benchmark_solutions.py \
+  --benchmark humaneval_headroom \
+  --baseline docs/demo/humaneval_headroom_baseline.py \
+  --candidate docs/demo/humaneval_headroom_improved.py \
+  --output docs/demo/humaneval_headroom_score_movement.json
+```
+
+This should report a baseline score below `0.750`, a candidate score of
+`1.000`, and a positive delta of at least `+0.250`.
 
 For live DGM runs, summarize the generated archive metadata before claiming
 score movement:
@@ -272,9 +291,9 @@ the already-perfect base score.
 
 The planned live score-movement rehearsal is captured in
 `config/live_score_movement.yaml`. It is bounded to two generations, five agent
-steps, one benchmark (`humaneval_style`), and a 2,048-token output cap per model
-call. Before any live provider call, run the no-network plan check and verify
-current provider pricing:
+steps, one benchmark (`humaneval_headroom`), and a 2,048-token output cap per
+model call. Before any live provider call, run the no-network plan check and
+verify current provider pricing:
 
 ```bash
 python scripts/verify_live_score_movement_plan.py

--- a/config/benchmarks/humaneval_headroom.yaml
+++ b/config/benchmarks/humaneval_headroom.yaml
@@ -1,0 +1,97 @@
+name: humaneval_headroom
+description: HumanEval-style tasks with public examples and hidden evaluation cases
+difficulty: medium
+timeout: 30
+category: algorithms
+scoring_method: partial
+
+task_prompt: |
+  Implement the requested standalone Python functions. The examples below are
+  public examples only; evaluation includes additional hidden edge cases. Return
+  only Python code that defines the requested functions.
+
+prompt_test_cases:
+  - function_name: dedupe_preserve_order
+    task_description: removes duplicates while keeping the first occurrence order
+    inputs:
+      - "[1, 2, 1, 3]"
+    expected_outputs:
+      - "[1, 2, 3]"
+
+  - function_name: chunked
+    task_description: splits a list into consecutive chunks of the requested size
+    inputs:
+      - "[1, 2, 3, 4], 2"
+    expected_outputs:
+      - "[[1, 2], [3, 4]]"
+
+  - function_name: parse_key_values
+    task_description: parses comma-separated key=value pairs into a dictionary
+    inputs:
+      - "'a=1,b=2'"
+    expected_outputs:
+      - "{'a': '1', 'b': '2'}"
+
+  - function_name: balanced_brackets
+    task_description: returns True when brackets are balanced and properly nested
+    inputs:
+      - "'()'"
+      - "'(]'"
+    expected_outputs:
+      - "True"
+      - "False"
+
+test_cases:
+  - function_name: dedupe_preserve_order
+    task_description: removes duplicates while keeping the first occurrence order
+    inputs:
+      - "[1, 2, 1, 3]"
+      - "[]"
+      - "['b', 'a', 'b']"
+      - "[3, 1, 3, 2]"
+    expected_outputs:
+      - "[1, 2, 3]"
+      - "[]"
+      - "['b', 'a']"
+      - "[3, 1, 2]"
+
+  - function_name: chunked
+    task_description: splits a list into consecutive chunks of the requested size
+    inputs:
+      - "[1, 2, 3, 4], 2"
+      - "[1, 2, 3, 4, 5], 2"
+      - "[], 3"
+      - "[1, 2], 5"
+    expected_outputs:
+      - "[[1, 2], [3, 4]]"
+      - "[[1, 2], [3, 4], [5]]"
+      - "[]"
+      - "[[1, 2]]"
+
+  - function_name: parse_key_values
+    task_description: parses comma-separated key=value pairs into a dictionary
+    inputs:
+      - "'a=1,b=2'"
+      - "' a = 1 , b=2 '"
+      - "''"
+      - "'a=1,,b=2'"
+    expected_outputs:
+      - "{'a': '1', 'b': '2'}"
+      - "{'a': '1', 'b': '2'}"
+      - "{}"
+      - "{'a': '1', 'b': '2'}"
+
+  - function_name: balanced_brackets
+    task_description: returns True when brackets are balanced and properly nested
+    inputs:
+      - "'()'"
+      - "'(]'"
+      - "'([{}])'"
+      - "''"
+      - "'([)]'"
+    expected_outputs:
+      - "True"
+      - "False"
+      - "True"
+      - "True"
+      - "False"

--- a/config/live_score_movement.yaml
+++ b/config/live_score_movement.yaml
@@ -44,7 +44,7 @@ benchmarks:
   timeout_default: 30
   max_attempts: 3
   enabled:
-    - humaneval_style
+    - humaneval_headroom
 
 logging:
   level: INFO
@@ -56,6 +56,15 @@ live_run:
   purpose: live_score_movement_rehearsal
   approval_required: true
   recommended_generations: 2
+  headroom_gate:
+    benchmark: humaneval_headroom
+    prompt_examples_are_public_only: true
+    baseline_solution: docs/demo/humaneval_headroom_baseline.py
+    candidate_solution: docs/demo/humaneval_headroom_improved.py
+    score_report: docs/demo/humaneval_headroom_score_movement.json
+    max_baseline_score: 0.75
+    min_candidate_score: 1.0
+    min_delta: 0.25
   cost_gate:
     check_current_provider_pricing_before_run: true
     pricing_source: https://platform.claude.com/docs/en/about-claude/pricing

--- a/docs/demo/humaneval_headroom_baseline.py
+++ b/docs/demo/humaneval_headroom_baseline.py
@@ -1,0 +1,21 @@
+def dedupe_preserve_order(items):
+    return sorted(set(items))
+
+
+def chunked(items, size):
+    stop = len(items) - (len(items) % size)
+    return [items[index:index + size] for index in range(0, stop, size)]
+
+
+def parse_key_values(text):
+    if not text:
+        return {}
+    return dict(part.split("=") for part in text.split(","))
+
+
+def balanced_brackets(text):
+    return (
+        text.count("(") == text.count(")")
+        and text.count("[") == text.count("]")
+        and text.count("{") == text.count("}")
+    )

--- a/docs/demo/humaneval_headroom_improved.py
+++ b/docs/demo/humaneval_headroom_improved.py
@@ -1,0 +1,38 @@
+def dedupe_preserve_order(items):
+    seen = set()
+    result = []
+    for item in items:
+        if item not in seen:
+            seen.add(item)
+            result.append(item)
+    return result
+
+
+def chunked(items, size):
+    return [items[index:index + size] for index in range(0, len(items), size)]
+
+
+def parse_key_values(text):
+    result = {}
+    for part in text.split(","):
+        part = part.strip()
+        if not part:
+            continue
+        key, value = part.split("=", 1)
+        result[key.strip()] = value.strip()
+    return result
+
+
+def balanced_brackets(text):
+    pairs = {"(": ")", "[": "]", "{": "}"}
+    closing = set(pairs.values())
+    stack = []
+
+    for char in text:
+        if char in pairs:
+            stack.append(pairs[char])
+        elif char in closing:
+            if not stack or stack.pop() != char:
+                return False
+
+    return not stack

--- a/docs/demo/humaneval_headroom_score_movement.json
+++ b/docs/demo/humaneval_headroom_score_movement.json
@@ -1,0 +1,325 @@
+{
+  "baseline": {
+    "label": "baseline",
+    "passed": 10,
+    "path": "docs/demo/humaneval_headroom_baseline.py",
+    "score": 0.5882352941176471,
+    "test_cases": [
+      {
+        "function_name": "dedupe_preserve_order",
+        "individual_results": [
+          {
+            "actual_output": "[1, 2, 3]",
+            "error": null,
+            "expected_output": "[1, 2, 3]",
+            "input": "[1, 2, 1, 3]",
+            "success": true
+          },
+          {
+            "actual_output": "[]",
+            "error": null,
+            "expected_output": "[]",
+            "input": "[]",
+            "success": true
+          },
+          {
+            "actual_output": "['a', 'b']",
+            "error": null,
+            "expected_output": "['b', 'a']",
+            "input": "['b', 'a', 'b']",
+            "success": false
+          },
+          {
+            "actual_output": "[1, 2, 3]",
+            "error": null,
+            "expected_output": "[3, 1, 2]",
+            "input": "[3, 1, 3, 2]",
+            "success": false
+          }
+        ],
+        "passed": 2,
+        "success": false,
+        "total": 4
+      },
+      {
+        "function_name": "chunked",
+        "individual_results": [
+          {
+            "actual_output": "[[1, 2], [3, 4]]",
+            "error": null,
+            "expected_output": "[[1, 2], [3, 4]]",
+            "input": "[1, 2, 3, 4], 2",
+            "success": true
+          },
+          {
+            "actual_output": "[[1, 2], [3, 4]]",
+            "error": null,
+            "expected_output": "[[1, 2], [3, 4], [5]]",
+            "input": "[1, 2, 3, 4, 5], 2",
+            "success": false
+          },
+          {
+            "actual_output": "[]",
+            "error": null,
+            "expected_output": "[]",
+            "input": "[], 3",
+            "success": true
+          },
+          {
+            "actual_output": "[]",
+            "error": null,
+            "expected_output": "[[1, 2]]",
+            "input": "[1, 2], 5",
+            "success": false
+          }
+        ],
+        "passed": 2,
+        "success": false,
+        "total": 4
+      },
+      {
+        "function_name": "parse_key_values",
+        "individual_results": [
+          {
+            "actual_output": "{'a': '1', 'b': '2'}",
+            "error": null,
+            "expected_output": "{'a': '1', 'b': '2'}",
+            "input": "'a=1,b=2'",
+            "success": true
+          },
+          {
+            "actual_output": "{' a ': ' 1 ', ' b': '2 '}",
+            "error": null,
+            "expected_output": "{'a': '1', 'b': '2'}",
+            "input": "' a = 1 , b=2 '",
+            "success": false
+          },
+          {
+            "actual_output": "{}",
+            "error": null,
+            "expected_output": "{}",
+            "input": "''",
+            "success": true
+          },
+          {
+            "actual_output": null,
+            "error": "CallError: dictionary update sequence element #1 has length 1; 2 is required",
+            "expected_output": "{'a': '1', 'b': '2'}",
+            "input": "'a=1,,b=2'",
+            "success": false
+          }
+        ],
+        "passed": 2,
+        "success": false,
+        "total": 4
+      },
+      {
+        "function_name": "balanced_brackets",
+        "individual_results": [
+          {
+            "actual_output": "True",
+            "error": null,
+            "expected_output": "True",
+            "input": "'()'",
+            "success": true
+          },
+          {
+            "actual_output": "False",
+            "error": null,
+            "expected_output": "False",
+            "input": "'(]'",
+            "success": true
+          },
+          {
+            "actual_output": "True",
+            "error": null,
+            "expected_output": "True",
+            "input": "'([{}])'",
+            "success": true
+          },
+          {
+            "actual_output": "True",
+            "error": null,
+            "expected_output": "True",
+            "input": "''",
+            "success": true
+          },
+          {
+            "actual_output": "True",
+            "error": null,
+            "expected_output": "False",
+            "input": "'([)]'",
+            "success": false
+          }
+        ],
+        "passed": 4,
+        "success": false,
+        "total": 5
+      }
+    ],
+    "total": 17
+  },
+  "benchmark": "humaneval_headroom",
+  "benchmarks_dir": "config/benchmarks",
+  "candidate": {
+    "label": "candidate",
+    "passed": 17,
+    "path": "docs/demo/humaneval_headroom_improved.py",
+    "score": 1.0,
+    "test_cases": [
+      {
+        "function_name": "dedupe_preserve_order",
+        "individual_results": [
+          {
+            "actual_output": "[1, 2, 3]",
+            "error": null,
+            "expected_output": "[1, 2, 3]",
+            "input": "[1, 2, 1, 3]",
+            "success": true
+          },
+          {
+            "actual_output": "[]",
+            "error": null,
+            "expected_output": "[]",
+            "input": "[]",
+            "success": true
+          },
+          {
+            "actual_output": "['b', 'a']",
+            "error": null,
+            "expected_output": "['b', 'a']",
+            "input": "['b', 'a', 'b']",
+            "success": true
+          },
+          {
+            "actual_output": "[3, 1, 2]",
+            "error": null,
+            "expected_output": "[3, 1, 2]",
+            "input": "[3, 1, 3, 2]",
+            "success": true
+          }
+        ],
+        "passed": 4,
+        "success": true,
+        "total": 4
+      },
+      {
+        "function_name": "chunked",
+        "individual_results": [
+          {
+            "actual_output": "[[1, 2], [3, 4]]",
+            "error": null,
+            "expected_output": "[[1, 2], [3, 4]]",
+            "input": "[1, 2, 3, 4], 2",
+            "success": true
+          },
+          {
+            "actual_output": "[[1, 2], [3, 4], [5]]",
+            "error": null,
+            "expected_output": "[[1, 2], [3, 4], [5]]",
+            "input": "[1, 2, 3, 4, 5], 2",
+            "success": true
+          },
+          {
+            "actual_output": "[]",
+            "error": null,
+            "expected_output": "[]",
+            "input": "[], 3",
+            "success": true
+          },
+          {
+            "actual_output": "[[1, 2]]",
+            "error": null,
+            "expected_output": "[[1, 2]]",
+            "input": "[1, 2], 5",
+            "success": true
+          }
+        ],
+        "passed": 4,
+        "success": true,
+        "total": 4
+      },
+      {
+        "function_name": "parse_key_values",
+        "individual_results": [
+          {
+            "actual_output": "{'a': '1', 'b': '2'}",
+            "error": null,
+            "expected_output": "{'a': '1', 'b': '2'}",
+            "input": "'a=1,b=2'",
+            "success": true
+          },
+          {
+            "actual_output": "{'a': '1', 'b': '2'}",
+            "error": null,
+            "expected_output": "{'a': '1', 'b': '2'}",
+            "input": "' a = 1 , b=2 '",
+            "success": true
+          },
+          {
+            "actual_output": "{}",
+            "error": null,
+            "expected_output": "{}",
+            "input": "''",
+            "success": true
+          },
+          {
+            "actual_output": "{'a': '1', 'b': '2'}",
+            "error": null,
+            "expected_output": "{'a': '1', 'b': '2'}",
+            "input": "'a=1,,b=2'",
+            "success": true
+          }
+        ],
+        "passed": 4,
+        "success": true,
+        "total": 4
+      },
+      {
+        "function_name": "balanced_brackets",
+        "individual_results": [
+          {
+            "actual_output": "True",
+            "error": null,
+            "expected_output": "True",
+            "input": "'()'",
+            "success": true
+          },
+          {
+            "actual_output": "False",
+            "error": null,
+            "expected_output": "False",
+            "input": "'(]'",
+            "success": true
+          },
+          {
+            "actual_output": "True",
+            "error": null,
+            "expected_output": "True",
+            "input": "'([{}])'",
+            "success": true
+          },
+          {
+            "actual_output": "True",
+            "error": null,
+            "expected_output": "True",
+            "input": "''",
+            "success": true
+          },
+          {
+            "actual_output": "False",
+            "error": null,
+            "expected_output": "False",
+            "input": "'([)]'",
+            "success": true
+          }
+        ],
+        "passed": 5,
+        "success": true,
+        "total": 5
+      }
+    ],
+    "total": 17
+  },
+  "delta": 0.4117647058823529
+}

--- a/evaluation/benchmark_runner.py
+++ b/evaluation/benchmark_runner.py
@@ -52,6 +52,7 @@ class BenchmarkTask:
     timeout: int
     validation_code: str
     scoring_method: str
+    prompt_test_cases: Optional[List[Dict[str, Any]]] = None
 
     @classmethod
     def from_config(cls, config_path: str) -> 'BenchmarkTask':
@@ -66,7 +67,8 @@ class BenchmarkTask:
             test_cases=config['test_cases'],
             timeout=config.get('timeout', 60),
             validation_code=config.get('validation_code', ''),
-            scoring_method=config.get('scoring_method', 'pass_fail')
+            scoring_method=config.get('scoring_method', 'pass_fail'),
+            prompt_test_cases=config.get('prompt_test_cases'),
         )
 
 
@@ -175,9 +177,19 @@ class BenchmarkRunner:
         start_time = time.time()
 
         try:
-            # Build enhanced task description with test cases.
-            test_cases_text = "\n\nOFFICIAL TEST CASES:\n"
-            for i, test_case in enumerate(benchmark.test_cases, 1):
+            # Build enhanced task description with prompt-visible examples.
+            # When prompt_test_cases is configured, evaluation still runs the
+            # full test_cases set below. This lets benchmark configs keep a
+            # hidden scoring set instead of handing every expected output to
+            # the agent before it writes a solution.
+            prompt_cases = benchmark.prompt_test_cases or benchmark.test_cases
+            prompt_label = (
+                "PUBLIC EXAMPLES"
+                if benchmark.prompt_test_cases is not None
+                else "OFFICIAL TEST CASES"
+            )
+            test_cases_text = f"\n\n{prompt_label}:\n"
+            for i, test_case in enumerate(prompt_cases, 1):
                 func_name = test_case.get('function_name', 'function')
                 test_cases_text += f"{i}. Function: {func_name}\n"
                 for j, (inp, exp) in enumerate(zip(test_case['inputs'], test_case['expected_outputs'])):
@@ -185,7 +197,7 @@ class BenchmarkRunner:
 
             enhanced_description = (
                 f"{benchmark.task_prompt}{test_cases_text}"
-                "\nFocus on these exact test cases - do not invent additional ones."
+                "\nFocus on the requested behavior and the examples above."
             )
 
             task = Task(

--- a/scripts/verify_demo_path.py
+++ b/scripts/verify_demo_path.py
@@ -72,6 +72,7 @@ async def _verify_humaneval_reference(project_root: Path) -> dict[str, Any]:
         use_sandbox=False,
     )
     expected = {
+        "humaneval_headroom",
         "humaneval_style",
         "list_processing",
         "simple_algorithm",
@@ -125,6 +126,37 @@ async def _verify_score_movement(project_root: Path) -> dict[str, Any]:
         "baseline_score": report["baseline"]["score"],
         "candidate_score": report["candidate"]["score"],
         "delta": report["delta"],
+    }
+
+
+async def _verify_live_headroom_score_movement(project_root: Path) -> dict[str, Any]:
+    report = await compare_solutions(
+        benchmarks_dir=project_root / "config" / "benchmarks",
+        benchmark_name="humaneval_headroom",
+        baseline_path=project_root / "docs" / "demo" / "humaneval_headroom_baseline.py",
+        candidate_path=project_root / "docs" / "demo" / "humaneval_headroom_improved.py",
+    )
+    checked_in = _load_json(
+        project_root / "docs" / "demo" / "humaneval_headroom_score_movement.json"
+    )
+
+    _require(report["baseline"]["score"] <= 0.75, "Expected headroom baseline score <= 0.75")
+    _require(report["candidate"]["score"] == 1.0, "Expected headroom candidate score 1.0")
+    _require(report["delta"] >= 0.25, "Expected headroom score delta >= 0.25")
+    _require(checked_in["baseline"]["score"] == report["baseline"]["score"], "Stale headroom baseline JSON report")
+    _require(checked_in["candidate"]["score"] == report["candidate"]["score"], "Stale headroom candidate JSON report")
+    _require(checked_in["delta"] == report["delta"], "Stale headroom delta JSON report")
+
+    return {
+        "name": "live_headroom_score_movement_demo",
+        "status": "ok",
+        "benchmark": report["benchmark"],
+        "baseline_score": report["baseline"]["score"],
+        "candidate_score": report["candidate"]["score"],
+        "delta": report["delta"],
+        "baseline_passed": report["baseline"]["passed"],
+        "candidate_passed": report["candidate"]["passed"],
+        "total": report["candidate"]["total"],
     }
 
 
@@ -422,7 +454,11 @@ async def verify_demo_path(project_root: Path = PROJECT_ROOT) -> list[dict[str, 
         project_root / "requirements.txt",
         project_root / "config" / "dgm_config.yaml",
         project_root / "config" / "live_score_movement.yaml",
+        project_root / "config" / "benchmarks" / "humaneval_headroom.yaml",
         project_root / "config" / "benchmarks" / "humaneval_style.yaml",
+        project_root / "docs" / "demo" / "humaneval_headroom_baseline.py",
+        project_root / "docs" / "demo" / "humaneval_headroom_improved.py",
+        project_root / "docs" / "demo" / "humaneval_headroom_score_movement.json",
         project_root / "docs" / "demo" / "humaneval_style_baseline.py",
         project_root / "docs" / "demo" / "humaneval_style_improved.py",
         project_root / "docs" / "demo" / "humaneval_score_movement.json",
@@ -430,6 +466,7 @@ async def verify_demo_path(project_root: Path = PROJECT_ROOT) -> list[dict[str, 
     checks.extend(_check_file(path, project_root) for path in required_files)
     checks.append(await _verify_humaneval_reference(project_root))
     checks.append(await _verify_score_movement(project_root))
+    checks.append(await _verify_live_headroom_score_movement(project_root))
     checks.append(_verify_live_run_docs(project_root))
     checks.append(_verify_live_score_movement_attempt_docs(project_root))
     checks.append(_verify_archive_lineage(project_root))

--- a/scripts/verify_live_score_movement_plan.py
+++ b/scripts/verify_live_score_movement_plan.py
@@ -59,6 +59,24 @@ def _require_under_run_dir(path_text: str, project_root: Path, run_dir: Path) ->
     return str(relative_path)
 
 
+def _require_project_file(path_text: str, project_root: Path) -> Path:
+    relative_path = _project_relative(path_text, project_root)
+    path = project_root / relative_path
+    _require(path.is_file(), f"Missing required project file: {relative_path}")
+    return path
+
+
+def _case_pairs(cases: list[dict[str, Any]]) -> set[tuple[str, str, str]]:
+    pairs = set()
+    for case in cases:
+        function_name = str(case.get("function_name", "solve"))
+        inputs = case.get("inputs", [])
+        expected_outputs = case.get("expected_outputs", [])
+        for raw_input, raw_expected in zip(inputs, expected_outputs):
+            pairs.add((function_name, str(raw_input), str(raw_expected)))
+    return pairs
+
+
 def verify_live_score_movement_plan(
     config_path: Path = PROJECT_ROOT / "config" / "live_score_movement.yaml",
     *,
@@ -80,7 +98,7 @@ def verify_live_score_movement_plan(
 
     benchmark_config = config.get("benchmarks", {})
     enabled = benchmark_config.get("enabled", [])
-    _require(enabled == ["humaneval_style"], "Live score-movement run must target humaneval_style only")
+    _require(enabled == ["humaneval_headroom"], "Live score-movement run must target humaneval_headroom only")
     _require(
         benchmark_config.get("max_attempts", 0) <= 3,
         "Benchmark max_attempts must stay <= 3",
@@ -122,6 +140,63 @@ def verify_live_score_movement_plan(
     _require(live_run.get("purpose") == "live_score_movement_rehearsal", "Missing live-run purpose")
     _require(live_run.get("approval_required") is True, "Live run must require explicit approval")
     _require(live_run.get("recommended_generations") == 2, "Recommended generations must be 2")
+
+    headroom_gate = live_run.get("headroom_gate", {})
+    _require(headroom_gate.get("benchmark") == enabled[0], "Headroom gate benchmark must match enabled benchmark")
+    _require(
+        headroom_gate.get("prompt_examples_are_public_only") is True,
+        "Headroom gate must require public-only prompt examples",
+    )
+    benchmark_path = project_root / "config" / "benchmarks" / f"{enabled[0]}.yaml"
+    benchmark_data = _load_yaml(benchmark_path)
+    prompt_cases = benchmark_data.get("prompt_test_cases")
+    test_cases = benchmark_data.get("test_cases")
+    _require(prompt_cases, "Headroom benchmark must define prompt_test_cases")
+    _require(test_cases, "Headroom benchmark must define hidden evaluation test_cases")
+    prompt_pairs = _case_pairs(prompt_cases)
+    test_pairs = _case_pairs(test_cases)
+    _require(prompt_pairs, "Headroom benchmark prompt examples must not be empty")
+    _require(test_pairs, "Headroom benchmark evaluation cases must not be empty")
+    _require(
+        prompt_pairs.issubset(test_pairs),
+        "Headroom benchmark prompt examples must be included in evaluation cases",
+    )
+    _require(
+        len(test_pairs) > len(prompt_pairs),
+        "Headroom benchmark must include hidden evaluation cases beyond prompt examples",
+    )
+
+    baseline_path = _require_project_file(headroom_gate.get("baseline_solution", ""), project_root)
+    candidate_path = _require_project_file(headroom_gate.get("candidate_solution", ""), project_root)
+    report_path = _require_project_file(headroom_gate.get("score_report", ""), project_root)
+    try:
+        score_report = json.loads(report_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise LiveRunPlanError(f"Invalid headroom score report JSON: {report_path}: {exc}") from exc
+    baseline_score = float(score_report.get("baseline", {}).get("score", -1))
+    candidate_score = float(score_report.get("candidate", {}).get("score", -1))
+    delta = float(score_report.get("delta", -1))
+    _require(score_report.get("benchmark") == enabled[0], "Headroom score report benchmark mismatch")
+    _require(
+        Path(score_report.get("baseline", {}).get("path", "")) == baseline_path.relative_to(project_root),
+        "Headroom score report baseline path mismatch",
+    )
+    _require(
+        Path(score_report.get("candidate", {}).get("path", "")) == candidate_path.relative_to(project_root),
+        "Headroom score report candidate path mismatch",
+    )
+    _require(
+        baseline_score <= float(headroom_gate.get("max_baseline_score", 0)),
+        "Headroom baseline score is too high for a live score-movement rehearsal",
+    )
+    _require(
+        candidate_score >= float(headroom_gate.get("min_candidate_score", 1)),
+        "Headroom candidate score is below the required reference score",
+    )
+    _require(
+        delta >= float(headroom_gate.get("min_delta", 0)),
+        "Headroom score delta is too small for a live score-movement rehearsal",
+    )
 
     cost_gate = live_run.get("cost_gate", {})
     _require(
@@ -205,6 +280,11 @@ def verify_live_score_movement_plan(
         "requires_current_pricing_check": True,
         "requires_full_process_sandbox": True,
         "requires_scorecard_improvement": True,
+        "requires_headroom_gate": True,
+        "headroom_baseline_score": baseline_score,
+        "headroom_candidate_score": candidate_score,
+        "headroom_delta": delta,
+        "headroom_score_report": str(report_path.relative_to(project_root)),
         "pricing_checked_at": str(cost_gate["pricing_checked_at"]),
         "input_price_per_mtok": cost_estimate["input_price_per_mtok"],
         "output_price_per_mtok": cost_estimate["output_price_per_mtok"],

--- a/tests/integration/test_benchmark_evaluation.py
+++ b/tests/integration/test_benchmark_evaluation.py
@@ -115,6 +115,48 @@ class TestBenchmarkEvaluationPipeline:
         avg = self.runner.get_average_score(results)
         assert avg == pytest.approx(0.7)
 
+    async def test_prompt_test_cases_are_public_examples_only(self, tmp_path):
+        bdir = tmp_path / "hidden_benchmarks"
+        bdir.mkdir()
+        cfg = {
+            "name": "hidden_add",
+            "description": "Add two numbers",
+            "task_prompt": "Implement add(a, b).",
+            "prompt_test_cases": [
+                {
+                    "function_name": "add",
+                    "inputs": ["1, 2"],
+                    "expected_outputs": ["3"],
+                }
+            ],
+            "test_cases": [
+                {
+                    "function_name": "add",
+                    "inputs": ["10, 20"],
+                    "expected_outputs": ["30"],
+                }
+            ],
+            "timeout": 10,
+            "scoring_method": "partial",
+        }
+        (bdir / "hidden_add.yaml").write_text(yaml.safe_dump(cfg))
+        runner = BenchmarkRunner(benchmarks_dir=str(bdir), use_sandbox=False)
+        captured = {}
+
+        class CapturingAgent:
+            agent_id = "agent"
+
+            async def solve_task(self, task):
+                captured["description"] = task.description
+                return {"solution": "def add(a, b):\n    return a + b\n"}
+
+        result = await runner.run_benchmark(CapturingAgent(), "hidden_add")
+
+        assert result.score == pytest.approx(1.0)
+        assert "PUBLIC EXAMPLES" in captured["description"]
+        assert "1, 2" in captured["description"]
+        assert "10, 20" not in captured["description"]
+
 
 async def test_humaneval_style_reference_solution_passes():
     """The shipped HumanEval-style pack must be verified without API calls."""

--- a/tests/integration/test_benchmark_score_movement_demo.py
+++ b/tests/integration/test_benchmark_score_movement_demo.py
@@ -24,3 +24,24 @@ async def test_demo_solutions_show_score_movement():
     assert report["baseline"]["total"] == 20
     assert report["candidate"]["passed"] == 20
     assert report["candidate"]["total"] == 20
+
+
+@pytest.mark.asyncio
+async def test_headroom_demo_solutions_show_hidden_case_score_movement():
+    project_root = Path(__file__).resolve().parents[2]
+
+    report = await compare_solutions(
+        benchmarks_dir=project_root / "config" / "benchmarks",
+        benchmark_name="humaneval_headroom",
+        baseline_path=project_root / "docs" / "demo" / "humaneval_headroom_baseline.py",
+        candidate_path=project_root / "docs" / "demo" / "humaneval_headroom_improved.py",
+    )
+
+    assert report["benchmark"] == "humaneval_headroom"
+    assert report["baseline"]["score"] == pytest.approx(10 / 17)
+    assert report["candidate"]["score"] == pytest.approx(1.0)
+    assert report["delta"] == pytest.approx(7 / 17)
+    assert report["baseline"]["passed"] == 10
+    assert report["baseline"]["total"] == 17
+    assert report["candidate"]["passed"] == 17
+    assert report["candidate"]["total"] == 17

--- a/tests/integration/test_demo_path_verifier.py
+++ b/tests/integration/test_demo_path_verifier.py
@@ -14,6 +14,7 @@ async def test_no_network_demo_path_verifier_passes():
 
     assert "humaneval_reference" in names
     assert "score_movement_demo" in names
+    assert "live_headroom_score_movement_demo" in names
     assert "live_run_docs" in names
     assert "archive_lineage_artifact" in names
     assert "sandbox_runner_cli" in names
@@ -24,6 +25,14 @@ async def test_no_network_demo_path_verifier_passes():
     assert score_check["baseline_score"] == 0.5
     assert score_check["candidate_score"] == 1.0
     assert score_check["delta"] == 0.5
+
+    headroom_check = next(
+        check for check in checks if check["name"] == "live_headroom_score_movement_demo"
+    )
+    assert headroom_check["benchmark"] == "humaneval_headroom"
+    assert headroom_check["baseline_score"] == pytest.approx(10 / 17)
+    assert headroom_check["candidate_score"] == 1.0
+    assert headroom_check["delta"] == pytest.approx(7 / 17)
 
     live_run_check = next(check for check in checks if check["name"] == "live_run_docs")
     assert live_run_check["scorecard"] == "docs/live-runs/2026-06-12-proof/scorecard.json"
@@ -47,12 +56,16 @@ async def test_no_network_demo_path_verifier_passes():
     live_plan_check = next(
         check for check in checks if check["name"] == "live_score_movement_plan"
     )
-    assert live_plan_check["benchmark"] == "humaneval_style"
+    assert live_plan_check["benchmark"] == "humaneval_headroom"
     assert live_plan_check["recommended_generations"] == 2
     assert live_plan_check["approval_required"] is True
     assert live_plan_check["requires_current_pricing_check"] is True
     assert live_plan_check["requires_full_process_sandbox"] is True
     assert live_plan_check["requires_scorecard_improvement"] is True
+    assert live_plan_check["requires_headroom_gate"] is True
+    assert live_plan_check["headroom_baseline_score"] == pytest.approx(10 / 17)
+    assert live_plan_check["headroom_candidate_score"] == 1.0
+    assert live_plan_check["headroom_delta"] == pytest.approx(7 / 17)
     assert live_plan_check["request_ceiling"] == 25
     assert live_plan_check["estimated_total_cost_usd"] == pytest.approx(4.518)
     assert live_plan_check["max_estimated_cost_usd"] == 5

--- a/tests/unit/test_estimate_live_run_cost.py
+++ b/tests/unit/test_estimate_live_run_cost.py
@@ -22,7 +22,7 @@ def test_estimate_live_score_movement_cost_from_config():
     )
 
     assert estimate["model"] == "claude-sonnet-4-6"
-    assert estimate["enabled_benchmarks"] == ["humaneval_style"]
+    assert estimate["enabled_benchmarks"] == ["humaneval_headroom"]
     assert estimate["benchmark_count"] == 1
     assert estimate["generations"] == 2
     assert estimate["max_agent_steps"] == 5

--- a/tests/unit/test_verify_live_score_movement_plan.py
+++ b/tests/unit/test_verify_live_score_movement_plan.py
@@ -32,7 +32,7 @@ def test_live_score_movement_plan_verifies_default_config():
     report = verify_live_score_movement_plan(project_root=project_root)
 
     assert report["config"] == "config/live_score_movement.yaml"
-    assert report["benchmark"] == "humaneval_style"
+    assert report["benchmark"] == "humaneval_headroom"
     assert report["recommended_generations"] == 2
     assert report["max_agent_steps"] == 5
     assert report["max_output_tokens_per_call"] == 2048
@@ -41,6 +41,11 @@ def test_live_score_movement_plan_verifies_default_config():
     assert report["requires_current_pricing_check"] is True
     assert report["requires_full_process_sandbox"] is True
     assert report["requires_scorecard_improvement"] is True
+    assert report["requires_headroom_gate"] is True
+    assert report["headroom_baseline_score"] == pytest.approx(10 / 17)
+    assert report["headroom_candidate_score"] == 1.0
+    assert report["headroom_delta"] == pytest.approx(7 / 17)
+    assert report["headroom_score_report"] == "docs/demo/humaneval_headroom_score_movement.json"
     assert report["pricing_checked_at"] == "2026-06-15"
     assert report["input_price_per_mtok"] == 3
     assert report["output_price_per_mtok"] == 15
@@ -65,10 +70,20 @@ def test_live_score_movement_plan_rejects_unapproved_run(tmp_path):
 def test_live_score_movement_plan_rejects_extra_benchmarks(tmp_path):
     project_root = Path(__file__).resolve().parents[2]
     plan = deepcopy(_load_default_plan(project_root))
-    plan["benchmarks"]["enabled"] = ["humaneval_style", "list_processing"]
+    plan["benchmarks"]["enabled"] = ["humaneval_headroom", "list_processing"]
     config_path = _write_plan(tmp_path, plan)
 
-    with pytest.raises(LiveRunPlanError, match="humaneval_style only"):
+    with pytest.raises(LiveRunPlanError, match="humaneval_headroom only"):
+        verify_live_score_movement_plan(config_path, project_root=project_root)
+
+
+def test_live_score_movement_plan_rejects_missing_headroom(tmp_path):
+    project_root = Path(__file__).resolve().parents[2]
+    plan = deepcopy(_load_default_plan(project_root))
+    plan["live_run"]["headroom_gate"]["max_baseline_score"] = 0.1
+    config_path = _write_plan(tmp_path, plan)
+
+    with pytest.raises(LiveRunPlanError, match="baseline score is too high"):
         verify_live_score_movement_plan(config_path, project_root=project_root)
 
 
@@ -80,4 +95,4 @@ def test_live_score_movement_plan_cli_json(capsys):
 
     assert exit_code == 0
     assert '"status": "ok"' in captured.out
-    assert '"benchmark": "humaneval_style"' in captured.out
+    assert '"benchmark": "humaneval_headroom"' in captured.out


### PR DESCRIPTION
## Summary

- Add `humaneval_headroom`, a HumanEval-style benchmark with public prompt examples and broader hidden evaluation cases.
- Point `config/live_score_movement.yaml` at the new headroom benchmark and require a committed no-network headroom gate before another live score-movement run is treated as ready.
- Extend the benchmark runner, demo verifier, README, and tests so the live rehearsal target has measured score headroom: baseline `10/17` (`0.588`), candidate `17/17` (`1.000`), delta `+0.412`.

## Why

The prior bounded live run proved a real sandboxed provider-backed DGM cycle, but the scorecard failed closed because the initial parent already scored `1.000` on `humaneval_style`. This change moves the next live rehearsal to a benchmark that does not expose every scored input/output pair in the prompt and verifies local headroom before API budget is spent again.

## Validation

- `PATH="$PWD/.venv/bin:$PATH" python scripts/verify_live_score_movement_plan.py`
- `PATH="$PWD/.venv/bin:$PATH" python scripts/verify_demo_path.py`
- `PATH="$PWD/.venv/bin:$PATH" python scripts/estimate_live_run_cost.py --input-price-per-mtok 3 --output-price-per-mtok 15 --assumed-input-tokens-per-call 50000 --max-budget 5`
- `PATH="$PWD/.venv/bin:$PATH" python -m pytest`

Result: `228 passed, 7 skipped, 2 warnings`.