### PR TITLE
[codex] isolate benchmark evaluation workspaces

### DIFF
--- a/dgm_controller.py
+++ b/dgm_controller.py
@@ -9,6 +9,7 @@ import asyncio
 import logging
 import json
 import os
+import tempfile
 from datetime import datetime
 from pathlib import Path
 from typing import Dict, Any, Optional, List, Tuple
@@ -579,42 +580,45 @@ performance."""
             try:
                 logger.info(f"Running benchmark: {benchmark_name}")
 
-                # Create minimal agent config for evaluation
+                # Create minimal agent config for evaluation. Benchmark tasks
+                # get a scratch workspace so generated solution files do not
+                # modify the agent source directory being evaluated.
                 primary_provider = self.config['fm_providers']['primary']
                 provider_config = self.config['fm_providers'][primary_provider]
 
                 agent_path_obj = Path(agent_path)
-                agent_config = AgentConfig(
-                    agent_id=f"eval_{agent_path_obj.stem}_{benchmark_name}",
-                    fm_provider=primary_provider,
-                    fm_config=provider_config,
-                    working_directory=str(agent_path_obj.parent),
-                    max_iterations=self.config['agents'].get('max_steps', 20),
-                    sandbox_manager=self.sandbox_manager,
-                    use_sandbox=self.use_sandbox,
-                )
-
-                # Load the agent class from the file path using load_from_path,
-                # which handles all file paths correctly and avoids sys.modules
-                # collisions.  Fall back to the default Agent only when the file
-                # doesn't exist.
-                if agent_path_obj.exists():
-                    AgentClass = self.agent_loader.load_from_path(agent_path_obj)
-                else:
-                    logger.warning(
-                        f"Agent file not found at {agent_path_obj}, using default Agent"
+                with tempfile.TemporaryDirectory(prefix="dgm-benchmark-") as benchmark_workspace:
+                    agent_config = AgentConfig(
+                        agent_id=f"eval_{agent_path_obj.stem}_{benchmark_name}",
+                        fm_provider=primary_provider,
+                        fm_config=provider_config,
+                        working_directory=benchmark_workspace,
+                        max_iterations=self.config['agents'].get('max_steps', 20),
+                        sandbox_manager=self.sandbox_manager,
+                        use_sandbox=self.use_sandbox,
                     )
-                    AgentClass = Agent
 
-                # Create agent instance
-                agent = AgentClass(agent_config)
+                    # Load the agent class from the file path using load_from_path,
+                    # which handles all file paths correctly and avoids sys.modules
+                    # collisions.  Fall back to the default Agent only when the file
+                    # doesn't exist.
+                    if agent_path_obj.exists():
+                        AgentClass = self.agent_loader.load_from_path(agent_path_obj)
+                    else:
+                        logger.warning(
+                            f"Agent file not found at {agent_path_obj}, using default Agent"
+                        )
+                        AgentClass = Agent
 
-                # Run benchmark — result.score is the pre-computed pass fraction
-                result = await self.benchmark_runner.run_benchmark(
-                    agent=agent,
-                    benchmark_name=benchmark_name,
-                    verbose=False
-                )
+                    # Create agent instance
+                    agent = AgentClass(agent_config)
+
+                    # Run benchmark — result.score is the pre-computed pass fraction
+                    result = await self.benchmark_runner.run_benchmark(
+                        agent=agent,
+                        benchmark_name=benchmark_name,
+                        verbose=False
+                    )
 
                 scores[benchmark_name] = result.score
                 logger.info(f"{benchmark_name} score: {result.score:.3f}")

--- a/tests/unit/test_dgm_controller.py
+++ b/tests/unit/test_dgm_controller.py
@@ -346,6 +346,10 @@ class TestDGMControllerInit:
             captured["agent"] = agent
             captured["benchmark_name"] = benchmark_name
             captured["verbose"] = verbose
+            Path(agent.config.working_directory, "solution.py").write_text(
+                "generated scratch solution\n",
+                encoding="utf-8",
+            )
             return SimpleNamespace(score=0.75)
 
         ctrl.benchmark_runner.run_benchmark = fake_run_benchmark
@@ -355,7 +359,10 @@ class TestDGMControllerInit:
         assert scores == {"dummy": 0.75}
         assert captured["config"].sandbox_manager is ctrl.sandbox_manager
         assert captured["config"].use_sandbox is True
-        assert captured["config"].working_directory == str(agent_file.parent)
+        assert captured["config"].working_directory != str(agent_file.parent)
+        assert "dgm-benchmark-" in Path(captured["config"].working_directory).name
+        assert not (agent_file.parent / "solution.py").exists()
+        assert not Path(captured["config"].working_directory).exists()
         assert captured["agent"].config is captured["config"]
         assert captured["benchmark_name"] == "dummy"
         assert captured["verbose"] is False


### PR DESCRIPTION
## Summary

- Run DGM benchmark evaluation agents from temporary scratch workspaces instead of the evaluated agent source directory.
- Keep loading candidate agent code from its real source path, but keep generated benchmark files like `solution.py` out of that source tree.
- Add a regression assertion that a simulated generated `solution.py` does not appear beside the candidate agent and that the scratch workspace is cleaned up.

## Why

The bounded live run exposed that benchmark-solving scratch files can be written next to agent source and then sync back from the full-process sandbox. This fix removes that source-tree side effect without changing benchmark scoring behavior.

## Validation

- `PATH="$PWD/.venv/bin:$PATH" python -m pytest tests/unit/test_dgm_controller.py`
- `PATH="$PWD/.venv/bin:$PATH" python -m pytest`

Result: `225 passed, 7 skipped, 2 warnings`.