### PR TITLE
[codex] add calibrated live eval pack

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,9 +240,10 @@ verified by the integration test suite; add `humaneval_style` to
 `benchmarks.enabled` when you want the DGM loop to evaluate against it.
 
 For live score-movement rehearsals, see
-`config/benchmarks/humaneval_headroom.yaml`. It uses public prompt examples plus
-additional hidden evaluation cases so the benchmark can show measurable
-headroom instead of handing every scored input/output pair to the agent.
+`config/benchmarks/humaneval_calibrated.yaml`. It uses 10 public prompt
+examples and 50 scored evaluation cases across 10 standalone functions, so the
+benchmark has broader hidden-case headroom than the earlier single-pack
+`humaneval_headroom` rehearsal.
 
 To demonstrate benchmark score movement without API keys or model calls, compare
 the bundled weak and improved HumanEval-style demo solutions:
@@ -259,19 +260,21 @@ This local comparison should report a baseline score of `0.500`, a candidate
 score of `1.000`, and `delta=+0.500`. It verifies the benchmark harness and
 reporting path; it is not evidence of autonomous DGM self-improvement.
 
-The planned live rehearsal uses the hidden-case headroom benchmark. Its
+The planned live rehearsal uses the calibrated hidden-case benchmark. Its
 no-network headroom check is:
 
 ```bash
 python scripts/compare_benchmark_solutions.py \
-  --benchmark humaneval_headroom \
-  --baseline docs/demo/humaneval_headroom_baseline.py \
-  --candidate docs/demo/humaneval_headroom_improved.py \
-  --output docs/demo/humaneval_headroom_score_movement.json
+  --benchmark humaneval_calibrated \
+  --baseline docs/demo/humaneval_calibrated_baseline.py \
+  --candidate docs/demo/humaneval_calibrated_improved.py \
+  --output docs/demo/humaneval_calibrated_score_movement.json
 ```
 
-This should report a baseline score below `0.750`, a candidate score of
-`1.000`, and a positive delta of at least `+0.250`.
+This should report a baseline score of `0.600` (`30/50`), a candidate score of
+`1.000` (`50/50`), and `delta=+0.400`. The live plan verifier requires the
+baseline to stay in a calibrated `0.400` to `0.700` band so the task is neither
+already saturated nor too weak to be a useful score-movement target.
 
 For live DGM runs, summarize the generated archive metadata before claiming
 score movement:
@@ -291,7 +294,7 @@ the already-perfect base score.
 
 The planned live score-movement rehearsal is captured in
 `config/live_score_movement.yaml`. It is bounded to two generations, five agent
-steps, one benchmark (`humaneval_headroom`), and a 2,048-token output cap per
+steps, one benchmark (`humaneval_calibrated`), and a 2,048-token output cap per
 model call. Before any live provider call, run the no-network plan check and
 verify current provider pricing:
 

--- a/config/benchmarks/humaneval_calibrated.yaml
+++ b/config/benchmarks/humaneval_calibrated.yaml
@@ -1,0 +1,233 @@
+name: humaneval_calibrated
+description: Calibrated HumanEval-style pack with public examples and broad hidden evaluation cases
+difficulty: medium
+timeout: 30
+category: algorithms
+scoring_method: partial
+
+task_prompt: |
+  Implement the requested standalone Python functions. The examples below are
+  public examples only; evaluation includes additional hidden edge cases. Return
+  only Python code that defines the requested functions.
+
+prompt_test_cases:
+  - function_name: normalize_whitespace
+    task_description: strips leading/trailing whitespace and collapses internal whitespace runs
+    inputs:
+      - "'  hello  world  '"
+    expected_outputs:
+      - "'hello world'"
+
+  - function_name: first_unique
+    task_description: returns the first item that appears exactly once, or None
+    inputs:
+      - "[2, 1, 2, 3, 1]"
+    expected_outputs:
+      - "3"
+
+  - function_name: rotate_left
+    task_description: rotates a list left by n positions, wrapping around
+    inputs:
+      - "[1, 2, 3, 4], 1"
+    expected_outputs:
+      - "[2, 3, 4, 1]"
+
+  - function_name: is_valid_slug
+    task_description: accepts lowercase alphanumeric slugs separated by single hyphens
+    inputs:
+      - "'valid-slug-1'"
+    expected_outputs:
+      - "True"
+
+  - function_name: parse_ints
+    task_description: extracts signed integers from comma or whitespace separated text
+    inputs:
+      - "'1,2,3'"
+    expected_outputs:
+      - "[1, 2, 3]"
+
+  - function_name: flatten_once
+    task_description: flattens one list or tuple nesting level and leaves strings intact
+    inputs:
+      - "[[1, 2], 3, [4]]"
+    expected_outputs:
+      - "[1, 2, 3, 4]"
+
+  - function_name: merge_intervals
+    task_description: merges overlapping intervals after sorting by start position
+    inputs:
+      - "[(1, 3), (2, 4)]"
+    expected_outputs:
+      - "[(1, 4)]"
+
+  - function_name: top_k_frequent
+    task_description: returns the k most frequent items, breaking ties by first appearance
+    inputs:
+      - "['a', 'b', 'a', 'c', 'b', 'a'], 2"
+    expected_outputs:
+      - "['a', 'b']"
+
+  - function_name: roman_to_int
+    task_description: converts a Roman numeral string to an integer
+    inputs:
+      - "'III'"
+    expected_outputs:
+      - "3"
+
+  - function_name: safe_get
+    task_description: follows a path through dictionaries and lists, returning default if missing
+    inputs:
+      - "{'a': {'b': 2}}, ['a', 'b'], None"
+    expected_outputs:
+      - "2"
+
+test_cases:
+  - function_name: normalize_whitespace
+    task_description: strips leading/trailing whitespace and collapses internal whitespace runs
+    inputs:
+      - "'  hello  world  '"
+      - "'\\nalpha\\t beta\\n'"
+      - "'one    two   three'"
+      - "''"
+      - "' spaced '"
+    expected_outputs:
+      - "'hello world'"
+      - "'alpha beta'"
+      - "'one two three'"
+      - "''"
+      - "'spaced'"
+
+  - function_name: first_unique
+    task_description: returns the first item that appears exactly once, or None
+    inputs:
+      - "[2, 1, 2, 3, 1]"
+      - "['a', 'b', 'a']"
+      - "[1, 1]"
+      - "[]"
+      - "['x', 'y', 'x', 'z']"
+    expected_outputs:
+      - "3"
+      - "'b'"
+      - "None"
+      - "None"
+      - "'y'"
+
+  - function_name: rotate_left
+    task_description: rotates a list left by n positions, wrapping around
+    inputs:
+      - "[1, 2, 3, 4], 1"
+      - "[1, 2, 3], 4"
+      - "[], 3"
+      - "[1, 2, 3], 0"
+      - "['a', 'b', 'c'], -1"
+    expected_outputs:
+      - "[2, 3, 4, 1]"
+      - "[2, 3, 1]"
+      - "[]"
+      - "[1, 2, 3]"
+      - "['c', 'a', 'b']"
+
+  - function_name: is_valid_slug
+    task_description: accepts lowercase alphanumeric slugs separated by single hyphens
+    inputs:
+      - "'valid-slug-1'"
+      - "'-bad'"
+      - "'bad--slug'"
+      - "'Bad'"
+      - "'ok'"
+    expected_outputs:
+      - "True"
+      - "False"
+      - "False"
+      - "False"
+      - "True"
+
+  - function_name: parse_ints
+    task_description: extracts signed integers from comma or whitespace separated text
+    inputs:
+      - "'1,2,3'"
+      - "'1, 2, -3'"
+      - "''"
+      - "'4 -5 6'"
+      - "'7,,8'"
+    expected_outputs:
+      - "[1, 2, 3]"
+      - "[1, 2, -3]"
+      - "[]"
+      - "[4, -5, 6]"
+      - "[7, 8]"
+
+  - function_name: flatten_once
+    task_description: flattens one list or tuple nesting level and leaves strings intact
+    inputs:
+      - "[[1, 2], 3, [4]]"
+      - "[(1, 2), [3]]"
+      - "[]"
+      - "[[[]], 1]"
+      - "['ab', [1, 2]]"
+    expected_outputs:
+      - "[1, 2, 3, 4]"
+      - "[1, 2, 3]"
+      - "[]"
+      - "[[], 1]"
+      - "['ab', 1, 2]"
+
+  - function_name: merge_intervals
+    task_description: merges overlapping intervals after sorting by start position
+    inputs:
+      - "[(1, 3), (2, 4)]"
+      - "[(5, 6), (1, 3)]"
+      - "[]"
+      - "[(1, 2), (3, 4)]"
+      - "[(1, 5), (2, 3)]"
+    expected_outputs:
+      - "[(1, 4)]"
+      - "[(1, 3), (5, 6)]"
+      - "[]"
+      - "[(1, 2), (3, 4)]"
+      - "[(1, 5)]"
+
+  - function_name: top_k_frequent
+    task_description: returns the k most frequent items, breaking ties by first appearance
+    inputs:
+      - "['a', 'b', 'a', 'c', 'b', 'a'], 2"
+      - "[3, 3, 2, 1, 2, 2], 1"
+      - "[], 3"
+      - "['b', 'a', 'b', 'a'], 2"
+      - "[5, 4, 5, 4, 4, 5], 1"
+    expected_outputs:
+      - "['a', 'b']"
+      - "[2]"
+      - "[]"
+      - "['b', 'a']"
+      - "[5]"
+
+  - function_name: roman_to_int
+    task_description: converts a Roman numeral string to an integer
+    inputs:
+      - "'III'"
+      - "'IV'"
+      - "'IX'"
+      - "'LVIII'"
+      - "''"
+    expected_outputs:
+      - "3"
+      - "4"
+      - "9"
+      - "58"
+      - "0"
+
+  - function_name: safe_get
+    task_description: follows a path through dictionaries and lists, returning default if missing
+    inputs:
+      - "{'a': {'b': 2}}, ['a', 'b'], None"
+      - "{'a': [10]}, ['a', 0], None"
+      - "{}, ['x'], 'missing'"
+      - "{'a': None}, ['a', 'b'], 7"
+      - "[1, {'x': 3}], [1, 'x'], None"
+    expected_outputs:
+      - "2"
+      - "10"
+      - "'missing'"
+      - "7"
+      - "3"

