### PR TITLE
[codex] record live calibrated run artifact

### DIFF
--- a/docs/live-runs/live-score-movement/README.md
+++ b/docs/live-runs/live-score-movement/README.md
@@ -4,19 +4,20 @@ Run date: 2026-06-15
 
 This was a bounded live DGM run for `config/live_score_movement.yaml`. It was
 intended to prove that the cost-gated, full-process Docker runner can execute a
-real provider-backed DGM cycle against `humaneval_headroom` and then fail closed
+real provider-backed DGM cycle against `humaneval_calibrated` and then fail closed
 if there is no parent-child score improvement.
 
 Preflight gates passed before the live call:
 
-- `python -m pytest`: 228 passed, 7 skipped
-- `python scripts/verify_demo_path.py`
-- `python scripts/verify_sandbox_docker.py --require`
-- `python scripts/verify_live_score_movement_plan.py`
-- `python scripts/estimate_live_run_cost.py --input-price-per-mtok 3 --output-price-per-mtok 15 --assumed-input-tokens-per-call 50000 --max-budget 5`
+- `.venv/bin/python scripts/verify_demo_path.py`
+- `.venv/bin/python scripts/verify_sandbox_docker.py --require`
+- `.venv/bin/python scripts/verify_live_score_movement_plan.py --json`
+- `.venv/bin/python scripts/estimate_live_run_cost.py --input-price-per-mtok 3 --output-price-per-mtok 15 --assumed-input-tokens-per-call 50000 --max-budget 5 --json`
 
 The current Anthropic pricing check used Claude Sonnet 4.6 at `$3 / MTok`
 input and `$15 / MTok` output, producing the configured `$4.5180` estimate.
+The observed run usage was 160,506 input tokens and 10,360 output tokens,
+for an estimated actual cost of `$0.636918`.
 
 The live command was:
 
@@ -33,17 +34,20 @@ Observed live evidence:
   responses from Anthropic.
 - The run logged 22 Anthropic API usage records.
 - The DGM controller completed two generations and wrote
-  `.dgm-live-runs/live-score-movement/results/dgm_report_20260615_224945.json`.
+  `.dgm-live-runs/live-score-movement/results/dgm_report_20260615_233123.json`.
 
 Outcome:
 
 - The archive contained 3 valid agents.
-- Top score was `0.8823529411764706` (`15/17`) on `humaneval_headroom`.
+- Top score was `0.880` (`44/50`) on `humaneval_calibrated`.
 - Best parent-child average-score delta was `+0.000`.
+- The scorecard recorded 0 benchmark improvements, 0 benchmark regressions,
+  and 2 unchanged parent-child benchmark comparisons.
 - `scripts/summarize_archive_scores.py --require-improvement` failed as
   designed because `has_improvement` is `false`.
 
 This proves a fully live, sandboxed, provider-backed DGM run completed. It does
-not prove benchmark improvement. The configured benchmark did have hidden-case
-headroom, but the initial parent already solved most cases and neither child
-improved on it in this bounded two-generation run.
+not prove benchmark improvement. The calibrated benchmark had hidden-case
+headroom in the no-network baseline/reference check, but the live initial parent
+already solved 44 of 50 cases and both child agents tied it in this bounded
+two-generation run.

--- a/docs/live-runs/live-score-movement/scorecard.json
+++ b/docs/live-runs/live-score-movement/scorecard.json
@@ -3,69 +3,77 @@
   "best_average_delta": 0.0,
   "generation_best_scores": [
     {
-      "agent_id": "5719cca2-7188-4ed3-b805-603252f204c3",
-      "average_score": 0.8823529411764706,
+      "agent_id": "95d56997-b6b5-454b-ac4d-24867f351b3c",
+      "average_score": 0.88,
       "benchmark_scores": {
-        "humaneval_headroom": 0.8823529411764706
+        "humaneval_calibrated": 0.88
       },
       "generation": 0
     },
     {
-      "agent_id": "aaace30a-fdc4-465b-892a-83bbcf1d1c75",
-      "average_score": 0.8823529411764706,
+      "agent_id": "947dafe9-6c9b-4020-83d9-273d3ace1da6",
+      "average_score": 0.88,
       "benchmark_scores": {
-        "humaneval_headroom": 0.8823529411764706
+        "humaneval_calibrated": 0.88
       },
       "generation": 1
+    },
+    {
+      "agent_id": "4fb5bd47-350c-4537-9a88-b05e8d13e7f7",
+      "average_score": 0.88,
+      "benchmark_scores": {
+        "humaneval_calibrated": 0.88
+      },
+      "generation": 2
     }
   ],
   "has_improvement": false,
