### PR TITLE
[codex] record live headroom run artifact

### DIFF
--- a/docs/live-runs/live-score-movement/README.md
+++ b/docs/live-runs/live-score-movement/README.md
@@ -4,12 +4,12 @@ Run date: 2026-06-15
 
 This was a bounded live DGM run for `config/live_score_movement.yaml`. It was
 intended to prove that the cost-gated, full-process Docker runner can execute a
-real provider-backed DGM cycle against `humaneval_style` and then fail closed if
-there is no parent-child score improvement.
+real provider-backed DGM cycle against `humaneval_headroom` and then fail closed
+if there is no parent-child score improvement.
 
 Preflight gates passed before the live call:
 
-- `python -m pytest`: 225 passed, 7 skipped
+- `python -m pytest`: 228 passed, 7 skipped
 - `python scripts/verify_demo_path.py`
 - `python scripts/verify_sandbox_docker.py --require`
 - `python scripts/verify_live_score_movement_plan.py`
@@ -31,17 +31,19 @@ Observed live evidence:
   name and hid the value.
 - The run logged successful `POST https://api.anthropic.com/v1/messages`
   responses from Anthropic.
+- The run logged 22 Anthropic API usage records.
 - The DGM controller completed two generations and wrote
-  `.dgm-live-runs/live-score-movement/results/dgm_report_20260615_154225.json`.
+  `.dgm-live-runs/live-score-movement/results/dgm_report_20260615_224945.json`.
 
 Outcome:
 
 - The archive contained 3 valid agents.
-- Top score remained `1.000`.
+- Top score was `0.8823529411764706` (`15/17`) on `humaneval_headroom`.
 - Best parent-child average-score delta was `+0.000`.
 - `scripts/summarize_archive_scores.py --require-improvement` failed as
   designed because `has_improvement` is `false`.
 
 This proves a fully live, sandboxed, provider-backed DGM run completed. It does
-not prove benchmark improvement. The configured benchmark still needs a live
-score-movement setup where the initial parent has measurable headroom.
+not prove benchmark improvement. The configured benchmark did have hidden-case
+headroom, but the initial parent already solved most cases and neither child
+improved on it in this bounded two-generation run.

--- a/docs/live-runs/live-score-movement/scorecard.json
+++ b/docs/live-runs/live-score-movement/scorecard.json
@@ -3,18 +3,18 @@
   "best_average_delta": 0.0,
   "generation_best_scores": [
     {
-      "agent_id": "f47d2466-708d-44f4-86be-c16a61580204",
-      "average_score": 1.0,
+      "agent_id": "5719cca2-7188-4ed3-b805-603252f204c3",
+      "average_score": 0.8823529411764706,
       "benchmark_scores": {
-        "humaneval_style": 1.0
+        "humaneval_headroom": 0.8823529411764706
       },
       "generation": 0
     },
     {
-      "agent_id": "84bb0743-82d1-462b-895b-9cae24dd5d4f",
-      "average_score": 1.0,
+      "agent_id": "aaace30a-fdc4-465b-892a-83bbcf1d1c75",
+      "average_score": 0.8823529411764706,
       "benchmark_scores": {
-        "humaneval_style": 1.0
+        "humaneval_headroom": 0.8823529411764706
       },
       "generation": 1
     }
@@ -26,32 +26,32 @@
     {
       "average_delta": 0.0,
       "benchmark_deltas": {
-        "humaneval_style": 0.0
+        "humaneval_headroom": 0.0
       },
-      "child_average_score": 1.0,
+      "child_average_score": 0.8823529411764706,
       "child_generation": 1,
-      "child_id": "84bb0743-82d1-462b-895b-9cae24dd5d4f",
+      "child_id": "aaace30a-fdc4-465b-892a-83bbcf1d1c75",
       "is_improvement": false,
-      "parent_average_score": 1.0,
+      "parent_average_score": 0.8823529411764706,
       "parent_generation": 0,
-      "parent_id": "f47d2466-708d-44f4-86be-c16a61580204"
+      "parent_id": "5719cca2-7188-4ed3-b805-603252f204c3"
     },
     {
-      "average_delta": -1.0,
+      "average_delta": -0.8823529411764706,
       "benchmark_deltas": {
-        "humaneval_style": -1.0
+        "humaneval_headroom": -0.8823529411764706
       },
       "child_average_score": 0.0,
       "child_generation": 1,
-      "child_id": "d73027b2-b348-4c3a-8b9a-fa90ffb29c05",
+      "child_id": "509181a6-d257-4bbc-a5da-9c6a9b01bff8",
       "is_improvement": false,
-      "parent_average_score": 1.0,
+      "parent_average_score": 0.8823529411764706,
       "parent_generation": 0,
-      "parent_id": "f47d2466-708d-44f4-86be-c16a61580204"
+      "parent_id": "5719cca2-7188-4ed3-b805-603252f204c3"
     }
   ],