--- a/config/live_score_movement.yaml
+++ b/config/live_score_movement.yaml
@@ -44,7 +44,7 @@ benchmarks:
   timeout_default: 30
   max_attempts: 3
   enabled:
-    - humaneval_headroom
+    - humaneval_calibrated
 
 logging:
   level: INFO
@@ -57,14 +57,15 @@ live_run:
   approval_required: true
   recommended_generations: 2
   headroom_gate:
-    benchmark: humaneval_headroom
+    benchmark: humaneval_calibrated
     prompt_examples_are_public_only: true
-    baseline_solution: docs/demo/humaneval_headroom_baseline.py
-    candidate_solution: docs/demo/humaneval_headroom_improved.py
-    score_report: docs/demo/humaneval_headroom_score_movement.json
-    max_baseline_score: 0.75
+    baseline_solution: docs/demo/humaneval_calibrated_baseline.py
+    candidate_solution: docs/demo/humaneval_calibrated_improved.py
+    score_report: docs/demo/humaneval_calibrated_score_movement.json
+    min_baseline_score: 0.4
+    max_baseline_score: 0.7
     min_candidate_score: 1.0
-    min_delta: 0.25
+    min_delta: 0.3
   cost_gate:
     check_current_provider_pricing_before_run: true
     pricing_source: https://platform.claude.com/docs/en/about-claude/pricing

--- a/docs/demo/humaneval_calibrated_baseline.py
+++ b/docs/demo/humaneval_calibrated_baseline.py
@@ -1,0 +1,59 @@
+def normalize_whitespace(text):
+    return text.strip().replace("  ", " ")
+
+
+def first_unique(items):
+    return items[0] if items else None
+
+
+def rotate_left(items, n):
+    return items[n:] + items[:n]
+
+
+def is_valid_slug(text):
+    return text != "" and text == text.lower() and " " not in text
+
+
+def parse_ints(text):
+    if not text.strip():
+        return []
+    return [int(part.strip()) for part in text.split(",")]
+
+
+def flatten_once(items):
+    result = []
+    for item in items:
+        if isinstance(item, list):
+            result.extend(item)
+        else:
+            result.append(item)
+    return result
+
+
+def merge_intervals(intervals):
+    merged = []
+    for start, end in intervals:
+        if not merged or start > merged[-1][1]:
+            merged.append((start, end))
+        else:
+            previous_start, previous_end = merged[-1]
+            merged[-1] = (previous_start, max(previous_end, end))
+    return merged
+
+
+def top_k_frequent(items, k):
+    return sorted(set(items))[:k]
+
+
+def roman_to_int(text):
+    values = {"I": 1, "V": 5, "X": 10, "L": 50, "C": 100, "D": 500, "M": 1000}
+    return sum(values[char] for char in text)
+
+
+def safe_get(data, path, default=None):
+    current = data
+    for key in path:
+        if not isinstance(current, dict) or key not in current:
+            return default
+        current = current[key]
+    return current

--- a/docs/demo/humaneval_calibrated_improved.py
+++ b/docs/demo/humaneval_calibrated_improved.py
@@ -1,0 +1,95 @@
+import re
+from collections import Counter
+
+
+def normalize_whitespace(text):
+    return " ".join(text.split())
+
+
+def first_unique(items):
+    counts = Counter(items)
+    for item in items:
+        if counts[item] == 1:
+            return item
+    return None
+
+
+def rotate_left(items, n):
+    if not items:
+        return []
+    offset = n % len(items)
+    return items[offset:] + items[:offset]
+
+
+def is_valid_slug(text):
+    if not text or text.startswith("-") or text.endswith("-"):
+        return False
+    if "--" in text:
+        return False
+    return all(char.islower() or char.isdigit() or char == "-" for char in text)
+
+
+def parse_ints(text):
+    return [int(match) for match in re.findall(r"[+-]?\d+", text)]
+
+
+def flatten_once(items):
+    result = []
+    for item in items:
+        if isinstance(item, (list, tuple)):
+            result.extend(item)
+        else:
+            result.append(item)
+    return result
+
+
+def merge_intervals(intervals):
+    merged = []
+    for start, end in sorted(intervals):
+        if not merged or start > merged[-1][1]:
+            merged.append((start, end))
+        else:
+            previous_start, previous_end = merged[-1]
+            merged[-1] = (previous_start, max(previous_end, end))
+    return merged
+
+
+def top_k_frequent(items, k):
+    first_index = {}
+    counts = Counter(items)
+    for index, item in enumerate(items):
+        first_index.setdefault(item, index)
+    ranked = sorted(counts, key=lambda item: (-counts[item], first_index[item]))
+    return ranked[:k]
+
+
+def roman_to_int(text):
+    values = {"I": 1, "V": 5, "X": 10, "L": 50, "C": 100, "D": 500, "M": 1000}
+    total = 0
+    index = 0
+    while index < len(text):
+        value = values[text[index]]
+        next_value = values[text[index + 1]] if index + 1 < len(text) else 0
+        if value < next_value:
+            total += next_value - value
+            index += 2
+        else:
+            total += value
+            index += 1
+    return total
+
+
+def safe_get(data, path, default=None):
+    current = data
+    for key in path:
+        if isinstance(current, dict):
+            if key not in current:
+                return default
+            current = current[key]
+        elif isinstance(current, (list, tuple)) and isinstance(key, int):
+            if key < 0 or key >= len(current):
+                return default
+            current = current[key]
+        else:
+            return default
+    return current