-  "has_regression": true,
+  "has_regression": false,
   "improvements": [],
   "min_delta": 0.0,
   "parent_child_deltas": [
     {
       "average_delta": 0.0,
       "benchmark_deltas": {
-        "humaneval_headroom": 0.0
+        "humaneval_calibrated": 0.0
       },
       "benchmark_improvements": {},
       "benchmark_regressions": {},
       "benchmark_unchanged": [
-        "humaneval_headroom"
+        "humaneval_calibrated"
       ],
-      "child_average_score": 0.8823529411764706,
+      "child_average_score": 0.88,
       "child_generation": 1,
-      "child_id": "aaace30a-fdc4-465b-892a-83bbcf1d1c75",
+      "child_id": "947dafe9-6c9b-4020-83d9-273d3ace1da6",
       "is_improvement": false,
-      "parent_average_score": 0.8823529411764706,
+      "parent_average_score": 0.88,
       "parent_generation": 0,
-      "parent_id": "5719cca2-7188-4ed3-b805-603252f204c3"
+      "parent_id": "95d56997-b6b5-454b-ac4d-24867f351b3c"
     },
     {
-      "average_delta": -0.8823529411764706,
+      "average_delta": 0.0,
       "benchmark_deltas": {
-        "humaneval_headroom": -0.8823529411764706
+        "humaneval_calibrated": 0.0
       },
       "benchmark_improvements": {},
-      "benchmark_regressions": {
-        "humaneval_headroom": -0.8823529411764706
-      },
-      "benchmark_unchanged": [],
-      "child_average_score": 0.0,
-      "child_generation": 1,
-      "child_id": "509181a6-d257-4bbc-a5da-9c6a9b01bff8",
+      "benchmark_regressions": {},
+      "benchmark_unchanged": [
+        "humaneval_calibrated"
+      ],
+      "child_average_score": 0.88,
+      "child_generation": 2,
+      "child_id": "4fb5bd47-350c-4537-9a88-b05e8d13e7f7",
       "is_improvement": false,
-      "parent_average_score": 0.8823529411764706,
-      "parent_generation": 0,
-      "parent_id": "5719cca2-7188-4ed3-b805-603252f204c3"
+      "parent_average_score": 0.88,
+      "parent_generation": 1,
+      "parent_id": "947dafe9-6c9b-4020-83d9-273d3ace1da6"
     }
   ],
-  "top_agent_id": "5719cca2-7188-4ed3-b805-603252f204c3",
-  "top_score": 0.8823529411764706,
+  "top_agent_id": "95d56997-b6b5-454b-ac4d-24867f351b3c",
+  "top_score": 0.88,
   "total_agents": 3,
   "total_benchmark_improvements": 0,
-  "total_benchmark_regressions": 1,
-  "total_benchmark_unchanged": 1,
+  "total_benchmark_regressions": 0,
+  "total_benchmark_unchanged": 2,
   "valid_agents": 3
 }