-  "top_agent_id": "f47d2466-708d-44f4-86be-c16a61580204",
-  "top_score": 1.0,
+  "top_agent_id": "5719cca2-7188-4ed3-b805-603252f204c3",
+  "top_score": 0.8823529411764706,
   "total_agents": 3,
   "valid_agents": 3
 }

--- a/scripts/verify_demo_path.py
+++ b/scripts/verify_demo_path.py
@@ -231,10 +231,20 @@ def _verify_live_score_movement_attempt_docs(project_root: Path) -> dict[str, An
     scorecard_json = _load_json(scorecard)
     _require(scorecard_json["total_agents"] == 3, "Live scorecard must record three agents")
     _require(scorecard_json["valid_agents"] == 3, "Live scorecard must record three valid agents")
-    _require(scorecard_json["top_score"] == 1.0, "Live scorecard top score must be 1.0")
+    _require(
+        abs(scorecard_json["top_score"] - (15 / 17)) < 1e-12,
+        "Live scorecard top score must record the approved headroom run",
+    )
     _require(
         scorecard_json["best_average_delta"] == 0.0,
         "Live scorecard must record zero best average-score delta",
+    )
+    _require(
+        all(
+            "humaneval_headroom" in item["benchmark_scores"]
+            for item in scorecard_json["generation_best_scores"]
+        ),
+        "Live scorecard must use the headroom benchmark",
     )
     _require(
         scorecard_json["has_improvement"] is False,

--- a/tests/integration/test_demo_path_verifier.py
+++ b/tests/integration/test_demo_path_verifier.py
@@ -20,6 +20,7 @@ async def test_no_network_demo_path_verifier_passes():
     assert "sandbox_runner_cli" in names
     assert "sandbox_discard_changes_contract" in names
     assert "live_score_movement_plan" in names
+    assert "live_score_movement_attempt_docs" in names
 
     score_check = next(check for check in checks if check["name"] == "score_movement_demo")
     assert score_check["baseline_score"] == 0.5
@@ -39,6 +40,15 @@ async def test_no_network_demo_path_verifier_passes():
     assert live_run_check["top_score"] == 1.0
     assert live_run_check["best_average_delta"] == 0.0
     assert live_run_check["has_improvement"] is False
+
+    live_attempt_check = next(
+        check for check in checks if check["name"] == "live_score_movement_attempt_docs"
+    )
+    assert live_attempt_check["scorecard"] == "docs/live-runs/live-score-movement/scorecard.json"
+    assert live_attempt_check["top_score"] == pytest.approx(15 / 17)
+    assert live_attempt_check["best_average_delta"] == 0.0
+    assert live_attempt_check["has_improvement"] is False
+    assert live_attempt_check["audit_hides_env_values"] is True
 
     sandbox_check = next(check for check in checks if check["name"] == "sandbox_runner_cli")
     assert "--discard-changes" in sandbox_check["safe_flags"]


### PR DESCRIPTION

## Summary
- record the approved 2026-06-15 live headroom run against humaneval_headroom
- update the scorecard to the fresh run: top score 15/17, best delta +0.000, no improvement
- update the demo-path verifier so the checked-in non-improvement artifact stays honest

## Result
- Proves a fully live, sandboxed, provider-backed DGM run completed.
- Does not prove benchmark improvement; the require-improvement scorecard gate failed as designed.

## Verification
- approved live sandbox run completed with Anthropic network calls
- scorecard generation with require-improvement failed with no improvement, as expected
- .venv/bin/python scripts/verify_demo_path.py
- .venv/bin/python -m pytest tests/integration/test_demo_path_verifier.py tests/unit/test_summarize_archive_scores.py
- .venv/bin/python -m pytest