--- a/docs/demo/humaneval_calibrated_score_movement.json
+++ b/docs/demo/humaneval_calibrated_score_movement.json
@@ -1,0 +1,883 @@
+{
+  "baseline": {
+    "label": "baseline",
+    "passed": 30,
+    "path": "docs/demo/humaneval_calibrated_baseline.py",
+    "score": 0.6,
+    "test_cases": [
+      {
+        "function_name": "normalize_whitespace",
+        "individual_results": [
+          {
+            "actual_output": "'hello world'",
+            "error": null,
+            "expected_output": "'hello world'",
+            "input": "'  hello  world  '",
+            "success": true
+          },
+          {
+            "actual_output": "'alpha\\t beta'",
+            "error": null,
+            "expected_output": "'alpha beta'",
+            "input": "'\\nalpha\\t beta\\n'",
+            "success": false
+          },
+          {
+            "actual_output": "'one  two  three'",
+            "error": null,
+            "expected_output": "'one two three'",
+            "input": "'one    two   three'",
+            "success": false
+          },
+          {
+            "actual_output": "''",
+            "error": null,
+            "expected_output": "''",
+            "input": "''",
+            "success": true
+          },
+          {
+            "actual_output": "'spaced'",
+            "error": null,
+            "expected_output": "'spaced'",
+            "input": "' spaced '",
+            "success": true
+          }
+        ],
+        "passed": 3,
+        "success": false,
+        "total": 5
+      },
+      {
+        "function_name": "first_unique",
+        "individual_results": [
+          {
+            "actual_output": "2",
+            "error": null,
+            "expected_output": "3",
+            "input": "[2, 1, 2, 3, 1]",
+            "success": false
+          },
+          {
+            "actual_output": "'a'",
+            "error": null,
+            "expected_output": "'b'",
+            "input": "['a', 'b', 'a']",
+            "success": false
+          },
+          {
+            "actual_output": "1",
+            "error": null,
+            "expected_output": "None",
+            "input": "[1, 1]",
+            "success": false
+          },
+          {
+            "actual_output": "None",
+            "error": null,
+            "expected_output": "None",
+            "input": "[]",
+            "success": true
+          },
+          {
+            "actual_output": "'x'",
+            "error": null,
+            "expected_output": "'y'",
+            "input": "['x', 'y', 'x', 'z']",
+            "success": false
+          }
+        ],
+        "passed": 1,
+        "success": false,
+        "total": 5
+      },
+      {
+        "function_name": "rotate_left",
+        "individual_results": [
+          {
+            "actual_output": "[2, 3, 4, 1]",
+            "error": null,
+            "expected_output": "[2, 3, 4, 1]",
+            "input": "[1, 2, 3, 4], 1",
+            "success": true
+          },
+          {
+            "actual_output": "[1, 2, 3]",
+            "error": null,
+            "expected_output": "[2, 3, 1]",
+            "input": "[1, 2, 3], 4",
+            "success": false
+          },
+          {
+            "actual_output": "[]",
+            "error": null,
+            "expected_output": "[]",
+            "input": "[], 3",
+            "success": true
+          },
+          {
+            "actual_output": "[1, 2, 3]",
+            "error": null,
+            "expected_output": "[1, 2, 3]",
+            "input": "[1, 2, 3], 0",
+            "success": true
+          },
+          {
+            "actual_output": "['c', 'a', 'b']",
+            "error": null,
+            "expected_output": "['c', 'a', 'b']",
+            "input": "['a', 'b', 'c'], -1",
+            "success": true
+          }
+        ],
+        "passed": 4,
+        "success": false,
+        "total": 5
+      },
+      {
+        "function_name": "is_valid_slug",
+        "individual_results": [
+          {
+            "actual_output": "True",
+            "error": null,
+            "expected_output": "True",
+            "input": "'valid-slug-1'",
+            "success": true
+          },
+          {
+            "actual_output": "True",
+            "error": null,
+            "expected_output": "False",
+            "input": "'-bad'",
+            "success": false
+          },
+          {
+            "actual_output": "True",
+            "error": null,
+            "expected_output": "False",
+            "input": "'bad--slug'",
+            "success": false
+          },
+          {
+            "actual_output": "False",
+            "error": null,
+            "expected_output": "False",
+            "input": "'Bad'",
+            "success": true
+          },
+          {
+            "actual_output": "True",
+            "error": null,
+            "expected_output": "True",
+            "input": "'ok'",
+            "success": true
+          }
+        ],
+        "passed": 3,
+        "success": false,
+        "total": 5
+      },
+      {
+        "function_name": "parse_ints",
+        "individual_results": [
+          {
+            "actual_output": "[1, 2, 3]",
+            "error": null,
+            "expected_output": "[1, 2, 3]",
+            "input": "'1,2,3'",
+            "success": true
+          },
+          {
+            "actual_output": "[1, 2, -3]",
+            "error": null,
+            "expected_output": "[1, 2, -3]",
+            "input": "'1, 2, -3'",
+            "success": true
+          },
+          {
+            "actual_output": "[]",
+            "error": null,
+            "expected_output": "[]",
+            "input": "''",
+            "success": true
+          },
+          {
+            "actual_output": null,
+            "error": "CallError: invalid literal for int() with base 10: '4 -5 6'",
+            "expected_output": "[4, -5, 6]",
+            "input": "'4 -5 6'",
+            "success": false
+          },
+          {
+            "actual_output": null,
+            "error": "CallError: invalid literal for int() with base 10: ''",
+            "expected_output": "[7, 8]",
+            "input": "'7,,8'",
+            "success": false
+          }
+        ],
+        "passed": 3,
+        "success": false,
+        "total": 5
+      },
+      {
+        "function_name": "flatten_once",
+        "individual_results": [
+          {
+            "actual_output": "[1, 2, 3, 4]",
+            "error": null,
+            "expected_output": "[1, 2, 3, 4]",
+            "input": "[[1, 2], 3, [4]]",
+            "success": true
+          },
+          {
+            "actual_output": "[(1, 2), 3]",
+            "error": null,
+            "expected_output": "[1, 2, 3]",
+            "input": "[(1, 2), [3]]",
+            "success": false
+          },
+          {
+            "actual_output": "[]",
+            "error": null,
+            "expected_output": "[]",
+            "input": "[]",
+            "success": true
+          },
+          {
+            "actual_output": "[[], 1]",
+            "error": null,
+            "expected_output": "[[], 1]",
+            "input": "[[[]], 1]",
+            "success": true
+          },
+          {
+            "actual_output": "['ab', 1, 2]",
+            "error": null,
+            "expected_output": "['ab', 1, 2]",
+            "input": "['ab', [1, 2]]",
+            "success": true
+          }
+        ],
+        "passed": 4,
+        "success": false,
+        "total": 5
+      },
+      {
+        "function_name": "merge_intervals",
+        "individual_results": [
+          {
+            "actual_output": "[(1, 4)]",
+            "error": null,
+            "expected_output": "[(1, 4)]",
+            "input": "[(1, 3), (2, 4)]",
+            "success": true
+          },
+          {
+            "actual_output": "[(5, 6)]",
+            "error": null,
+            "expected_output": "[(1, 3), (5, 6)]",
+            "input": "[(5, 6), (1, 3)]",
+            "success": false
+          },
+          {
+            "actual_output": "[]",
+            "error": null,
+            "expected_output": "[]",
+            "input": "[]",
+            "success": true
+          },
+          {
+            "actual_output": "[(1, 2), (3, 4)]",
+            "error": null,
+            "expected_output": "[(1, 2), (3, 4)]",
+            "input": "[(1, 2), (3, 4)]",
+            "success": true
+          },
+          {
+            "actual_output": "[(1, 5)]",
+            "error": null,
+            "expected_output": "[(1, 5)]",
+            "input": "[(1, 5), (2, 3)]",
+            "success": true
+          }
+        ],
+        "passed": 4,
+        "success": false,
+        "total": 5
+      },
+      {
+        "function_name": "top_k_frequent",
+        "individual_results": [
+          {
+            "actual_output": "['a', 'b']",
+            "error": null,
+            "expected_output": "['a', 'b']",
+            "input": "['a', 'b', 'a', 'c', 'b', 'a'], 2",
+            "success": true
+          },
+          {
+            "actual_output": "[1]",
+            "error": null,
+            "expected_output": "[2]",
+            "input": "[3, 3, 2, 1, 2, 2], 1",
+            "success": false
+          },
+          {
+            "actual_output": "[]",
+            "error": null,
+            "expected_output": "[]",
+            "input": "[], 3",
+            "success": true
+          },
+          {
+            "actual_output": "['a', 'b']",
+            "error": null,
+            "expected_output": "['b', 'a']",
+            "input": "['b', 'a', 'b', 'a'], 2",
+            "success": false
+          },
+          {
+            "actual_output": "[4]",
+            "error": null,
+            "expected_output": "[5]",
+            "input": "[5, 4, 5, 4, 4, 5], 1",
+            "success": false
+          }
+        ],
+        "passed": 2,
+        "success": false,
+        "total": 5
+      },
+      {
+        "function_name": "roman_to_int",
+        "individual_results": [
+          {
+            "actual_output": "3",
+            "error": null,
+            "expected_output": "3",
+            "input": "'III'",
+            "success": true
+          },
+          {
+            "actual_output": "6",
+            "error": null,
+            "expected_output": "4",
+            "input": "'IV'",
+            "success": false
+          },
+          {
+            "actual_output": "11",
+            "error": null,
+            "expected_output": "9",
+            "input": "'IX'",
+            "success": false
+          },
+          {
+            "actual_output": "58",
+            "error": null,
+            "expected_output": "58",
+            "input": "'LVIII'",
+            "success": true
+          },
+          {
+            "actual_output": "0",
+            "error": null,
+            "expected_output": "0",
+            "input": "''",
+            "success": true
+          }
+        ],
+        "passed": 3,
+        "success": false,
+        "total": 5
+      },
+      {
+        "function_name": "safe_get",
+        "individual_results": [
+          {
+            "actual_output": "2",
+            "error": null,
+            "expected_output": "2",
+            "input": "{'a': {'b': 2}}, ['a', 'b'], None",
+            "success": true
+          },
+          {
+            "actual_output": "None",
+            "error": null,
+            "expected_output": "10",
+            "input": "{'a': [10]}, ['a', 0], None",
+            "success": false
+          },
+          {
+            "actual_output": "'missing'",
+            "error": null,
+            "expected_output": "'missing'",
+            "input": "{}, ['x'], 'missing'",
+            "success": true
+          },
+          {
+            "actual_output": "7",
+            "error": null,
+            "expected_output": "7",
+            "input": "{'a': None}, ['a', 'b'], 7",
+            "success": true
+          },
+          {
+            "actual_output": "None",
+            "error": null,
+            "expected_output": "3",
+            "input": "[1, {'x': 3}], [1, 'x'], None",
+            "success": false
+          }
+        ],
+        "passed": 3,
+        "success": false,
+        "total": 5
+      }
+    ],
+    "total": 50
+  },
+  "benchmark": "humaneval_calibrated",
+  "benchmarks_dir": "config/benchmarks",
+  "candidate": {
+    "label": "candidate",
+    "passed": 50,
+    "path": "docs/demo/humaneval_calibrated_improved.py",
+    "score": 1.0,
+    "test_cases": [
+      {
+        "function_name": "normalize_whitespace",
+        "individual_results": [
+          {
+            "actual_output": "'hello world'",
+            "error": null,
+            "expected_output": "'hello world'",
+            "input": "'  hello  world  '",
+            "success": true
+          },
+          {
+            "actual_output": "'alpha beta'",
+            "error": null,
+            "expected_output": "'alpha beta'",
+            "input": "'\\nalpha\\t beta\\n'",
+            "success": true
+          },
+          {
+            "actual_output": "'one two three'",
+            "error": null,
+            "expected_output": "'one two three'",
+            "input": "'one    two   three'",
+            "success": true
+          },
+          {
+            "actual_output": "''",
+            "error": null,
+            "expected_output": "''",
+            "input": "''",
+            "success": true
+          },
+          {
+            "actual_output": "'spaced'",
+            "error": null,
+            "expected_output": "'spaced'",
+            "input": "' spaced '",
+            "success": true
+          }
+        ],
+        "passed": 5,
+        "success": true,
+        "total": 5
+      },
+      {
+        "function_name": "first_unique",
+        "individual_results": [
+          {
+            "actual_output": "3",
+            "error": null,
+            "expected_output": "3",
+            "input": "[2, 1, 2, 3, 1]",
+            "success": true
+          },
+          {
+            "actual_output": "'b'",
+            "error": null,
+            "expected_output": "'b'",
+            "input": "['a', 'b', 'a']",
+            "success": true
+          },
+          {
+            "actual_output": "None",
+            "error": null,
+            "expected_output": "None",
+            "input": "[1, 1]",
+            "success": true
+          },
+          {
+            "actual_output": "None",
+            "error": null,
+            "expected_output": "None",
+            "input": "[]",
+            "success": true
+          },
+          {
+            "actual_output": "'y'",
+            "error": null,
+            "expected_output": "'y'",
+            "input": "['x', 'y', 'x', 'z']",
+            "success": true
+          }
+        ],
+        "passed": 5,
+        "success": true,
+        "total": 5
+      },
+      {
+        "function_name": "rotate_left",
+        "individual_results": [
+          {
+            "actual_output": "[2, 3, 4, 1]",
+            "error": null,
+            "expected_output": "[2, 3, 4, 1]",
+            "input": "[1, 2, 3, 4], 1",
+            "success": true
+          },
+          {
+            "actual_output": "[2, 3, 1]",
+            "error": null,
+            "expected_output": "[2, 3, 1]",
+            "input": "[1, 2, 3], 4",
+            "success": true
+          },
+          {
+            "actual_output": "[]",
+            "error": null,
+            "expected_output": "[]",
+            "input": "[], 3",
+            "success": true
+          },
+          {
+            "actual_output": "[1, 2, 3]",
+            "error": null,
+            "expected_output": "[1, 2, 3]",
+            "input": "[1, 2, 3], 0",
+            "success": true
+          },
+          {
+            "actual_output": "['c', 'a', 'b']",
+            "error": null,
+            "expected_output": "['c', 'a', 'b']",
+            "input": "['a', 'b', 'c'], -1",
+            "success": true
+          }
+        ],
+        "passed": 5,
+        "success": true,
+        "total": 5
+      },
+      {
+        "function_name": "is_valid_slug",
+        "individual_results": [
+          {
+            "actual_output": "True",
+            "error": null,
+            "expected_output": "True",
+            "input": "'valid-slug-1'",
+            "success": true
+          },
+          {
+            "actual_output": "False",
+            "error": null,
+            "expected_output": "False",
+            "input": "'-bad'",
+            "success": true
+          },
+          {
+            "actual_output": "False",
+            "error": null,
+            "expected_output": "False",
+            "input": "'bad--slug'",
+            "success": true
+          },
+          {
+            "actual_output": "False",
+            "error": null,
+            "expected_output": "False",
+            "input": "'Bad'",
+            "success": true
+          },
+          {
+            "actual_output": "True",
+            "error": null,
+            "expected_output": "True",
+            "input": "'ok'",
+            "success": true
+          }
+        ],
+        "passed": 5,
+        "success": true,
+        "total": 5
+      },
+      {
+        "function_name": "parse_ints",
+        "individual_results": [
+          {
+            "actual_output": "[1, 2, 3]",
+            "error": null,
+            "expected_output": "[1, 2, 3]",
+            "input": "'1,2,3'",
+            "success": true
+          },
+          {
+            "actual_output": "[1, 2, -3]",
+            "error": null,
+            "expected_output": "[1, 2, -3]",
+            "input": "'1, 2, -3'",
+            "success": true
+          },
+          {
+            "actual_output": "[]",
+            "error": null,
+            "expected_output": "[]",
+            "input": "''",
+            "success": true
+          },
+          {
+            "actual_output": "[4, -5, 6]",
+            "error": null,
+            "expected_output": "[4, -5, 6]",
+            "input": "'4 -5 6'",
+            "success": true
+          },
+          {
+            "actual_output": "[7, 8]",
+            "error": null,
+            "expected_output": "[7, 8]",
+            "input": "'7,,8'",
+            "success": true
+          }
+        ],
+        "passed": 5,
+        "success": true,
+        "total": 5
+      },
+      {
+        "function_name": "flatten_once",
+        "individual_results": [
+          {
+            "actual_output": "[1, 2, 3, 4]",
+            "error": null,
+            "expected_output": "[1, 2, 3, 4]",
+            "input": "[[1, 2], 3, [4]]",
+            "success": true
+          },
+          {
+            "actual_output": "[1, 2, 3]",
+            "error": null,
+            "expected_output": "[1, 2, 3]",
+            "input": "[(1, 2), [3]]",
+            "success": true
+          },
+          {
+            "actual_output": "[]",
+            "error": null,
+            "expected_output": "[]",
+            "input": "[]",
+            "success": true
+          },
+          {
+            "actual_output": "[[], 1]",
+            "error": null,
+            "expected_output": "[[], 1]",
+            "input": "[[[]], 1]",
+            "success": true
+          },
+          {
+            "actual_output": "['ab', 1, 2]",
+            "error": null,
+            "expected_output": "['ab', 1, 2]",
+            "input": "['ab', [1, 2]]",
+            "success": true
+          }
+        ],
+        "passed": 5,
+        "success": true,
+        "total": 5
+      },
+      {
+        "function_name": "merge_intervals",
+        "individual_results": [
+          {
+            "actual_output": "[(1, 4)]",
+            "error": null,
+            "expected_output": "[(1, 4)]",
+            "input": "[(1, 3), (2, 4)]",
+            "success": true
+          },
+          {
+            "actual_output": "[(1, 3), (5, 6)]",
+            "error": null,
+            "expected_output": "[(1, 3), (5, 6)]",
+            "input": "[(5, 6), (1, 3)]",
+            "success": true
+          },
+          {
+            "actual_output": "[]",
+            "error": null,
+            "expected_output": "[]",
+            "input": "[]",
+            "success": true
+          },
+          {
+            "actual_output": "[(1, 2), (3, 4)]",
+            "error": null,
+            "expected_output": "[(1, 2), (3, 4)]",
+            "input": "[(1, 2), (3, 4)]",
+            "success": true
+          },
+          {
+            "actual_output": "[(1, 5)]",
+            "error": null,
+            "expected_output": "[(1, 5)]",
+            "input": "[(1, 5), (2, 3)]",
+            "success": true
+          }
+        ],
+        "passed": 5,
+        "success": true,
+        "total": 5
+      },
+      {
+        "function_name": "top_k_frequent",
+        "individual_results": [
+          {
+            "actual_output": "['a', 'b']",
+            "error": null,
+            "expected_output": "['a', 'b']",
+            "input": "['a', 'b', 'a', 'c', 'b', 'a'], 2",
+            "success": true
+          },
+          {
+            "actual_output": "[2]",
+            "error": null,
+            "expected_output": "[2]",
+            "input": "[3, 3, 2, 1, 2, 2], 1",
+            "success": true
+          },
+          {
+            "actual_output": "[]",
+            "error": null,
+            "expected_output": "[]",
+            "input": "[], 3",
+            "success": true
+          },
+          {
+            "actual_output": "['b', 'a']",
+            "error": null,
+            "expected_output": "['b', 'a']",
+            "input": "['b', 'a', 'b', 'a'], 2",
+            "success": true
+          },
+          {
+            "actual_output": "[5]",
+            "error": null,
+            "expected_output": "[5]",
+            "input": "[5, 4, 5, 4, 4, 5], 1",
+            "success": true
+          }
+        ],
+        "passed": 5,
+        "success": true,
+        "total": 5
+      },
+      {
+        "function_name": "roman_to_int",
+        "individual_results": [
+          {
+            "actual_output": "3",
+            "error": null,
+            "expected_output": "3",
+            "input": "'III'",
+            "success": true
+          },
+          {
+            "actual_output": "4",
+            "error": null,
+            "expected_output": "4",
+            "input": "'IV'",
+            "success": true
+          },
+          {
+            "actual_output": "9",
+            "error": null,
+            "expected_output": "9",
+            "input": "'IX'",
+            "success": true
+          },
+          {
+            "actual_output": "58",
+            "error": null,
+            "expected_output": "58",
+            "input": "'LVIII'",
+            "success": true
+          },
+          {
+            "actual_output": "0",
+            "error": null,
+            "expected_output": "0",
+            "input": "''",
+            "success": true
+          }
+        ],
+        "passed": 5,
+        "success": true,
+        "total": 5
+      },
+      {
+        "function_name": "safe_get",
+        "individual_results": [
+          {
+            "actual_output": "2",
+            "error": null,
+            "expected_output": "2",
+            "input": "{'a': {'b': 2}}, ['a', 'b'], None",
+            "success": true
+          },
+          {
+            "actual_output": "10",
+            "error": null,
+            "expected_output": "10",
+            "input": "{'a': [10]}, ['a', 0], None",
+            "success": true
+          },
+          {
+            "actual_output": "'missing'",
+            "error": null,
+            "expected_output": "'missing'",
+            "input": "{}, ['x'], 'missing'",
+            "success": true
+          },
+          {
+            "actual_output": "7",
+            "error": null,
+            "expected_output": "7",
+            "input": "{'a': None}, ['a', 'b'], 7",
+            "success": true
+          },
+          {
+            "actual_output": "3",
+            "error": null,
+            "expected_output": "3",
+            "input": "[1, {'x': 3}], [1, 'x'], None",
+            "success": true
+          }
+        ],
+        "passed": 5,
+        "success": true,
+        "total": 5
+      }
+    ],
+    "total": 50
+  },
+  "delta": 0.4
+}