--- a/scripts/verify_demo_path.py
+++ b/scripts/verify_demo_path.py
@@ -266,8 +266,8 @@ def _verify_live_score_movement_attempt_docs(project_root: Path) -> dict[str, An
     _require(scorecard_json["total_agents"] == 3, "Live scorecard must record three agents")
     _require(scorecard_json["valid_agents"] == 3, "Live scorecard must record three valid agents")
     _require(
-        abs(scorecard_json["top_score"] - (15 / 17)) < 1e-12,
-        "Live scorecard top score must record the approved headroom run",
+        scorecard_json["top_score"] == 0.88,
+        "Live scorecard top score must record the approved calibrated run",
     )
     _require(
         scorecard_json["best_average_delta"] == 0.0,
@@ -275,22 +275,26 @@ def _verify_live_score_movement_attempt_docs(project_root: Path) -> dict[str, An
     )
     _require(
         all(
-            "humaneval_headroom" in item["benchmark_scores"]
+            "humaneval_calibrated" in item["benchmark_scores"]
             for item in scorecard_json["generation_best_scores"]
         ),
-        "Live scorecard must use the headroom benchmark",
+        "Live scorecard must use the calibrated benchmark",
     )
     _require(
         scorecard_json["has_improvement"] is False,
         "Live scorecard must preserve the failed-improvement gate",
     )
     _require(
-        scorecard_json["has_regression"] is True,
-        "Live scorecard must preserve benchmark regression evidence",
+        scorecard_json["has_regression"] is False,
+        "Live scorecard must preserve absence of benchmark regressions",
     )
     _require(
-        scorecard_json["total_benchmark_regressions"] == 1,
-        "Live scorecard must record the regressed child benchmark",
+        scorecard_json["total_benchmark_regressions"] == 0,
+        "Live scorecard must record zero benchmark regressions",
+    )
+    _require(
+        scorecard_json["total_benchmark_unchanged"] == 2,
+        "Live scorecard must record tied child benchmark comparisons",
     )
 
     audit_text = audit.read_text(encoding="utf-8")
@@ -318,6 +322,7 @@ def _verify_live_score_movement_attempt_docs(project_root: Path) -> dict[str, An
         "has_improvement": scorecard_json["has_improvement"],
         "has_regression": scorecard_json["has_regression"],
         "total_benchmark_regressions": scorecard_json["total_benchmark_regressions"],
+        "total_benchmark_unchanged": scorecard_json["total_benchmark_unchanged"],
         "audit_hides_env_values": True,
     }
 

--- a/tests/integration/test_demo_path_verifier.py
+++ b/tests/integration/test_demo_path_verifier.py
@@ -56,11 +56,12 @@ async def test_no_network_demo_path_verifier_passes():
         check for check in checks if check["name"] == "live_score_movement_attempt_docs"
     )
     assert live_attempt_check["scorecard"] == "docs/live-runs/live-score-movement/scorecard.json"
-    assert live_attempt_check["top_score"] == pytest.approx(15 / 17)
+    assert live_attempt_check["top_score"] == pytest.approx(0.88)
     assert live_attempt_check["best_average_delta"] == 0.0
     assert live_attempt_check["has_improvement"] is False
-    assert live_attempt_check["has_regression"] is True
-    assert live_attempt_check["total_benchmark_regressions"] == 1
+    assert live_attempt_check["has_regression"] is False
+    assert live_attempt_check["total_benchmark_regressions"] == 0
+    assert live_attempt_check["total_benchmark_unchanged"] == 2
     assert live_attempt_check["audit_hides_env_values"] is True
 
     sandbox_check = next(check for check in checks if check["name"] == "sandbox_runner_cli")


### PR DESCRIPTION

## Summary
- record the approved 2026-06-15 live run against humaneval_calibrated
- update the live scorecard: 3 valid agents, top score 44/50, best delta +0.000, no improvement
- update the demo verifier to preserve the calibrated non-improvement artifact

## Result
- Proves the full-process Docker runner completed a live provider-backed DGM cycle against the calibrated benchmark.
- Does not prove benchmark improvement; require-improvement failed closed as designed.

## Observed usage
- 22 Anthropic API calls
- 160,506 input tokens
- 10,360 output tokens
- estimated actual cost: $0.636918 at $3/MTok input and $15/MTok output

## Verification
- .venv/bin/python scripts/verify_demo_path.py
- .venv/bin/python -m pytest tests/integration/test_demo_path_verifier.py tests/unit/test_summarize_archive_scores.py
- .venv/bin/python -m pytest
