### PR TITLE
[codex] add dry-run model matrix harness

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,8 +7,9 @@ GEMINI_API_KEY=your-gemini-api-key-here
 # Anthropic Claude API
 ANTHROPIC_API_KEY=your-anthropic-api-key-here
 
-# OpenAI API (optional for future use)
+# OpenAI-compatible APIs
 OPENAI_API_KEY=your-openai-api-key-here
+OPENROUTER_API_KEY=your-openrouter-api-key-here
 
 # DGM Configuration
 DGM_LOG_LEVEL=INFO

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ For more details, see the [official blog post](https://sakana.ai/dgm/) from Saka
 - **🔄 Self-Referential Self-Improvement**: Agents modify their own source code to improve performance
 - **📊 Empirical Validation**: Changes validated through coding benchmarks rather than formal proofs
 - **🏗️ Population-Based Evolution**: Maintains archive of all valid agents for diverse exploration
-- **🤖 Foundation Model Integration**: Supports Claude, Gemini, and OpenAI models
+- **🤖 Foundation Model Integration**: Supports Claude, Gemini, OpenAI, and OpenAI-compatible endpoints
 - **🛠️ Tool-Equipped Agents**: Agents use Bash and file editing tools to solve problems
 - **🏪 Agent Archive System**: Stores successful agents with performance and novelty metrics
 - **🎯 Benchmark-Driven Evolution**: Uses custom coding challenges to measure improvement
@@ -32,7 +32,7 @@ For more details, see the [official blog post](https://sakana.ai/dgm/) from Saka
 ### Prerequisites
 
 - Python 3.9+
-- API keys for supported Foundation Models (Claude, Gemini, or OpenAI)
+- API keys for supported Foundation Models (Claude, Gemini, OpenAI, or an OpenAI-compatible provider)
 
 ### Installation
 
@@ -83,6 +83,10 @@ fm_providers:
   gemini:
     model: gemini-2.5-flash-preview-05-20
     api_key: ${GEMINI_API_KEY}
+  openai_compatible:
+    model: moonshotai/kimi-k2.7-code
+    api_key: ${OPENROUTER_API_KEY}
+    base_url: https://openrouter.ai/api/v1
 
 dgm_settings:
   max_iterations: 100
@@ -328,6 +332,26 @@ python scripts/run_dgm_in_sandbox.py \
 
 Then summarize the run archive with `scripts/summarize_archive_scores.py
 --require-improvement` before claiming benchmark improvement.
+
+### Dry-run model matrix
+
+`config/live_model_matrix.yaml` captures the next comparison harness without
+making provider calls. It estimates five bounded trials per model against the
+same calibrated live-run shape: Claude Sonnet 4.6 through Anthropic and Kimi
+K2.7 Code through an OpenAI-compatible OpenRouter endpoint. Run the verifier
+before any live matrix spend:
+
+```bash
+python scripts/estimate_model_matrix_cost.py
+```
+
+As checked on 2026-06-16, the matrix uses Anthropic's published Claude Sonnet
+4.6 pricing (`$3 / MTok` input, `$15 / MTok` output) and OpenRouter's Kimi K2.7
+Code listing (`$0.75 / MTok` input, `$3.50 / MTok` output). With the existing
+25-request live-run ceiling, a 50,000 input-token assumption per call, 2,048
+output-token cap, and five trials per model, the dry-run estimate is
+250 model-call slots and `$28.1735` total. This script performs no live calls
+and does not require provider API keys.
 
 ## 🧪 Running Experiments
 

--- a/agent/agent.py
+++ b/agent/agent.py
@@ -22,6 +22,7 @@ from .fm_interface.api_handler import (
 )
 from .fm_interface.providers.gemini import GeminiHandler
 from .fm_interface.providers.anthropic import AnthropicHandler
+from .fm_interface.providers.openai_compatible import OpenAICompatibleHandler
 from .fm_interface.message_formatter import MessageFormatter, ConversationContext
 from .tools.base_tool import BaseTool, ToolRegistry, ToolResult, ToolExecutionStatus
 from .tools.bash_tool import BashTool
@@ -109,10 +110,19 @@ class Agent:
         Returns:
             ApiHandler: Configured handler instance
         """
-        if provider.lower() == "gemini":
+        provider_key = provider.lower().replace("-", "_")
+        if provider_key == "gemini":
             return GeminiHandler(fm_config)
-        elif provider.lower() == "anthropic":
+        elif provider_key == "anthropic":
             return AnthropicHandler(fm_config)
+        elif provider_key in {
+            "openai",
+            "openai_compatible",
+            "openrouter",
+            "kimi",
+            "moonshot",
+        }:
+            return OpenAICompatibleHandler(fm_config)
         else:
             raise ValueError(f"Unsupported FM provider: {provider}")
     

--- a/agent/fm_interface/providers/__init__.py
+++ b/agent/fm_interface/providers/__init__.py
@@ -7,5 +7,6 @@ for different Foundation Model providers.
 
 from .gemini import GeminiHandler
 from .anthropic import AnthropicHandler
+from .openai_compatible import OpenAICompatibleHandler
 
-__all__ = ["GeminiHandler", "AnthropicHandler"]
+__all__ = ["GeminiHandler", "AnthropicHandler", "OpenAICompatibleHandler"]

--- a/agent/fm_interface/providers/openai_compatible.py
+++ b/agent/fm_interface/providers/openai_compatible.py
@@ -1,0 +1,315 @@
+"""
+OpenAI-compatible chat completions handler implementation.
+
+This provider is intentionally generic: it works with OpenAI itself and with
+providers that expose the OpenAI Chat Completions API, such as OpenRouter or
+Moonshot/Kimi.
+"""
+
+import json
+import logging
+import time
+from typing import Any, Dict, List, Optional
+
+from openai import (
+    APIStatusError as OpenAIAPIStatusError,
+    AsyncOpenAI,
+    AuthenticationError as OpenAIAuthError,
+    OpenAIError,
+    RateLimitError as OpenAIRateLimitError,
+)
+
+from ..api_handler import (
+    ApiHandler,
+    CompletionRequest,
+    CompletionResponse,
+    Message,
+    MessageRole,
+    ToolCall,
+    ApiError,
+    RateLimitError,
+    AuthenticationError,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class OpenAICompatibleHandler(ApiHandler):
+    """
+    OpenAI Chat Completions-compatible implementation of the ApiHandler interface.
+
+    Message layout contract
+    -----------------------
+    * SYSTEM, USER, and ASSISTANT messages map directly to OpenAI roles.
+    * ASSISTANT messages that carry tool calls store them in
+      ``message.metadata["tool_calls"]`` as ``{id, name, input}`` dictionaries.
+    * TOOL messages should carry ``message.metadata["tool_use_id"]`` so they can
+      become OpenAI ``role=tool`` turns. Missing tool ids fall back to user text
+      so older conversations remain serializable.
+    """
+
+    def __init__(self, config: Dict[str, Any]):
+        super().__init__(config)
+        self.base_url = (
+            config.get("base_url")
+            or config.get("baseURL")
+            or "https://api.openai.com/v1"
+        )
+        self.extra_headers = config.get("extra_headers")
+        self.extra_body = config.get("extra_body")
+
+        self.validate_config()
+        self.client = AsyncOpenAI(
+            api_key=self.api_key,
+            base_url=self.base_url,
+            timeout=self.timeout,
+            max_retries=5,
+        )
+
+    async def get_completion(self, request: CompletionRequest) -> CompletionResponse:
+        """Get a completion from an OpenAI-compatible Chat Completions API."""
+        try:
+            messages = self.format_messages(request.messages)
+            if request.system_prompt:
+                messages = [
+                    {"role": "system", "content": request.system_prompt},
+                    *messages,
+                ]
+
+            temperature = (
+                request.temperature if request.temperature is not None else self.temperature
+            )
+            max_tokens = (
+                request.max_tokens if request.max_tokens is not None else self.max_tokens
+            )
+
+            api_params: Dict[str, Any] = {
+                "model": self.model,
+                "messages": messages,
+                "max_tokens": max_tokens,
+                "temperature": temperature,
+            }
+            if request.tools:
+                api_params["tools"] = self.format_tools(request.tools)
+            if isinstance(self.extra_headers, dict) and self.extra_headers:
+                api_params["extra_headers"] = self.extra_headers
+            if isinstance(self.extra_body, dict) and self.extra_body:
+                api_params["extra_body"] = self.extra_body
+
+            logger.info(
+                "Starting OpenAI-compatible API request "
+                f"(timeout: {self.timeout}s, model: {self.model}, base_url: {self.base_url})"
+            )
+            start_time = time.time()
+            response = await self.client.chat.completions.create(**api_params)
+            elapsed_time = time.time() - start_time
+            logger.info(
+                "OpenAI-compatible API request completed successfully "
+                f"in {elapsed_time:.2f}s"
+            )
+            return self.parse_response(response)
+
+        except OpenAIAuthError as exc:
+            raise AuthenticationError(
+                f"OpenAI-compatible authentication failed: {str(exc)}",
+                provider="openai_compatible",
+            ) from exc
+        except OpenAIRateLimitError as exc:
+            raise RateLimitError(
+                f"OpenAI-compatible rate limit exceeded: {str(exc)}",
+                provider="openai_compatible",
+            ) from exc
+        except OpenAIAPIStatusError as exc:
+            raise ApiError(
+                f"OpenAI-compatible API status error: {str(exc)}",
+                status_code=exc.status_code,
+                provider="openai_compatible",
+            ) from exc
+        except OpenAIError as exc:
+            raise ApiError(
+                f"OpenAI-compatible API error: {str(exc)}",
+                provider="openai_compatible",
+            ) from exc
+        except Exception as exc:
+            error_str = str(exc).lower()
+            if "rate" in error_str or "quota" in error_str:
+                raise RateLimitError(
+                    f"OpenAI-compatible rate limit exceeded: {str(exc)}",
+                    provider="openai_compatible",
+                ) from exc
+            if "authentication" in error_str or "api key" in error_str:
+                raise AuthenticationError(
+                    f"OpenAI-compatible authentication failed: {str(exc)}",
+                    provider="openai_compatible",
+                ) from exc
+            raise ApiError(
+                f"OpenAI-compatible API error: {str(exc)}",
+                provider="openai_compatible",
+            ) from exc
+
+    def format_messages(self, messages: List[Message]) -> List[Dict[str, Any]]:
+        """Convert internal messages to OpenAI Chat Completions format."""
+        formatted: List[Dict[str, Any]] = []
+        role_mapping = {
+            MessageRole.SYSTEM: "system",
+            MessageRole.USER: "user",
+            MessageRole.ASSISTANT: "assistant",
+        }
+
+        for message in messages:
+            if message.role == MessageRole.TOOL:
+                tool_call_id = (
+                    message.metadata.get("tool_use_id") if message.metadata else None
+                )
+                if tool_call_id:
+                    formatted.append(
+                        {
+                            "role": "tool",
+                            "tool_call_id": tool_call_id,
+                            "content": message.content or "",
+                        }
+                    )
+                else:
+                    formatted.append(
+                        {
+                            "role": "user",
+                            "content": f"Tool result:\n{message.content or ''}",
+                        }
+                    )
+                continue
+
+            formatted_message: Dict[str, Any] = {
+                "role": role_mapping.get(message.role, "user"),
+                "content": message.content or "",
+            }
+
+            tool_calls_meta: Optional[List[Dict[str, Any]]] = (
+                message.metadata.get("tool_calls") if message.metadata else None
+            )
+            if message.role == MessageRole.ASSISTANT and tool_calls_meta:
+                formatted_message["tool_calls"] = [
+                    {
+                        "id": tool_call["id"],
+                        "type": "function",
+                        "function": {
+                            "name": tool_call["name"],
+                            "arguments": json.dumps(tool_call["input"]),
+                        },
+                    }
+                    for tool_call in tool_calls_meta
+                ]
+                if not formatted_message["content"]:
+                    formatted_message["content"] = None
+
+            formatted.append(formatted_message)
+
+        return formatted
+
+    def parse_response(self, response: Any) -> CompletionResponse:
+        """Parse an OpenAI-compatible response into the standard format."""
+        try:
+            choices = self._get(response, "choices", [])
+            if not choices:
+                raise ApiError("OpenAI-compatible response did not include choices")
+
+            choice = choices[0]
+            message = self._get(choice, "message")
+            content = self._get(message, "content") or ""
+            tool_calls: List[ToolCall] = []
+
+            for raw_tool_call in self._get(message, "tool_calls", []) or []:
+                function = self._get(raw_tool_call, "function", {})
+                raw_arguments = self._get(function, "arguments", "{}")
+                parameters = self._parse_tool_arguments(raw_arguments)
+                tool_calls.append(
+                    ToolCall(
+                        tool_name=self._get(function, "name", "unknown"),
+                        parameters=parameters,
+                        call_id=self._get(raw_tool_call, "id"),
+                    )
+                )
+
+            if not content and not tool_calls:
+                content = "No response generated"
+
+            usage = None
+            raw_usage = self._get(response, "usage")
+            if raw_usage:
+                usage = {
+                    "prompt_tokens": int(self._get(raw_usage, "prompt_tokens", 0) or 0),
+                    "completion_tokens": int(
+                        self._get(raw_usage, "completion_tokens", 0) or 0
+                    ),
+                    "total_tokens": int(self._get(raw_usage, "total_tokens", 0) or 0),
+                }
+
+            return CompletionResponse(
+                content=content,
+                tool_calls=tool_calls,
+                usage=usage,
+                model=self._get(response, "model", self.model),
+                finish_reason=self._get(choice, "finish_reason"),
+            )
+
+        except ApiError:
+            raise
+        except Exception as exc:
+            raise ApiError(
+                f"Failed to parse OpenAI-compatible response: {str(exc)}",
+                provider="openai_compatible",
+            ) from exc
+
+    def format_tools(self, tools: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        """Convert standard tool definitions to OpenAI function-tool format."""
+        formatted_tools = []
+        for tool in tools:
+            parameters = tool.get(
+                "parameters",
+                {"type": "object", "properties": {}, "required": []},
+            )
+            if "type" not in parameters:
+                parameters = {"type": "object", **parameters}
+
+            formatted_tools.append(
+                {
+                    "type": "function",
+                    "function": {
+                        "name": tool.get("name", "unknown"),
+                        "description": tool.get("description", ""),
+                        "parameters": parameters,
+                    },
+                }
+            )
+        return formatted_tools
+
+    def validate_config(self) -> bool:
+        """Validate OpenAI-compatible configuration without stale model allowlists."""
+        super().validate_config()
+        if not isinstance(self.base_url, str) or not self.base_url.startswith(
+            ("https://", "http://")
+        ):
+            raise ValueError(f"Invalid OpenAI-compatible base_url: {self.base_url}")
+        return True
+
+    @staticmethod
+    def _get(value: Any, key: str, default: Any = None) -> Any:
+        """Read either dict keys or object attributes from SDK/fake responses."""
+        if isinstance(value, dict):
+            return value.get(key, default)
+        return getattr(value, key, default)
+
+    @staticmethod
+    def _parse_tool_arguments(raw_arguments: Any) -> Dict[str, Any]:
+        if raw_arguments is None:
+            return {}
+        if isinstance(raw_arguments, dict):
+            return raw_arguments
+        if not isinstance(raw_arguments, str):
+            return {"arguments": raw_arguments}
+        try:
+            parsed = json.loads(raw_arguments or "{}")
+        except json.JSONDecodeError:
+            return {"arguments": raw_arguments}
+        if isinstance(parsed, dict):
+            return parsed
+        return {"arguments": parsed}

--- a/config/dgm_config.yaml
+++ b/config/dgm_config.yaml
@@ -20,10 +20,11 @@ fm_providers:
     temperature: 0.1
     timeout: 60
   
-  # OpenAI Configuration (placeholder)
+  # OpenAI-compatible Configuration
   openai:
     model: gpt-4
     api_key: ${OPENAI_API_KEY}
+    base_url: https://api.openai.com/v1
     max_tokens: 8192
     temperature: 0.1
     timeout: 60

--- a/config/live_model_matrix.yaml
+++ b/config/live_model_matrix.yaml
@@ -1,0 +1,47 @@
+# Dry-run model-matrix plan for the calibrated live DGM benchmark.
+#
+# This config prepares a multi-trial provider comparison, but it is not a live
+# run command and must not spend API budget by itself. The verifier estimates
+# the full matrix cost from the bounded live_score_movement run shape before any
+# provider keys or network access are used.
+
+base_live_run_config: config/live_score_movement.yaml
+
+model_matrix:
+  purpose: live_model_matrix_dry_run
+  approval_required: true
+  dry_run_only: true
+  benchmark: humaneval_calibrated
+  trials_per_model: 5
+  max_trials_without_reapproval: 5
+  max_estimated_cost_usd: 30
+  assumed_input_tokens_per_call: 50000
+  pricing_checked_at: 2026-06-16
+  required_preflight:
+    - PATH="$PWD/.venv/bin:$PATH" python scripts/verify_demo_path.py
+    - PATH="$PWD/.venv/bin:$PATH" python scripts/estimate_model_matrix_cost.py --json
+  post_run_scorecard_template:
+    command: PATH="$PWD/.venv/bin:$PATH" python scripts/summarize_archive_scores.py --archive-metadata <archive_metadata.json> --output <scorecard.json> --require-improvement
+    require_improvement: true
+  models:
+    - id: claude-sonnet-4-6
+      provider: anthropic
+      model: claude-sonnet-4-6
+      api_key_env: ANTHROPIC_API_KEY
+      max_tokens: 2048
+      temperature: 0.1
+      timeout: 60
+      pricing_source: https://platform.claude.com/docs/en/about-claude/models/overview
+      input_price_per_mtok: 3
+      output_price_per_mtok: 15
+    - id: kimi-k2.7-code-openrouter
+      provider: openai_compatible
+      model: moonshotai/kimi-k2.7-code
+      api_key_env: OPENROUTER_API_KEY
+      base_url: https://openrouter.ai/api/v1
+      max_tokens: 2048
+      temperature: 0.1
+      timeout: 60
+      pricing_source: https://openrouter.ai/moonshotai/kimi-k2.7-code
+      input_price_per_mtok: 0.75
+      output_price_per_mtok: 3.50

--- a/scripts/estimate_model_matrix_cost.py
+++ b/scripts/estimate_model_matrix_cost.py
@@ -1,0 +1,301 @@
+#!/usr/bin/env python3
+"""Verify and estimate the dry-run live model-matrix plan."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from scripts.estimate_live_run_cost import estimate_live_run_cost
+
+
+class ModelMatrixPlanError(RuntimeError):
+    """Raised when a model-matrix plan is unsafe or cannot be estimated."""
+
+
+def _require(condition: bool, message: str) -> None:
+    if not condition:
+        raise ModelMatrixPlanError(message)
+
+
+def _load_yaml(path: Path) -> dict[str, Any]:
+    try:
+        data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    except FileNotFoundError as exc:
+        raise ModelMatrixPlanError(f"Missing config: {path}") from exc
+    except yaml.YAMLError as exc:
+        raise ModelMatrixPlanError(f"Invalid YAML in {path}: {exc}") from exc
+    _require(isinstance(data, dict), f"Config must be a mapping: {path}")
+    return data
+
+
+def _project_file(path_text: str, project_root: Path) -> Path:
+    path = Path(path_text).expanduser()
+    if not path.is_absolute():
+        path = project_root / path
+    try:
+        relative_path = path.resolve().relative_to(project_root.resolve())
+    except ValueError as exc:
+        raise ModelMatrixPlanError(f"{path_text} must stay inside the project root") from exc
+    path = project_root / relative_path
+    _require(path.is_file(), f"Missing required project file: {relative_path}")
+    return path
+
+
+def _require_positive(name: str, value: float) -> None:
+    if value <= 0:
+        raise ModelMatrixPlanError(f"{name} must be greater than zero")
+
+
+def _require_no_secret_fields(model: dict[str, Any]) -> None:
+    forbidden = {"api_key", "secret", "token"}
+    present = forbidden.intersection(model)
+    _require(
+        not present,
+        f"Model {model.get('id', '<unknown>')} must use api_key_env, not secret fields",
+    )
+
+
+def _model_cost(
+    *,
+    model: dict[str, Any],
+    request_ceiling: int,
+    assumed_input_tokens_per_call: int,
+    trials_per_model: int,
+) -> dict[str, Any]:
+    input_price = float(model.get("input_price_per_mtok", 0))
+    output_price = float(model.get("output_price_per_mtok", 0))
+    max_tokens = int(model.get("max_tokens", 0))
+    _require_positive(f"{model['id']}.input_price_per_mtok", input_price)
+    _require_positive(f"{model['id']}.output_price_per_mtok", output_price)
+    _require_positive(f"{model['id']}.max_tokens", max_tokens)
+
+    input_token_ceiling = request_ceiling * assumed_input_tokens_per_call
+    output_token_ceiling = request_ceiling * max_tokens
+    input_cost = input_token_ceiling / 1_000_000 * input_price
+    output_cost = output_token_ceiling / 1_000_000 * output_price
+    per_trial_total = input_cost + output_cost
+
+    return {
+        "id": model["id"],
+        "provider": model["provider"],
+        "model": model["model"],
+        "api_key_env": model["api_key_env"],
+        "base_url": model.get("base_url"),
+        "pricing_source": model["pricing_source"],
+        "input_price_per_mtok": input_price,
+        "output_price_per_mtok": output_price,
+        "request_ceiling_per_trial": request_ceiling,
+        "assumed_input_tokens_per_call": assumed_input_tokens_per_call,
+        "max_output_tokens_per_call": max_tokens,
+        "input_token_ceiling_per_trial": input_token_ceiling,
+        "output_token_ceiling_per_trial": output_token_ceiling,
+        "estimated_input_cost_usd_per_trial": input_cost,
+        "estimated_output_cost_usd_per_trial": output_cost,
+        "estimated_total_cost_usd_per_trial": per_trial_total,
+        "trials": trials_per_model,
+        "total_request_ceiling": request_ceiling * trials_per_model,
+        "estimated_total_cost_usd": per_trial_total * trials_per_model,
+    }
+
+
+def estimate_model_matrix_cost(
+    config_path: Path = PROJECT_ROOT / "config" / "live_model_matrix.yaml",
+    *,
+    project_root: Path = PROJECT_ROOT,
+) -> dict[str, Any]:
+    """Verify the dry-run matrix contract and estimate its bounded cost."""
+    project_root = project_root.resolve()
+    config_path = config_path if config_path.is_absolute() else project_root / config_path
+    config = _load_yaml(config_path)
+
+    base_config_path = _project_file(config.get("base_live_run_config", ""), project_root)
+    base_config = _load_yaml(base_config_path)
+
+    matrix = config.get("model_matrix", {})
+    _require(isinstance(matrix, dict), "model_matrix must be a mapping")
+    _require(
+        matrix.get("purpose") == "live_model_matrix_dry_run",
+        "Model matrix must declare live_model_matrix_dry_run purpose",
+    )
+    _require(matrix.get("approval_required") is True, "Model matrix must require approval")
+    _require(matrix.get("dry_run_only") is True, "Model matrix must stay dry_run_only")
+    _require(
+        matrix.get("benchmark") == "humaneval_calibrated",
+        "Model matrix must target humaneval_calibrated",
+    )
+    _require(
+        base_config.get("benchmarks", {}).get("enabled") == ["humaneval_calibrated"],
+        "Base live-run config must target humaneval_calibrated only",
+    )
+
+    trials_per_model = int(matrix.get("trials_per_model", 0))
+    max_trials_without_reapproval = int(matrix.get("max_trials_without_reapproval", 0))
+    assumed_input_tokens_per_call = int(matrix.get("assumed_input_tokens_per_call", 0))
+    max_estimated_cost_usd = float(matrix.get("max_estimated_cost_usd", 0))
+    _require_positive("trials_per_model", trials_per_model)
+    _require_positive("max_trials_without_reapproval", max_trials_without_reapproval)
+    _require_positive("assumed_input_tokens_per_call", assumed_input_tokens_per_call)
+    _require_positive("max_estimated_cost_usd", max_estimated_cost_usd)
+    _require(
+        trials_per_model <= max_trials_without_reapproval <= 10,
+        "Model matrix trials must stay bounded without reapproval",
+    )
+    _require(matrix.get("pricing_checked_at"), "Model matrix must record pricing_checked_at")
+
+    preflight = matrix.get("required_preflight", [])
+    _require(
+        any("scripts/verify_demo_path.py" in command for command in preflight),
+        "Model matrix preflight must include verify_demo_path.py",
+    )
+    _require(
+        any("scripts/estimate_model_matrix_cost.py" in command for command in preflight),
+        "Model matrix preflight must include this estimator",
+    )
+
+    scorecard = matrix.get("post_run_scorecard_template", {})
+    _require(
+        scorecard.get("require_improvement") is True,
+        "Model matrix post-run scorecard must require improvement",
+    )
+    _require(
+        "scripts/summarize_archive_scores.py" in scorecard.get("command", ""),
+        "Model matrix post-run scorecard command must summarize archive scores",
+    )
+    _require(
+        "--require-improvement" in scorecard.get("command", ""),
+        "Model matrix post-run scorecard must fail closed without improvement",
+    )
+
+    models = matrix.get("models", [])
+    _require(isinstance(models, list) and len(models) >= 2, "Model matrix needs at least two models")
+
+    base_estimate = estimate_live_run_cost(
+        config_path=base_config_path,
+        input_price_per_mtok=1,
+        output_price_per_mtok=1,
+        assumed_input_tokens_per_call=assumed_input_tokens_per_call,
+    )
+    request_ceiling = int(base_estimate["request_ceiling"])
+
+    model_reports: list[dict[str, Any]] = []
+    providers: set[str] = set()
+    for raw_model in models:
+        _require(isinstance(raw_model, dict), "Each model entry must be a mapping")
+        _require(raw_model.get("id"), "Each model must define id")
+        _require(raw_model.get("provider"), f"Model {raw_model.get('id')} must define provider")
+        _require(raw_model.get("model"), f"Model {raw_model.get('id')} must define model")
+        _require(raw_model.get("api_key_env"), f"Model {raw_model.get('id')} must define api_key_env")
+        _require(raw_model.get("pricing_source"), f"Model {raw_model.get('id')} must define pricing_source")
+        _require(
+            str(raw_model["pricing_source"]).startswith("https://"),
+            f"Model {raw_model['id']} pricing_source must be an HTTPS URL",
+        )
+        _require_no_secret_fields(raw_model)
+
+        provider = str(raw_model["provider"])
+        providers.add(provider)
+        if provider == "openai_compatible":
+            base_url = str(raw_model.get("base_url", ""))
+            _require(
+                base_url.startswith(("https://", "http://")),
+                f"Model {raw_model['id']} must define an OpenAI-compatible base_url",
+            )
+
+        model_reports.append(
+            _model_cost(
+                model=raw_model,
+                request_ceiling=request_ceiling,
+                assumed_input_tokens_per_call=assumed_input_tokens_per_call,
+                trials_per_model=trials_per_model,
+            )
+        )
+
+    _require("anthropic" in providers, "Model matrix must include an Anthropic baseline")
+    _require(
+        "openai_compatible" in providers,
+        "Model matrix must include an OpenAI-compatible comparison model",
+    )
+
+    total_cost = sum(item["estimated_total_cost_usd"] for item in model_reports)
+    total_requests = sum(item["total_request_ceiling"] for item in model_reports)
+    within_budget = total_cost <= max_estimated_cost_usd
+    _require(within_budget, "Model matrix estimate exceeds configured max budget")
+
+    return {
+        "name": "live_model_matrix_plan",
+        "status": "ok",
+        "config": str(config_path.relative_to(project_root)),
+        "base_live_run_config": str(base_config_path.relative_to(project_root)),
+        "benchmark": matrix["benchmark"],
+        "approval_required": True,
+        "dry_run_only": True,
+        "live_calls_performed": 0,
+        "pricing_checked_at": str(matrix["pricing_checked_at"]),
+        "trials_per_model": trials_per_model,
+        "model_count": len(model_reports),
+        "request_ceiling_per_trial": request_ceiling,
+        "total_request_ceiling": total_requests,
+        "assumed_input_tokens_per_call": assumed_input_tokens_per_call,
+        "estimated_total_cost_usd": total_cost,
+        "max_estimated_cost_usd": max_estimated_cost_usd,
+        "within_budget": within_budget,
+        "models": model_reports,
+    }
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--config",
+        default=str(PROJECT_ROOT / "config" / "live_model_matrix.yaml"),
+        help="Dry-run model-matrix config to verify and estimate.",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Print machine-readable JSON instead of a one-line status.",
+    )
+    return parser
+
+
+def _main(args: argparse.Namespace) -> int:
+    try:
+        report = estimate_model_matrix_cost(Path(args.config))
+    except ModelMatrixPlanError as exc:
+        if args.json:
+            print(json.dumps({"status": "failed", "error": str(exc)}, indent=2))
+        else:
+            print(f"[fail] {exc}", file=sys.stderr)
+        return 1
+
+    if args.json:
+        print(json.dumps(report, indent=2, sort_keys=True))
+    else:
+        print(
+            "[ok] live_model_matrix_plan "
+            f"models={report['model_count']} "
+            f"trials_per_model={report['trials_per_model']} "
+            f"requests<={report['total_request_ceiling']} "
+            f"total=${report['estimated_total_cost_usd']:.4f} "
+            "dry_run_only=true"
+        )
+    return 0
+
+
+def main() -> int:
+    return _main(_build_parser().parse_args())
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/verify_demo_path.py
+++ b/scripts/verify_demo_path.py
@@ -36,6 +36,7 @@ from scripts.run_dgm_in_sandbox import (
     write_run_audit,
 )
 from scripts.verify_live_score_movement_plan import verify_live_score_movement_plan
+from scripts.estimate_model_matrix_cost import estimate_model_matrix_cost
 
 
 class VerificationError(RuntimeError):
@@ -512,6 +513,7 @@ async def verify_demo_path(project_root: Path = PROJECT_ROOT) -> list[dict[str, 
         project_root / "README.md",
         project_root / "requirements.txt",
         project_root / "config" / "dgm_config.yaml",
+        project_root / "config" / "live_model_matrix.yaml",
         project_root / "config" / "live_score_movement.yaml",
         project_root / "config" / "benchmarks" / "humaneval_calibrated.yaml",
         project_root / "config" / "benchmarks" / "humaneval_headroom.yaml",
@@ -525,6 +527,7 @@ async def verify_demo_path(project_root: Path = PROJECT_ROOT) -> list[dict[str, 
         project_root / "docs" / "demo" / "humaneval_style_baseline.py",
         project_root / "docs" / "demo" / "humaneval_style_improved.py",
         project_root / "docs" / "demo" / "humaneval_score_movement.json",
+        project_root / "scripts" / "estimate_model_matrix_cost.py",
     ]
     checks.extend(_check_file(path, project_root) for path in required_files)
     checks.append(await _verify_humaneval_reference(project_root))
@@ -539,6 +542,12 @@ async def verify_demo_path(project_root: Path = PROJECT_ROOT) -> list[dict[str, 
     checks.append(
         verify_live_score_movement_plan(
             project_root / "config" / "live_score_movement.yaml",
+            project_root=project_root,
+        )
+    )
+    checks.append(
+        estimate_model_matrix_cost(
+            project_root / "config" / "live_model_matrix.yaml",
             project_root=project_root,
         )
     )

--- a/tests/integration/test_demo_path_verifier.py
+++ b/tests/integration/test_demo_path_verifier.py
@@ -21,6 +21,7 @@ async def test_no_network_demo_path_verifier_passes():
     assert "sandbox_runner_cli" in names
     assert "sandbox_discard_changes_contract" in names
     assert "live_score_movement_plan" in names
+    assert "live_model_matrix_plan" in names
     assert "live_score_movement_attempt_docs" in names
 
     score_check = next(check for check in checks if check["name"] == "score_movement_demo")
@@ -95,3 +96,17 @@ async def test_no_network_demo_path_verifier_passes():
     assert live_plan_check["request_ceiling"] == 25
     assert live_plan_check["estimated_total_cost_usd"] == pytest.approx(4.518)
     assert live_plan_check["max_estimated_cost_usd"] == 5
+
+    matrix_check = next(
+        check for check in checks if check["name"] == "live_model_matrix_plan"
+    )
+    assert matrix_check["benchmark"] == "humaneval_calibrated"
+    assert matrix_check["approval_required"] is True
+    assert matrix_check["dry_run_only"] is True
+    assert matrix_check["live_calls_performed"] == 0
+    assert matrix_check["trials_per_model"] == 5
+    assert matrix_check["model_count"] == 2
+    assert matrix_check["request_ceiling_per_trial"] == 25
+    assert matrix_check["total_request_ceiling"] == 250
+    assert matrix_check["estimated_total_cost_usd"] == pytest.approx(28.1735)
+    assert matrix_check["max_estimated_cost_usd"] == 30

--- a/tests/unit/test_agent.py
+++ b/tests/unit/test_agent.py
@@ -12,6 +12,7 @@ from agent.agent import Agent, AgentConfig, Task
 from agent.fm_interface.api_handler import (
     ApiHandler, CompletionResponse, CompletionRequest, ToolCall
 )
+from agent.fm_interface.providers.openai_compatible import OpenAICompatibleHandler
 from agent.tools.bash_tool import BashTool
 from agent.tools.edit_tool import EditTool
 
@@ -100,6 +101,22 @@ class TestAgentInit:
     def test_fm_handler_is_api_handler(self, tmp_path):
         agent = Agent(_make_config(tmp_path))
         assert isinstance(agent.fm_handler, ApiHandler)
+
+    def test_openai_compatible_provider_supported(self, tmp_path):
+        cfg = AgentConfig(
+            agent_id="x",
+            fm_provider="openai_compatible",
+            fm_config={
+                "model": "moonshotai/kimi-k2.7-code",
+                "api_key": "test-key-dummy",
+                "base_url": "https://openrouter.ai/api/v1",
+                "max_tokens": 256,
+                "temperature": 0.0,
+            },
+            working_directory=str(tmp_path),
+        )
+        agent = Agent(cfg)
+        assert isinstance(agent.fm_handler, OpenAICompatibleHandler)
 
     def test_unsupported_provider_raises(self, tmp_path):
         cfg = AgentConfig(

--- a/tests/unit/test_estimate_model_matrix_cost.py
+++ b/tests/unit/test_estimate_model_matrix_cost.py
@@ -1,0 +1,117 @@
+from copy import deepcopy
+from pathlib import Path
+
+import pytest
+import yaml
+
+from scripts.estimate_model_matrix_cost import (
+    ModelMatrixPlanError,
+    _build_parser,
+    _main,
+    estimate_model_matrix_cost,
+)
+
+
+def _load_default_plan(project_root: Path) -> dict:
+    return yaml.safe_load(
+        (project_root / "config" / "live_model_matrix.yaml").read_text(
+            encoding="utf-8"
+        )
+    )
+
+
+def _write_plan(tmp_path: Path, plan: dict) -> Path:
+    config_path = tmp_path / "live_model_matrix.yaml"
+    config_path.write_text(yaml.safe_dump(plan, sort_keys=False), encoding="utf-8")
+    return config_path
+
+
+def test_model_matrix_estimate_from_default_config():
+    project_root = Path(__file__).resolve().parents[2]
+
+    report = estimate_model_matrix_cost(project_root=project_root)
+
+    assert report["config"] == "config/live_model_matrix.yaml"
+    assert report["base_live_run_config"] == "config/live_score_movement.yaml"
+    assert report["benchmark"] == "humaneval_calibrated"
+    assert report["approval_required"] is True
+    assert report["dry_run_only"] is True
+    assert report["live_calls_performed"] == 0
+    assert report["trials_per_model"] == 5
+    assert report["model_count"] == 2
+    assert report["request_ceiling_per_trial"] == 25
+    assert report["total_request_ceiling"] == 250
+    assert report["estimated_total_cost_usd"] == pytest.approx(28.1735)
+    assert report["max_estimated_cost_usd"] == 30
+    assert report["within_budget"] is True
+
+    by_id = {model["id"]: model for model in report["models"]}
+    assert by_id["claude-sonnet-4-6"]["provider"] == "anthropic"
+    assert by_id["claude-sonnet-4-6"]["estimated_total_cost_usd"] == pytest.approx(22.59)
+    assert by_id["kimi-k2.7-code-openrouter"]["provider"] == "openai_compatible"
+    assert by_id["kimi-k2.7-code-openrouter"]["base_url"] == "https://openrouter.ai/api/v1"
+    assert by_id["kimi-k2.7-code-openrouter"]["estimated_total_cost_usd"] == pytest.approx(5.5835)
+
+
+def test_model_matrix_rejects_live_enabled_config(tmp_path):
+    project_root = Path(__file__).resolve().parents[2]
+    plan = deepcopy(_load_default_plan(project_root))
+    plan["model_matrix"]["dry_run_only"] = False
+    config_path = _write_plan(tmp_path, plan)
+
+    with pytest.raises(ModelMatrixPlanError, match="dry_run_only"):
+        estimate_model_matrix_cost(config_path, project_root=project_root)
+
+
+def test_model_matrix_rejects_secret_fields(tmp_path):
+    project_root = Path(__file__).resolve().parents[2]
+    plan = deepcopy(_load_default_plan(project_root))
+    plan["model_matrix"]["models"][1]["api_key"] = "sk-leaked"
+    config_path = _write_plan(tmp_path, plan)
+
+    with pytest.raises(ModelMatrixPlanError, match="api_key_env"):
+        estimate_model_matrix_cost(config_path, project_root=project_root)
+
+
+def test_model_matrix_rejects_missing_openai_base_url(tmp_path):
+    project_root = Path(__file__).resolve().parents[2]
+    plan = deepcopy(_load_default_plan(project_root))
+    del plan["model_matrix"]["models"][1]["base_url"]
+    config_path = _write_plan(tmp_path, plan)
+
+    with pytest.raises(ModelMatrixPlanError, match="base_url"):
+        estimate_model_matrix_cost(config_path, project_root=project_root)
+
+
+def test_model_matrix_rejects_over_budget(tmp_path):
+    project_root = Path(__file__).resolve().parents[2]
+    plan = deepcopy(_load_default_plan(project_root))
+    plan["model_matrix"]["max_estimated_cost_usd"] = 1
+    config_path = _write_plan(tmp_path, plan)
+
+    with pytest.raises(ModelMatrixPlanError, match="budget"):
+        estimate_model_matrix_cost(config_path, project_root=project_root)
+
+
+def test_model_matrix_cli_json(capsys):
+    args = _build_parser().parse_args(["--json"])
+
+    exit_code = _main(args)
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    assert '"status": "ok"' in captured.out
+    assert '"name": "live_model_matrix_plan"' in captured.out
+    assert '"live_calls_performed": 0' in captured.out
+
+
+def test_model_matrix_cli_text(capsys):
+    args = _build_parser().parse_args([])
+
+    exit_code = _main(args)
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    assert "live_model_matrix_plan" in captured.out
+    assert "requests<=250" in captured.out
+    assert "dry_run_only=true" in captured.out

--- a/tests/unit/test_openai_compatible_provider.py
+++ b/tests/unit/test_openai_compatible_provider.py
@@ -1,0 +1,213 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from agent.fm_interface.api_handler import (
+    ApiError,
+    CompletionRequest,
+    Message,
+    MessageRole,
+)
+from agent.fm_interface.providers.openai_compatible import OpenAICompatibleHandler
+
+
+def _handler(**overrides):
+    config = {
+        "api_key": "sk-test-dummy",
+        "base_url": "https://example.com/v1",
+        "model": "test/model",
+        "max_tokens": 256,
+        "temperature": 0.1,
+        "timeout": 10,
+    }
+    config.update(overrides)
+    return OpenAICompatibleHandler(config)
+
+
+def test_format_messages_preserves_openai_tool_call_shape():
+    h = _handler()
+
+    messages = [
+        Message(role=MessageRole.SYSTEM, content="system"),
+        Message(role=MessageRole.USER, content="do work"),
+        Message(
+            role=MessageRole.ASSISTANT,
+            content="calling bash",
+            metadata={
+                "tool_calls": [
+                    {
+                        "id": "call_123",
+                        "name": "bash",
+                        "input": {"command": "ls"},
+                    }
+                ]
+            },
+        ),
+        Message(
+            role=MessageRole.TOOL,
+            content="ok",
+            metadata={"tool_use_id": "call_123"},
+        ),
+    ]
+
+    formatted = h.format_messages(messages)
+
+    assert formatted[0] == {"role": "system", "content": "system"}
+    assert formatted[1] == {"role": "user", "content": "do work"}
+    assert formatted[2]["role"] == "assistant"
+    assert formatted[2]["tool_calls"][0]["id"] == "call_123"
+    assert formatted[2]["tool_calls"][0]["type"] == "function"
+    assert formatted[2]["tool_calls"][0]["function"]["name"] == "bash"
+    assert formatted[2]["tool_calls"][0]["function"]["arguments"] == '{"command": "ls"}'
+    assert formatted[3] == {
+        "role": "tool",
+        "tool_call_id": "call_123",
+        "content": "ok",
+    }
+
+
+def test_format_tools_uses_function_schema():
+    h = _handler()
+
+    formatted = h.format_tools(
+        [
+            {
+                "name": "edit",
+                "description": "Edit files",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"path": {"type": "string"}},
+                    "required": ["path"],
+                },
+            }
+        ]
+    )
+
+    assert formatted == [
+        {
+            "type": "function",
+            "function": {
+                "name": "edit",
+                "description": "Edit files",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"path": {"type": "string"}},
+                    "required": ["path"],
+                },
+            },
+        }
+    ]
+
+
+def test_parse_response_extracts_content_tool_calls_and_usage():
+    h = _handler()
+    response = SimpleNamespace(
+        model="test/model",
+        choices=[
+            SimpleNamespace(
+                finish_reason="tool_calls",
+                message=SimpleNamespace(
+                    content="I will run a command.",
+                    tool_calls=[
+                        SimpleNamespace(
+                            id="call_abc",
+                            function=SimpleNamespace(
+                                name="bash",
+                                arguments='{"command": "pwd"}',
+                            ),
+                        )
+                    ],
+                ),
+            )
+        ],
+        usage=SimpleNamespace(
+            prompt_tokens=11,
+            completion_tokens=7,
+            total_tokens=18,
+        ),
+    )
+
+    parsed = h.parse_response(response)
+
+    assert parsed.content == "I will run a command."
+    assert parsed.model == "test/model"
+    assert parsed.finish_reason == "tool_calls"
+    assert parsed.usage == {
+        "prompt_tokens": 11,
+        "completion_tokens": 7,
+        "total_tokens": 18,
+    }
+    assert len(parsed.tool_calls) == 1
+    assert parsed.tool_calls[0].tool_name == "bash"
+    assert parsed.tool_calls[0].parameters == {"command": "pwd"}
+    assert parsed.tool_calls[0].call_id == "call_abc"
+
+
+def test_parse_response_keeps_invalid_tool_arguments_as_raw_text():
+    h = _handler()
+    response = {
+        "model": "test/model",
+        "choices": [
+            {
+                "finish_reason": "tool_calls",
+                "message": {
+                    "content": "",
+                    "tool_calls": [
+                        {
+                            "id": "call_bad",
+                            "function": {
+                                "name": "bash",
+                                "arguments": "not-json",
+                            },
+                        }
+                    ],
+                },
+            }
+        ],
+    }
+
+    parsed = h.parse_response(response)
+
+    assert parsed.content == ""
+    assert parsed.tool_calls[0].parameters == {"arguments": "not-json"}
+
+
+async def test_get_completion_preserves_zero_temperature_and_extra_body():
+    h = _handler(extra_body={"reasoning": {"enabled": True}})
+    fake_response = {
+        "model": "test/model",
+        "choices": [{"message": {"content": "ok"}, "finish_reason": "stop"}],
+    }
+
+    with patch.object(
+        h.client.chat.completions,
+        "create",
+        new_callable=AsyncMock,
+        return_value=fake_response,
+    ) as mock_create:
+        request = CompletionRequest(
+            messages=[Message(role=MessageRole.USER, content="hi")],
+            max_tokens=12,
+            temperature=0.0,
+        )
+        parsed = await h.get_completion(request)
+
+    assert parsed.content == "ok"
+    mock_create.assert_awaited_once()
+    kwargs = mock_create.await_args.kwargs
+    assert kwargs["temperature"] == 0.0
+    assert kwargs["max_tokens"] == 12
+    assert kwargs["extra_body"] == {"reasoning": {"enabled": True}}
+
+
+def test_validate_config_rejects_bad_base_url():
+    with pytest.raises(ValueError, match="base_url"):
+        _handler(base_url="not-a-url")
+
+
+def test_parse_response_requires_choices():
+    h = _handler()
+
+    with pytest.raises(ApiError, match="choices"):
+        h.parse_response({"choices": []})


### PR DESCRIPTION
Summary
- Add an OpenAI-compatible chat completions handler and wire it into agent provider selection for OpenAI, OpenRouter, Kimi, and Moonshot-style configs.
- Add config/live_model_matrix.yaml plus scripts/estimate_model_matrix_cost.py for a no-spend Claude Sonnet 4.6 versus Kimi K2.7 Code dry-run matrix.
- Extend the no-network demo verifier and tests so the matrix plan is checked by default.

Verification
- .venv/bin/python -m pytest
- .venv/bin/python scripts/estimate_model_matrix_cost.py --json
- .venv/bin/python scripts/verify_demo_path.py
- .venv/bin/python scripts/verify_sandbox_docker.py --require

No live provider calls were run. The estimator reports live_calls_performed=0, 250 planned call slots, and estimated_total_cost_usd=28.1735.