--- a/docs/live-runs/live-score-movement/scorecard.json
+++ b/docs/live-runs/live-score-movement/scorecard.json
@@ -20,6 +20,7 @@
     }
   ],
   "has_improvement": false,
+  "has_regression": true,
   "improvements": [],
   "min_delta": 0.0,
   "parent_child_deltas": [
@@ -28,6 +29,11 @@
       "benchmark_deltas": {
         "humaneval_headroom": 0.0
       },
+      "benchmark_improvements": {},
+      "benchmark_regressions": {},
+      "benchmark_unchanged": [
+        "humaneval_headroom"
+      ],
       "child_average_score": 0.8823529411764706,
       "child_generation": 1,
       "child_id": "aaace30a-fdc4-465b-892a-83bbcf1d1c75",
@@ -41,6 +47,11 @@
       "benchmark_deltas": {
         "humaneval_headroom": -0.8823529411764706
       },
+      "benchmark_improvements": {},
+      "benchmark_regressions": {
+        "humaneval_headroom": -0.8823529411764706
+      },
+      "benchmark_unchanged": [],
       "child_average_score": 0.0,
       "child_generation": 1,
       "child_id": "509181a6-d257-4bbc-a5da-9c6a9b01bff8",
@@ -53,5 +64,8 @@
   "top_agent_id": "5719cca2-7188-4ed3-b805-603252f204c3",
   "top_score": 0.8823529411764706,
   "total_agents": 3,
+  "total_benchmark_improvements": 0,
+  "total_benchmark_regressions": 1,
+  "total_benchmark_unchanged": 1,
   "valid_agents": 3
 }

--- a/scripts/summarize_archive_scores.py
+++ b/scripts/summarize_archive_scores.py
@@ -104,6 +104,21 @@ def summarize_archive_scores(
                 set(parent["benchmark_scores"]) & set(child["benchmark_scores"])
             )
         }
+        benchmark_improvements = {
+            name: delta
+            for name, delta in benchmark_deltas.items()
+            if delta > min_delta
+        }
+        benchmark_regressions = {
+            name: delta
+            for name, delta in benchmark_deltas.items()
+            if delta < -min_delta
+        }
+        benchmark_unchanged = [
+            name
+            for name, delta in benchmark_deltas.items()
+            if -min_delta <= delta <= min_delta
+        ]
         average_delta = child["average_score"] - parent["average_score"]
         parent_child_deltas.append(
             {
@@ -115,6 +130,9 @@ def summarize_archive_scores(
                 "child_average_score": child["average_score"],
                 "average_delta": average_delta,
                 "benchmark_deltas": benchmark_deltas,
+                "benchmark_improvements": benchmark_improvements,
+                "benchmark_regressions": benchmark_regressions,
+                "benchmark_unchanged": benchmark_unchanged,
                 "is_improvement": average_delta > min_delta,
             }
         )
@@ -141,6 +159,18 @@ def summarize_archive_scores(
         "best_average_delta": best_delta,
         "min_delta": min_delta,
         "has_improvement": bool(improvements),
+        "has_regression": any(
+            delta["benchmark_regressions"] for delta in parent_child_deltas
+        ),
+        "total_benchmark_improvements": sum(
+            len(delta["benchmark_improvements"]) for delta in parent_child_deltas
+        ),
+        "total_benchmark_regressions": sum(
+            len(delta["benchmark_regressions"]) for delta in parent_child_deltas
+        ),
+        "total_benchmark_unchanged": sum(
+            len(delta["benchmark_unchanged"]) for delta in parent_child_deltas
+        ),
         "generation_best_scores": _generation_best_scores(agents),
         "parent_child_deltas": parent_child_deltas,
         "improvements": improvements,

--- a/scripts/verify_demo_path.py
+++ b/scripts/verify_demo_path.py
@@ -72,6 +72,7 @@ async def _verify_humaneval_reference(project_root: Path) -> dict[str, Any]:
         use_sandbox=False,
     )
     expected = {
+        "humaneval_calibrated",
         "humaneval_headroom",
         "humaneval_style",
         "list_processing",
@@ -149,6 +150,39 @@ async def _verify_live_headroom_score_movement(project_root: Path) -> dict[str, 
 
     return {
         "name": "live_headroom_score_movement_demo",
+        "status": "ok",
+        "benchmark": report["benchmark"],
+        "baseline_score": report["baseline"]["score"],
+        "candidate_score": report["candidate"]["score"],
+        "delta": report["delta"],
+        "baseline_passed": report["baseline"]["passed"],
+        "candidate_passed": report["candidate"]["passed"],
+        "total": report["candidate"]["total"],
+    }
+
+
+async def _verify_calibrated_score_movement(project_root: Path) -> dict[str, Any]:
+    report = await compare_solutions(
+        benchmarks_dir=project_root / "config" / "benchmarks",
+        benchmark_name="humaneval_calibrated",
+        baseline_path=project_root / "docs" / "demo" / "humaneval_calibrated_baseline.py",
+        candidate_path=project_root / "docs" / "demo" / "humaneval_calibrated_improved.py",
+    )
+    checked_in = _load_json(
+        project_root / "docs" / "demo" / "humaneval_calibrated_score_movement.json"
+    )
+
+    _require(report["baseline"]["score"] == 0.6, "Expected calibrated baseline score 0.6")
+    _require(report["candidate"]["score"] == 1.0, "Expected calibrated candidate score 1.0")
+    _require(report["delta"] == 0.4, "Expected calibrated score delta 0.4")
+    _require(report["baseline"]["passed"] == 30, "Expected calibrated baseline to pass 30 cases")
+    _require(report["baseline"]["total"] == 50, "Expected calibrated benchmark to have 50 cases")
+    _require(checked_in["baseline"]["score"] == report["baseline"]["score"], "Stale calibrated baseline JSON report")
+    _require(checked_in["candidate"]["score"] == report["candidate"]["score"], "Stale calibrated candidate JSON report")
+    _require(checked_in["delta"] == report["delta"], "Stale calibrated delta JSON report")
+
+    return {
+        "name": "calibrated_score_movement_demo",
         "status": "ok",
         "benchmark": report["benchmark"],
         "baseline_score": report["baseline"]["score"],
@@ -250,6 +284,14 @@ def _verify_live_score_movement_attempt_docs(project_root: Path) -> dict[str, An
         scorecard_json["has_improvement"] is False,
         "Live scorecard must preserve the failed-improvement gate",
     )
+    _require(
+        scorecard_json["has_regression"] is True,
+        "Live scorecard must preserve benchmark regression evidence",
+    )
+    _require(
+        scorecard_json["total_benchmark_regressions"] == 1,
+        "Live scorecard must record the regressed child benchmark",
+    )
 
     audit_text = audit.read_text(encoding="utf-8")
     audit_json = json.loads(audit_text)
@@ -274,6 +316,8 @@ def _verify_live_score_movement_attempt_docs(project_root: Path) -> dict[str, An
         "top_score": scorecard_json["top_score"],
         "best_average_delta": scorecard_json["best_average_delta"],
         "has_improvement": scorecard_json["has_improvement"],
+        "has_regression": scorecard_json["has_regression"],
+        "total_benchmark_regressions": scorecard_json["total_benchmark_regressions"],
         "audit_hides_env_values": True,
     }
 
@@ -464,8 +508,12 @@ async def verify_demo_path(project_root: Path = PROJECT_ROOT) -> list[dict[str, 
         project_root / "requirements.txt",
         project_root / "config" / "dgm_config.yaml",
         project_root / "config" / "live_score_movement.yaml",
+        project_root / "config" / "benchmarks" / "humaneval_calibrated.yaml",
         project_root / "config" / "benchmarks" / "humaneval_headroom.yaml",
         project_root / "config" / "benchmarks" / "humaneval_style.yaml",
+        project_root / "docs" / "demo" / "humaneval_calibrated_baseline.py",
+        project_root / "docs" / "demo" / "humaneval_calibrated_improved.py",
+        project_root / "docs" / "demo" / "humaneval_calibrated_score_movement.json",
         project_root / "docs" / "demo" / "humaneval_headroom_baseline.py",
         project_root / "docs" / "demo" / "humaneval_headroom_improved.py",
         project_root / "docs" / "demo" / "humaneval_headroom_score_movement.json",
@@ -477,6 +525,7 @@ async def verify_demo_path(project_root: Path = PROJECT_ROOT) -> list[dict[str, 
     checks.append(await _verify_humaneval_reference(project_root))
     checks.append(await _verify_score_movement(project_root))
     checks.append(await _verify_live_headroom_score_movement(project_root))
+    checks.append(await _verify_calibrated_score_movement(project_root))
     checks.append(_verify_live_run_docs(project_root))
     checks.append(_verify_live_score_movement_attempt_docs(project_root))
     checks.append(_verify_archive_lineage(project_root))

--- a/scripts/verify_live_score_movement_plan.py
+++ b/scripts/verify_live_score_movement_plan.py
@@ -98,7 +98,10 @@ def verify_live_score_movement_plan(
 
     benchmark_config = config.get("benchmarks", {})
     enabled = benchmark_config.get("enabled", [])
-    _require(enabled == ["humaneval_headroom"], "Live score-movement run must target humaneval_headroom only")
+    _require(
+        enabled == ["humaneval_calibrated"],
+        "Live score-movement run must target humaneval_calibrated only",
+    )
     _require(
         benchmark_config.get("max_attempts", 0) <= 3,
         "Benchmark max_attempts must stay <= 3",
@@ -165,6 +168,14 @@ def verify_live_score_movement_plan(
         len(test_pairs) > len(prompt_pairs),
         "Headroom benchmark must include hidden evaluation cases beyond prompt examples",
     )
+    _require(
+        len(prompt_pairs) >= 8,
+        "Headroom benchmark must include broad public examples",
+    )
+    _require(
+        len(test_pairs) >= 40,
+        "Headroom benchmark must include at least 40 evaluation cases",
+    )
 
     baseline_path = _require_project_file(headroom_gate.get("baseline_solution", ""), project_root)
     candidate_path = _require_project_file(headroom_gate.get("candidate_solution", ""), project_root)
@@ -184,6 +195,10 @@ def verify_live_score_movement_plan(
     _require(
         Path(score_report.get("candidate", {}).get("path", "")) == candidate_path.relative_to(project_root),
         "Headroom score report candidate path mismatch",
+    )
+    _require(
+        baseline_score >= float(headroom_gate.get("min_baseline_score", 0)),
+        "Headroom baseline score is too low for a calibrated live rehearsal",
     )
     _require(
         baseline_score <= float(headroom_gate.get("max_baseline_score", 0)),
@@ -284,6 +299,8 @@ def verify_live_score_movement_plan(
         "headroom_baseline_score": baseline_score,
         "headroom_candidate_score": candidate_score,
         "headroom_delta": delta,
+        "headroom_public_examples": len(prompt_pairs),
+        "headroom_evaluation_cases": len(test_pairs),
         "headroom_score_report": str(report_path.relative_to(project_root)),
         "pricing_checked_at": str(cost_gate["pricing_checked_at"]),
         "input_price_per_mtok": cost_estimate["input_price_per_mtok"],

--- a/tests/integration/test_benchmark_score_movement_demo.py
+++ b/tests/integration/test_benchmark_score_movement_demo.py
@@ -45,3 +45,24 @@ async def test_headroom_demo_solutions_show_hidden_case_score_movement():
     assert report["baseline"]["total"] == 17
     assert report["candidate"]["passed"] == 17
     assert report["candidate"]["total"] == 17
+
+
+@pytest.mark.asyncio
+async def test_calibrated_demo_solutions_show_broad_hidden_case_score_movement():
+    project_root = Path(__file__).resolve().parents[2]
+
+    report = await compare_solutions(
+        benchmarks_dir=project_root / "config" / "benchmarks",
+        benchmark_name="humaneval_calibrated",
+        baseline_path=project_root / "docs" / "demo" / "humaneval_calibrated_baseline.py",
+        candidate_path=project_root / "docs" / "demo" / "humaneval_calibrated_improved.py",
+    )
+
+    assert report["benchmark"] == "humaneval_calibrated"
+    assert report["baseline"]["score"] == pytest.approx(0.6)
+    assert report["candidate"]["score"] == pytest.approx(1.0)
+    assert report["delta"] == pytest.approx(0.4)
+    assert report["baseline"]["passed"] == 30
+    assert report["baseline"]["total"] == 50
+    assert report["candidate"]["passed"] == 50
+    assert report["candidate"]["total"] == 50

--- a/tests/integration/test_demo_path_verifier.py
+++ b/tests/integration/test_demo_path_verifier.py
@@ -15,6 +15,7 @@ async def test_no_network_demo_path_verifier_passes():
     assert "humaneval_reference" in names
     assert "score_movement_demo" in names
     assert "live_headroom_score_movement_demo" in names
+    assert "calibrated_score_movement_demo" in names
     assert "live_run_docs" in names
     assert "archive_lineage_artifact" in names
     assert "sandbox_runner_cli" in names
@@ -35,6 +36,16 @@ async def test_no_network_demo_path_verifier_passes():
     assert headroom_check["candidate_score"] == 1.0
     assert headroom_check["delta"] == pytest.approx(7 / 17)
 
+    calibrated_check = next(
+        check for check in checks if check["name"] == "calibrated_score_movement_demo"
+    )
+    assert calibrated_check["benchmark"] == "humaneval_calibrated"
+    assert calibrated_check["baseline_score"] == pytest.approx(0.6)
+    assert calibrated_check["candidate_score"] == 1.0
+    assert calibrated_check["delta"] == pytest.approx(0.4)
+    assert calibrated_check["baseline_passed"] == 30
+    assert calibrated_check["total"] == 50
+
     live_run_check = next(check for check in checks if check["name"] == "live_run_docs")
     assert live_run_check["scorecard"] == "docs/live-runs/2026-06-12-proof/scorecard.json"
     assert live_run_check["top_score"] == 1.0
@@ -48,6 +59,8 @@ async def test_no_network_demo_path_verifier_passes():
     assert live_attempt_check["top_score"] == pytest.approx(15 / 17)
     assert live_attempt_check["best_average_delta"] == 0.0
     assert live_attempt_check["has_improvement"] is False
+    assert live_attempt_check["has_regression"] is True
+    assert live_attempt_check["total_benchmark_regressions"] == 1
     assert live_attempt_check["audit_hides_env_values"] is True
 
     sandbox_check = next(check for check in checks if check["name"] == "sandbox_runner_cli")
@@ -66,16 +79,18 @@ async def test_no_network_demo_path_verifier_passes():
     live_plan_check = next(
         check for check in checks if check["name"] == "live_score_movement_plan"
     )
-    assert live_plan_check["benchmark"] == "humaneval_headroom"
+    assert live_plan_check["benchmark"] == "humaneval_calibrated"
     assert live_plan_check["recommended_generations"] == 2
     assert live_plan_check["approval_required"] is True
     assert live_plan_check["requires_current_pricing_check"] is True
     assert live_plan_check["requires_full_process_sandbox"] is True
     assert live_plan_check["requires_scorecard_improvement"] is True
     assert live_plan_check["requires_headroom_gate"] is True
-    assert live_plan_check["headroom_baseline_score"] == pytest.approx(10 / 17)
+    assert live_plan_check["headroom_baseline_score"] == pytest.approx(0.6)
     assert live_plan_check["headroom_candidate_score"] == 1.0
-    assert live_plan_check["headroom_delta"] == pytest.approx(7 / 17)
+    assert live_plan_check["headroom_delta"] == pytest.approx(0.4)
+    assert live_plan_check["headroom_public_examples"] == 10
+    assert live_plan_check["headroom_evaluation_cases"] == 50
     assert live_plan_check["request_ceiling"] == 25
     assert live_plan_check["estimated_total_cost_usd"] == pytest.approx(4.518)
     assert live_plan_check["max_estimated_cost_usd"] == 5

--- a/tests/unit/test_estimate_live_run_cost.py
+++ b/tests/unit/test_estimate_live_run_cost.py
@@ -22,7 +22,7 @@ def test_estimate_live_score_movement_cost_from_config():
     )
 
     assert estimate["model"] == "claude-sonnet-4-6"
-    assert estimate["enabled_benchmarks"] == ["humaneval_headroom"]
+    assert estimate["enabled_benchmarks"] == ["humaneval_calibrated"]
     assert estimate["benchmark_count"] == 1
     assert estimate["generations"] == 2
     assert estimate["max_agent_steps"] == 5

--- a/tests/unit/test_summarize_archive_scores.py
+++ b/tests/unit/test_summarize_archive_scores.py
@@ -52,6 +52,15 @@ def test_summarize_archive_scores_finds_parent_child_improvement(tmp_path):
     assert report["parent_child_deltas"][0]["benchmark_deltas"] == {
         "humaneval_style": 0.5
     }
+    assert report["parent_child_deltas"][0]["benchmark_improvements"] == {
+        "humaneval_style": 0.5
+    }
+    assert report["parent_child_deltas"][0]["benchmark_regressions"] == {}
+    assert report["parent_child_deltas"][0]["benchmark_unchanged"] == []
+    assert report["total_benchmark_improvements"] == 1
+    assert report["total_benchmark_regressions"] == 0
+    assert report["total_benchmark_unchanged"] == 0
+    assert report["has_regression"] is False
     assert report["generation_best_scores"] == [
         {
             "generation": 0,
@@ -103,6 +112,42 @@ def test_require_improvement_fails_flat_archive(tmp_path, capsys):
     assert exit_code == 1
     assert "best_delta=+0.000" in captured.out
     assert "no valid parent-child average-score improvement" in captured.err
+
+
+def test_summarize_archive_scores_reports_benchmark_regressions(tmp_path):
+    metadata = tmp_path / "archive_metadata.json"
+    _write_archive_metadata(
+        metadata,
+        {
+            "root": {
+                "agent_id": "root",
+                "parent_id": None,
+                "generation": 0,
+                "average_score": 0.75,
+                "benchmark_scores": {"a": 1.0, "b": 0.5, "c": 0.75},
+                "is_valid": True,
+            },
+            "child": {
+                "agent_id": "child",
+                "parent_id": "root",
+                "generation": 1,
+                "average_score": 0.5,
+                "benchmark_scores": {"a": 0.5, "b": 0.75, "c": 0.75},
+                "is_valid": True,
+            },
+        },
+    )
+
+    report = summarize_archive_scores(metadata)
+    delta = report["parent_child_deltas"][0]
+
+    assert delta["benchmark_improvements"] == {"b": 0.25}
+    assert delta["benchmark_regressions"] == {"a": -0.5}
+    assert delta["benchmark_unchanged"] == ["c"]
+    assert report["has_regression"] is True
+    assert report["total_benchmark_improvements"] == 1
+    assert report["total_benchmark_regressions"] == 1
+    assert report["total_benchmark_unchanged"] == 1
 
 
 def test_main_writes_scorecard_json(tmp_path, capsys):

--- a/tests/unit/test_verify_live_score_movement_plan.py
+++ b/tests/unit/test_verify_live_score_movement_plan.py
@@ -32,7 +32,7 @@ def test_live_score_movement_plan_verifies_default_config():
     report = verify_live_score_movement_plan(project_root=project_root)
 
     assert report["config"] == "config/live_score_movement.yaml"
-    assert report["benchmark"] == "humaneval_headroom"
+    assert report["benchmark"] == "humaneval_calibrated"
     assert report["recommended_generations"] == 2
     assert report["max_agent_steps"] == 5
     assert report["max_output_tokens_per_call"] == 2048
@@ -42,10 +42,12 @@ def test_live_score_movement_plan_verifies_default_config():
     assert report["requires_full_process_sandbox"] is True
     assert report["requires_scorecard_improvement"] is True
     assert report["requires_headroom_gate"] is True
-    assert report["headroom_baseline_score"] == pytest.approx(10 / 17)
+    assert report["headroom_baseline_score"] == pytest.approx(0.6)
     assert report["headroom_candidate_score"] == 1.0
-    assert report["headroom_delta"] == pytest.approx(7 / 17)
-    assert report["headroom_score_report"] == "docs/demo/humaneval_headroom_score_movement.json"
+    assert report["headroom_delta"] == pytest.approx(0.4)
+    assert report["headroom_public_examples"] == 10
+    assert report["headroom_evaluation_cases"] == 50
+    assert report["headroom_score_report"] == "docs/demo/humaneval_calibrated_score_movement.json"
     assert report["pricing_checked_at"] == "2026-06-15"
     assert report["input_price_per_mtok"] == 3
     assert report["output_price_per_mtok"] == 15
@@ -70,10 +72,10 @@ def test_live_score_movement_plan_rejects_unapproved_run(tmp_path):
 def test_live_score_movement_plan_rejects_extra_benchmarks(tmp_path):
     project_root = Path(__file__).resolve().parents[2]
     plan = deepcopy(_load_default_plan(project_root))
-    plan["benchmarks"]["enabled"] = ["humaneval_headroom", "list_processing"]
+    plan["benchmarks"]["enabled"] = ["humaneval_calibrated", "list_processing"]
     config_path = _write_plan(tmp_path, plan)
 
-    with pytest.raises(LiveRunPlanError, match="humaneval_headroom only"):
+    with pytest.raises(LiveRunPlanError, match="humaneval_calibrated only"):
         verify_live_score_movement_plan(config_path, project_root=project_root)
 
 
@@ -87,6 +89,16 @@ def test_live_score_movement_plan_rejects_missing_headroom(tmp_path):
         verify_live_score_movement_plan(config_path, project_root=project_root)
 
 
+def test_live_score_movement_plan_rejects_overly_weak_baseline(tmp_path):
+    project_root = Path(__file__).resolve().parents[2]
+    plan = deepcopy(_load_default_plan(project_root))
+    plan["live_run"]["headroom_gate"]["min_baseline_score"] = 0.9
+    config_path = _write_plan(tmp_path, plan)
+
+    with pytest.raises(LiveRunPlanError, match="baseline score is too low"):
+        verify_live_score_movement_plan(config_path, project_root=project_root)
+
+
 def test_live_score_movement_plan_cli_json(capsys):
     args = _build_parser().parse_args(["--json"])
 
@@ -95,4 +107,4 @@ def test_live_score_movement_plan_cli_json(capsys):
 
     assert exit_code == 0
     assert '"status": "ok"' in captured.out
-    assert '"benchmark": "humaneval_headroom"' in captured.out
+    assert '"benchmark": "humaneval_calibrated"' in captured.out


### PR DESCRIPTION

## Summary
- add humaneval_calibrated with 10 public examples and 50 scored evaluation cases across 10 functions
- add weak/reference demo solutions with calibrated score movement: 30/50 to 50/50, delta +0.400
- point the live score-movement plan at the calibrated benchmark and require a 0.400-0.700 baseline band
- extend archive scorecards with explicit per-benchmark improvements, regressions, and unchanged counts

## Verification
- .venv/bin/python scripts/compare_benchmark_solutions.py --benchmark humaneval_calibrated --baseline docs/demo/humaneval_calibrated_baseline.py --candidate docs/demo/humaneval_calibrated_improved.py --output docs/demo/humaneval_calibrated_score_movement.json
- .venv/bin/python scripts/verify_live_score_movement_plan.py --json
- .venv/bin/python scripts/verify_demo_path.py
- .venv/bin/python -m pytest tests/unit/test_summarize_archive_scores.py tests/integration/test_benchmark_score_movement_demo.py tests/integration/test_demo_path_verifier.py tests/unit/test_verify_live_score_movement_plan.py tests/unit/test_estimate_live_run_cost.py
- .venv/bin/python -m pytest

## Notes
This is still a no-network calibration step. It does not spend provider budget or claim live improvement.
