### PR TITLE
[codex] Record live model matrix evidence

### DIFF
--- a/docs/live-runs/model-matrix-2026-06-16/README.md
+++ b/docs/live-runs/model-matrix-2026-06-16/README.md
@@ -1,0 +1,105 @@
+# Live model matrix run - 2026-06-16
+
+This directory records the first committed live model-matrix evidence artifact
+for the repository. The run used real provider calls through the Docker sandbox
+runner and completed five trials each for Claude Sonnet 4.6 and Kimi K2.7 Code
+through OpenRouter.
+
+## Command
+
+```bash
+OPENROUTER_API_KEY=<redacted> .venv/bin/python scripts/run_model_matrix.py \
+  --execute \
+  --allow-network \
+  --run-dir .dgm-live-runs/model-matrix-2026-06-16 \
+  --audit-dir .dgm-sandbox-runs/model-matrix-2026-06-16 \
+  --json
+```
+
+`ANTHROPIC_API_KEY` was already present in the local environment. The
+OpenRouter key value was recovered from a private local backup file, validated
+with OpenRouter's key endpoint, and was not committed.
+
+## Scope
+
+- Matrix config: `config/live_model_matrix.yaml`
+- Base live-run config: `config/live_score_movement.yaml`
+- Benchmark: `humaneval_calibrated`
+- Models: 2
+- Trials per model: 5
+- Generations per trial: 2
+- Total completed trials: 10 of 10
+- Total request ceiling: 250
+- Runtime output directory: `.dgm-live-runs/model-matrix-2026-06-16/`
+- Sandbox audit directory: `.dgm-sandbox-runs/model-matrix-2026-06-16/`
+
+The runtime directories remain ignored by git. This directory commits the stable
+proof materials: aggregate summary, normalized scorecards, and redacted sandbox
+audits.
+
+## Cost Gate
+
+The matrix runner produced a pre-run estimate of `$28.1735` against a configured
+maximum of `$30.0000`.
+
+| Model | Trials | Estimate per trial | Estimate total |
+| --- | ---: | ---: | ---: |
+| `claude-sonnet-4-6` | 5 | `$4.5180` | `$22.5900` |
+| `moonshotai/kimi-k2.7-code` | 5 | `$1.1167` | `$5.5835` |
+
+OpenRouter key metadata was checked before and after the OpenRouter leg. The
+observed OpenRouter usage delta was `$0.280637273`. Anthropic invoice-grade
+usage was not measured in this artifact; the committed Anthropic number is the
+runner's conservative estimate.
+
+## Result
+
+| Model ID | Provider | Trials | Top scores | Mean top score | Improvement trials | Regression trials |
+| --- | --- | ---: | --- | ---: | --- | --- |
+| `claude-sonnet-4-6` | `anthropic` | 5 | `0.88, 0.88, 0.88, 0.88, 0.88` | `0.88` | 1 | 0 |
+| `kimi-k2.7-code-openrouter` | `openai_compatible` | 5 | `0.92, 0.92, 0.92, 0.92, 0.92` | `0.92` | 0 | 3 |
+
+Trial-level scorecard summary:
+
+| Trial | Top score | Best average delta | Improvement | Regression |
+| --- | ---: | ---: | --- | --- |
+| `claude-sonnet-4-6-trial-01` | `0.88` | `0.88` | yes | no |
+| `claude-sonnet-4-6-trial-02` | `0.88` | `0.00` | no | no |
+| `claude-sonnet-4-6-trial-03` | `0.88` | `0.00` | no | no |
+| `claude-sonnet-4-6-trial-04` | `0.88` | `0.00` | no | no |
+| `claude-sonnet-4-6-trial-05` | `0.88` | `0.00` | no | no |
+| `kimi-k2-7-code-openrouter-trial-01` | `0.92` | `0.00` | no | no |
+| `kimi-k2-7-code-openrouter-trial-02` | `0.92` | `0.00` | no | yes |
+| `kimi-k2-7-code-openrouter-trial-03` | `0.92` | `0.00` | no | no |
+| `kimi-k2-7-code-openrouter-trial-04` | `0.92` | `0.00` | no | yes |
+| `kimi-k2-7-code-openrouter-trial-05` | `0.92` | `-0.02` | no | yes |
+
+Machine-readable details are in `summary.json`. Per-trial scorecards are in
+`scorecards/`, and per-trial sandbox audits are in `audits/`.
+
+## Evidence Notes
+
+- All 10 trials exited successfully.
+- All 10 scorecards reported 3 valid agents out of 3 total agents.
+- All 10 sandbox audits recorded `env_values` as `hidden`.
+- The audit files record environment variable names only:
+  `ANTHROPIC_API_KEY` or `OPENROUTER_API_KEY`.
+- Copied scorecards normalize `archive_metadata` to repo-relative ignored
+  runtime paths instead of local absolute paths.
+- Planner live calls remained at 0; provider calls happened only during the
+  explicit `--execute --allow-network` run.
+
+## Caveats
+
+The scorecard `has_improvement` and `best_average_delta` fields describe
+parent-child movement inside each isolated DGM run. They should not be read as a
+cross-model ranking by themselves.
+
+Kimi produced a higher top score than Claude in this matrix (`0.92` vs `0.88`),
+but three of five Kimi trials also had parent-child regression flags and none had
+a positive improvement trial. Claude was lower-scoring in this run but stable:
+five of five trials ended at `0.88` with no regression flags.
+
+This proves the live multi-provider matrix path executes under the sandbox and
+produces reviewable scorecards. It does not prove unattended autonomous
+improvement is ready for larger budgets.

--- a/docs/live-runs/model-matrix-2026-06-16/audits/claude-sonnet-4-6-trial-01-audit.json
+++ b/docs/live-runs/model-matrix-2026-06-16/audits/claude-sonnet-4-6-trial-01-audit.json
@@ -1,0 +1,15 @@
+{
+  "allow_network": true,
+  "config": ".dgm-live-runs/model-matrix-2026-06-16/configs/claude-sonnet-4-6-trial-01.yaml",
+  "env_names": [
+    "ANTHROPIC_API_KEY"
+  ],
+  "env_values": "hidden",
+  "generations": 2,
+  "network_mode": "bridge",
+  "stage_parent": "~/.cache/dgm-sandbox",
+  "stage_project": true,
+  "sync_back": true,
+  "sync_mode": "sync-back",
+  "timeout": 300
+}

--- a/docs/live-runs/model-matrix-2026-06-16/audits/claude-sonnet-4-6-trial-02-audit.json
+++ b/docs/live-runs/model-matrix-2026-06-16/audits/claude-sonnet-4-6-trial-02-audit.json
@@ -1,0 +1,15 @@
+{
+  "allow_network": true,
+  "config": ".dgm-live-runs/model-matrix-2026-06-16/configs/claude-sonnet-4-6-trial-02.yaml",
+  "env_names": [
+    "ANTHROPIC_API_KEY"
+  ],
+  "env_values": "hidden",
+  "generations": 2,
+  "network_mode": "bridge",
+  "stage_parent": "~/.cache/dgm-sandbox",
+  "stage_project": true,
+  "sync_back": true,
+  "sync_mode": "sync-back",
+  "timeout": 300
+}

--- a/docs/live-runs/model-matrix-2026-06-16/audits/claude-sonnet-4-6-trial-03-audit.json
+++ b/docs/live-runs/model-matrix-2026-06-16/audits/claude-sonnet-4-6-trial-03-audit.json
@@ -1,0 +1,15 @@
+{
+  "allow_network": true,
+  "config": ".dgm-live-runs/model-matrix-2026-06-16/configs/claude-sonnet-4-6-trial-03.yaml",
+  "env_names": [
+    "ANTHROPIC_API_KEY"
+  ],
+  "env_values": "hidden",
+  "generations": 2,
+  "network_mode": "bridge",
+  "stage_parent": "~/.cache/dgm-sandbox",
+  "stage_project": true,
+  "sync_back": true,
+  "sync_mode": "sync-back",
+  "timeout": 300
+}

--- a/docs/live-runs/model-matrix-2026-06-16/audits/claude-sonnet-4-6-trial-04-audit.json
+++ b/docs/live-runs/model-matrix-2026-06-16/audits/claude-sonnet-4-6-trial-04-audit.json
@@ -1,0 +1,15 @@
+{
+  "allow_network": true,
+  "config": ".dgm-live-runs/model-matrix-2026-06-16/configs/claude-sonnet-4-6-trial-04.yaml",
+  "env_names": [
+    "ANTHROPIC_API_KEY"
+  ],
+  "env_values": "hidden",
+  "generations": 2,
+  "network_mode": "bridge",
+  "stage_parent": "~/.cache/dgm-sandbox",
+  "stage_project": true,
+  "sync_back": true,
+  "sync_mode": "sync-back",
+  "timeout": 300
+}

--- a/docs/live-runs/model-matrix-2026-06-16/audits/claude-sonnet-4-6-trial-05-audit.json
+++ b/docs/live-runs/model-matrix-2026-06-16/audits/claude-sonnet-4-6-trial-05-audit.json
@@ -1,0 +1,15 @@
+{
+  "allow_network": true,
+  "config": ".dgm-live-runs/model-matrix-2026-06-16/configs/claude-sonnet-4-6-trial-05.yaml",
+  "env_names": [
+    "ANTHROPIC_API_KEY"
+  ],
+  "env_values": "hidden",
+  "generations": 2,
+  "network_mode": "bridge",
+  "stage_parent": "~/.cache/dgm-sandbox",
+  "stage_project": true,
+  "sync_back": true,
+  "sync_mode": "sync-back",
+  "timeout": 300
+}

--- a/docs/live-runs/model-matrix-2026-06-16/audits/kimi-k2-7-code-openrouter-trial-01-audit.json
+++ b/docs/live-runs/model-matrix-2026-06-16/audits/kimi-k2-7-code-openrouter-trial-01-audit.json
@@ -1,0 +1,15 @@
+{
+  "allow_network": true,
+  "config": ".dgm-live-runs/model-matrix-2026-06-16/configs/kimi-k2-7-code-openrouter-trial-01.yaml",
+  "env_names": [
+    "OPENROUTER_API_KEY"
+  ],
+  "env_values": "hidden",
+  "generations": 2,
+  "network_mode": "bridge",
+  "stage_parent": "~/.cache/dgm-sandbox",
+  "stage_project": true,
+  "sync_back": true,
+  "sync_mode": "sync-back",
+  "timeout": 300
+}

--- a/docs/live-runs/model-matrix-2026-06-16/audits/kimi-k2-7-code-openrouter-trial-02-audit.json
+++ b/docs/live-runs/model-matrix-2026-06-16/audits/kimi-k2-7-code-openrouter-trial-02-audit.json
@@ -1,0 +1,15 @@
+{
+  "allow_network": true,
+  "config": ".dgm-live-runs/model-matrix-2026-06-16/configs/kimi-k2-7-code-openrouter-trial-02.yaml",
+  "env_names": [
+    "OPENROUTER_API_KEY"
+  ],
+  "env_values": "hidden",
+  "generations": 2,
+  "network_mode": "bridge",
+  "stage_parent": "~/.cache/dgm-sandbox",
+  "stage_project": true,
+  "sync_back": true,
+  "sync_mode": "sync-back",
+  "timeout": 300
+}

--- a/docs/live-runs/model-matrix-2026-06-16/audits/kimi-k2-7-code-openrouter-trial-03-audit.json
+++ b/docs/live-runs/model-matrix-2026-06-16/audits/kimi-k2-7-code-openrouter-trial-03-audit.json
@@ -1,0 +1,15 @@
+{
+  "allow_network": true,
+  "config": ".dgm-live-runs/model-matrix-2026-06-16/configs/kimi-k2-7-code-openrouter-trial-03.yaml",
+  "env_names": [
+    "OPENROUTER_API_KEY"
+  ],
+  "env_values": "hidden",
+  "generations": 2,
+  "network_mode": "bridge",
+  "stage_parent": "~/.cache/dgm-sandbox",
+  "stage_project": true,
+  "sync_back": true,
+  "sync_mode": "sync-back",
+  "timeout": 300
+}

--- a/docs/live-runs/model-matrix-2026-06-16/audits/kimi-k2-7-code-openrouter-trial-04-audit.json
+++ b/docs/live-runs/model-matrix-2026-06-16/audits/kimi-k2-7-code-openrouter-trial-04-audit.json
@@ -1,0 +1,15 @@
+{
+  "allow_network": true,
+  "config": ".dgm-live-runs/model-matrix-2026-06-16/configs/kimi-k2-7-code-openrouter-trial-04.yaml",
+  "env_names": [
+    "OPENROUTER_API_KEY"
+  ],
+  "env_values": "hidden",
+  "generations": 2,
+  "network_mode": "bridge",
+  "stage_parent": "~/.cache/dgm-sandbox",
+  "stage_project": true,
+  "sync_back": true,
+  "sync_mode": "sync-back",
+  "timeout": 300
+}

--- a/docs/live-runs/model-matrix-2026-06-16/audits/kimi-k2-7-code-openrouter-trial-05-audit.json
+++ b/docs/live-runs/model-matrix-2026-06-16/audits/kimi-k2-7-code-openrouter-trial-05-audit.json
@@ -1,0 +1,15 @@
+{
+  "allow_network": true,
+  "config": ".dgm-live-runs/model-matrix-2026-06-16/configs/kimi-k2-7-code-openrouter-trial-05.yaml",
+  "env_names": [
+    "OPENROUTER_API_KEY"
+  ],
+  "env_values": "hidden",
+  "generations": 2,
+  "network_mode": "bridge",
+  "stage_parent": "~/.cache/dgm-sandbox",
+  "stage_project": true,
+  "sync_back": true,
+  "sync_mode": "sync-back",
+  "timeout": 300
+}

--- a/docs/live-runs/model-matrix-2026-06-16/scorecards/claude-sonnet-4-6-trial-01-scorecard.json
+++ b/docs/live-runs/model-matrix-2026-06-16/scorecards/claude-sonnet-4-6-trial-01-scorecard.json
@@ -1,0 +1,98 @@
+{
+  "archive_metadata": ".dgm-live-runs/model-matrix-2026-06-16/claude-sonnet-4-6-trial-01/archive/archive_metadata.json",
+  "best_average_delta": 0.88,
+  "generation_best_scores": [
+    {
+      "agent_id": "21085b94-dc6b-4517-a72e-8bc9e08eacf2",
+      "average_score": 0.0,
+      "benchmark_scores": {
+        "humaneval_calibrated": 0.0
+      },
+      "generation": 0
+    },
+    {
+      "agent_id": "7cbf5309-0886-4c2a-b5e2-c1264a8fc267",
+      "average_score": 0.88,
+      "benchmark_scores": {
+        "humaneval_calibrated": 0.88
+      },
+      "generation": 1
+    },
+    {
+      "agent_id": "c37b4d8a-ace0-4b71-8138-74088b605ab2",
+      "average_score": 0.88,
+      "benchmark_scores": {
+        "humaneval_calibrated": 0.88
+      },
+      "generation": 2
+    }
+  ],
+  "has_improvement": true,
+  "has_regression": false,
+  "improvements": [
+    {
+      "average_delta": 0.88,
+      "benchmark_deltas": {
+        "humaneval_calibrated": 0.88
+      },
+      "benchmark_improvements": {
+        "humaneval_calibrated": 0.88
+      },
+      "benchmark_regressions": {},
+      "benchmark_unchanged": [],
+      "child_average_score": 0.88,
+      "child_generation": 1,
+      "child_id": "7cbf5309-0886-4c2a-b5e2-c1264a8fc267",
+      "is_improvement": true,
+      "parent_average_score": 0.0,
+      "parent_generation": 0,
+      "parent_id": "21085b94-dc6b-4517-a72e-8bc9e08eacf2"
+    }
+  ],
+  "min_delta": 0.0,
+  "parent_child_deltas": [
+    {
+      "average_delta": 0.88,
+      "benchmark_deltas": {
+        "humaneval_calibrated": 0.88
+      },
+      "benchmark_improvements": {
+        "humaneval_calibrated": 0.88
+      },
+      "benchmark_regressions": {},
+      "benchmark_unchanged": [],
+      "child_average_score": 0.88,
+      "child_generation": 1,
+      "child_id": "7cbf5309-0886-4c2a-b5e2-c1264a8fc267",
+      "is_improvement": true,
+      "parent_average_score": 0.0,
+      "parent_generation": 0,
+      "parent_id": "21085b94-dc6b-4517-a72e-8bc9e08eacf2"
+    },
+    {
+      "average_delta": 0.0,
+      "benchmark_deltas": {
+        "humaneval_calibrated": 0.0
+      },
+      "benchmark_improvements": {},
+      "benchmark_regressions": {},
+      "benchmark_unchanged": [
+        "humaneval_calibrated"
+      ],
+      "child_average_score": 0.88,
+      "child_generation": 2,
+      "child_id": "c37b4d8a-ace0-4b71-8138-74088b605ab2",
+      "is_improvement": false,
+      "parent_average_score": 0.88,
+      "parent_generation": 1,
+      "parent_id": "7cbf5309-0886-4c2a-b5e2-c1264a8fc267"
+    }
+  ],
+  "top_agent_id": "7cbf5309-0886-4c2a-b5e2-c1264a8fc267",
+  "top_score": 0.88,
+  "total_agents": 3,
+  "total_benchmark_improvements": 1,
+  "total_benchmark_regressions": 0,
+  "total_benchmark_unchanged": 1,
+  "valid_agents": 3
+}

--- a/docs/live-runs/model-matrix-2026-06-16/scorecards/claude-sonnet-4-6-trial-02-scorecard.json
+++ b/docs/live-runs/model-matrix-2026-06-16/scorecards/claude-sonnet-4-6-trial-02-scorecard.json
@@ -1,0 +1,79 @@
+{
+  "archive_metadata": ".dgm-live-runs/model-matrix-2026-06-16/claude-sonnet-4-6-trial-02/archive/archive_metadata.json",
+  "best_average_delta": 0.0,
+  "generation_best_scores": [
+    {
+      "agent_id": "208e341e-3ab1-4ec7-a82b-a647effdca42",
+      "average_score": 0.88,
+      "benchmark_scores": {
+        "humaneval_calibrated": 0.88
+      },
+      "generation": 0
+    },
+    {
+      "agent_id": "6dfbf63c-2e94-49c1-8fdd-da0d396719a4",
+      "average_score": 0.88,
+      "benchmark_scores": {
+        "humaneval_calibrated": 0.88
+      },
+      "generation": 1
+    },
+    {
+      "agent_id": "3e1ff8ba-b2e1-438c-8834-01b115e93955",
+      "average_score": 0.88,
+      "benchmark_scores": {
+        "humaneval_calibrated": 0.88
+      },
+      "generation": 2
+    }
+  ],
+  "has_improvement": false,
+  "has_regression": false,
+  "improvements": [],
+  "min_delta": 0.0,
+  "parent_child_deltas": [
+    {
+      "average_delta": 0.0,
+      "benchmark_deltas": {
+        "humaneval_calibrated": 0.0
+      },
+      "benchmark_improvements": {},
+      "benchmark_regressions": {},
+      "benchmark_unchanged": [
+        "humaneval_calibrated"
+      ],
+      "child_average_score": 0.88,
+      "child_generation": 1,
+      "child_id": "6dfbf63c-2e94-49c1-8fdd-da0d396719a4",
+      "is_improvement": false,
+      "parent_average_score": 0.88,
+      "parent_generation": 0,
+      "parent_id": "208e341e-3ab1-4ec7-a82b-a647effdca42"
+    },
+    {
+      "average_delta": 0.0,
+      "benchmark_deltas": {
+        "humaneval_calibrated": 0.0
+      },
+      "benchmark_improvements": {},
+      "benchmark_regressions": {},
+      "benchmark_unchanged": [
+        "humaneval_calibrated"
+      ],
+      "child_average_score": 0.88,
+      "child_generation": 2,
+      "child_id": "3e1ff8ba-b2e1-438c-8834-01b115e93955",
+      "is_improvement": false,
+      "parent_average_score": 0.88,
+      "parent_generation": 1,
+      "parent_id": "6dfbf63c-2e94-49c1-8fdd-da0d396719a4"
+    }
+  ],
+  "top_agent_id": "208e341e-3ab1-4ec7-a82b-a647effdca42",
+  "top_score": 0.88,
+  "total_agents": 3,
+  "total_benchmark_improvements": 0,
+  "total_benchmark_regressions": 0,
+  "total_benchmark_unchanged": 2,
+  "valid_agents": 3
+}

--- a/docs/live-runs/model-matrix-2026-06-16/scorecards/claude-sonnet-4-6-trial-03-scorecard.json
+++ b/docs/live-runs/model-matrix-2026-06-16/scorecards/claude-sonnet-4-6-trial-03-scorecard.json
@@ -1,0 +1,71 @@
+{
+  "archive_metadata": ".dgm-live-runs/model-matrix-2026-06-16/claude-sonnet-4-6-trial-03/archive/archive_metadata.json",
+  "best_average_delta": 0.0,
+  "generation_best_scores": [
+    {
+      "agent_id": "853e0e46-4ac0-4510-8f04-73d8c30440c2",
+      "average_score": 0.88,
+      "benchmark_scores": {
+        "humaneval_calibrated": 0.88
+      },
+      "generation": 0
+    },
+    {
+      "agent_id": "3ff13969-ba67-4f7d-b0ff-6befd8c59bdd",
+      "average_score": 0.88,
+      "benchmark_scores": {
+        "humaneval_calibrated": 0.88
+      },
+      "generation": 1
+    }
+  ],
+  "has_improvement": false,
+  "has_regression": false,
+  "improvements": [],
+  "min_delta": 0.0,
+  "parent_child_deltas": [
+    {
+      "average_delta": 0.0,
+      "benchmark_deltas": {
+        "humaneval_calibrated": 0.0
+      },
+      "benchmark_improvements": {},
+      "benchmark_regressions": {},
+      "benchmark_unchanged": [
+        "humaneval_calibrated"
+      ],
+      "child_average_score": 0.88,
+      "child_generation": 1,
+      "child_id": "3ff13969-ba67-4f7d-b0ff-6befd8c59bdd",
+      "is_improvement": false,
+      "parent_average_score": 0.88,
+      "parent_generation": 0,
+      "parent_id": "853e0e46-4ac0-4510-8f04-73d8c30440c2"
+    },
+    {
+      "average_delta": 0.0,
+      "benchmark_deltas": {
+        "humaneval_calibrated": 0.0
+      },
+      "benchmark_improvements": {},
+      "benchmark_regressions": {},
+      "benchmark_unchanged": [
+        "humaneval_calibrated"
+      ],
+      "child_average_score": 0.88,
+      "child_generation": 1,
+      "child_id": "14afbfe6-c1bd-4a42-ac35-5213adce95ae",
+      "is_improvement": false,
+      "parent_average_score": 0.88,
+      "parent_generation": 0,
+      "parent_id": "853e0e46-4ac0-4510-8f04-73d8c30440c2"
+    }
+  ],
+  "top_agent_id": "853e0e46-4ac0-4510-8f04-73d8c30440c2",
+  "top_score": 0.88,
+  "total_agents": 3,
+  "total_benchmark_improvements": 0,
+  "total_benchmark_regressions": 0,
+  "total_benchmark_unchanged": 2,
+  "valid_agents": 3
+}

--- a/docs/live-runs/model-matrix-2026-06-16/scorecards/claude-sonnet-4-6-trial-04-scorecard.json
+++ b/docs/live-runs/model-matrix-2026-06-16/scorecards/claude-sonnet-4-6-trial-04-scorecard.json
@@ -1,0 +1,79 @@
+{
+  "archive_metadata": ".dgm-live-runs/model-matrix-2026-06-16/claude-sonnet-4-6-trial-04/archive/archive_metadata.json",
+  "best_average_delta": 0.0,
+  "generation_best_scores": [
+    {
+      "agent_id": "4058215e-bcff-4154-ac14-c3110806e5d6",
+      "average_score": 0.88,
+      "benchmark_scores": {
+        "humaneval_calibrated": 0.88
+      },
+      "generation": 0
+    },
+    {
+      "agent_id": "0e2c55c2-3b96-4532-acad-70c3403d11b2",
+      "average_score": 0.88,
+      "benchmark_scores": {
+        "humaneval_calibrated": 0.88
+      },
+      "generation": 1
+    },
+    {
+      "agent_id": "7dbc1878-bdd0-45ab-ae42-dfb3fd64b6af",
+      "average_score": 0.88,
+      "benchmark_scores": {
+        "humaneval_calibrated": 0.88
+      },
+      "generation": 2
+    }
+  ],
+  "has_improvement": false,
+  "has_regression": false,
+  "improvements": [],
+  "min_delta": 0.0,
+  "parent_child_deltas": [
+    {
+      "average_delta": 0.0,
+      "benchmark_deltas": {
+        "humaneval_calibrated": 0.0
+      },
+      "benchmark_improvements": {},
+      "benchmark_regressions": {},
+      "benchmark_unchanged": [
+        "humaneval_calibrated"
+      ],
+      "child_average_score": 0.88,
+      "child_generation": 1,
+      "child_id": "0e2c55c2-3b96-4532-acad-70c3403d11b2",
+      "is_improvement": false,
+      "parent_average_score": 0.88,
+      "parent_generation": 0,
+      "parent_id": "4058215e-bcff-4154-ac14-c3110806e5d6"
+    },
+    {
+      "average_delta": 0.0,
+      "benchmark_deltas": {
+        "humaneval_calibrated": 0.0
+      },
+      "benchmark_improvements": {},
+      "benchmark_regressions": {},
+      "benchmark_unchanged": [
+        "humaneval_calibrated"
+      ],
+      "child_average_score": 0.88,
+      "child_generation": 2,
+      "child_id": "7dbc1878-bdd0-45ab-ae42-dfb3fd64b6af",
+      "is_improvement": false,
+      "parent_average_score": 0.88,
+      "parent_generation": 1,
+      "parent_id": "0e2c55c2-3b96-4532-acad-70c3403d11b2"
+    }
+  ],
+  "top_agent_id": "4058215e-bcff-4154-ac14-c3110806e5d6",
+  "top_score": 0.88,
+  "total_agents": 3,
+  "total_benchmark_improvements": 0,
+  "total_benchmark_regressions": 0,
+  "total_benchmark_unchanged": 2,
+  "valid_agents": 3
+}

--- a/docs/live-runs/model-matrix-2026-06-16/scorecards/claude-sonnet-4-6-trial-05-scorecard.json
+++ b/docs/live-runs/model-matrix-2026-06-16/scorecards/claude-sonnet-4-6-trial-05-scorecard.json
@@ -1,0 +1,79 @@
+{
+  "archive_metadata": ".dgm-live-runs/model-matrix-2026-06-16/claude-sonnet-4-6-trial-05/archive/archive_metadata.json",
+  "best_average_delta": 0.0,
+  "generation_best_scores": [
+    {
+      "agent_id": "03f09fea-65c6-4df9-a564-02dad25a6379",
+      "average_score": 0.88,
+      "benchmark_scores": {
+        "humaneval_calibrated": 0.88
+      },
+      "generation": 0
+    },
+    {
+      "agent_id": "6cd27368-81cd-4d00-b98a-59bc0eabc284",
+      "average_score": 0.88,
+      "benchmark_scores": {
+        "humaneval_calibrated": 0.88
+      },
+      "generation": 1
+    },
+    {
+      "agent_id": "fba7c03c-784c-4922-9178-c186b80fe6d9",
+      "average_score": 0.88,
+      "benchmark_scores": {
+        "humaneval_calibrated": 0.88
+      },
+      "generation": 2
+    }
+  ],
+  "has_improvement": false,
+  "has_regression": false,
+  "improvements": [],
+  "min_delta": 0.0,
+  "parent_child_deltas": [
+    {
+      "average_delta": 0.0,
+      "benchmark_deltas": {
+        "humaneval_calibrated": 0.0
+      },
+      "benchmark_improvements": {},
+      "benchmark_regressions": {},
+      "benchmark_unchanged": [
+        "humaneval_calibrated"
+      ],
+      "child_average_score": 0.88,
+      "child_generation": 1,
+      "child_id": "6cd27368-81cd-4d00-b98a-59bc0eabc284",
+      "is_improvement": false,
+      "parent_average_score": 0.88,
+      "parent_generation": 0,
+      "parent_id": "03f09fea-65c6-4df9-a564-02dad25a6379"
+    },
+    {
+      "average_delta": 0.0,
+      "benchmark_deltas": {
+        "humaneval_calibrated": 0.0
+      },
+      "benchmark_improvements": {},
+      "benchmark_regressions": {},
+      "benchmark_unchanged": [
+        "humaneval_calibrated"
+      ],
+      "child_average_score": 0.88,
+      "child_generation": 2,
+      "child_id": "fba7c03c-784c-4922-9178-c186b80fe6d9",
+      "is_improvement": false,
+      "parent_average_score": 0.88,
+      "parent_generation": 1,
+      "parent_id": "6cd27368-81cd-4d00-b98a-59bc0eabc284"
+    }
+  ],
+  "top_agent_id": "03f09fea-65c6-4df9-a564-02dad25a6379",
+  "top_score": 0.88,
+  "total_agents": 3,
+  "total_benchmark_improvements": 0,
+  "total_benchmark_regressions": 0,
+  "total_benchmark_unchanged": 2,
+  "valid_agents": 3
+}

--- a/docs/live-runs/model-matrix-2026-06-16/scorecards/kimi-k2-7-code-openrouter-trial-01-scorecard.json
+++ b/docs/live-runs/model-matrix-2026-06-16/scorecards/kimi-k2-7-code-openrouter-trial-01-scorecard.json
@@ -1,0 +1,79 @@
+{
+  "archive_metadata": ".dgm-live-runs/model-matrix-2026-06-16/kimi-k2-7-code-openrouter-trial-01/archive/archive_metadata.json",
+  "best_average_delta": 0.0,
+  "generation_best_scores": [
+    {
+      "agent_id": "3eb500d9-343a-4b9f-a962-44fe2f93527c",
+      "average_score": 0.92,
+      "benchmark_scores": {
+        "humaneval_calibrated": 0.92
+      },
+      "generation": 0
+    },
+    {
+      "agent_id": "72210758-40c8-4bd3-82f5-ac7f9eaf70b0",
+      "average_score": 0.92,
+      "benchmark_scores": {
+        "humaneval_calibrated": 0.92
+      },
+      "generation": 1
+    },
+    {
+      "agent_id": "d0d37981-b090-41fa-930b-d7d6a9d5e937",
+      "average_score": 0.92,
+      "benchmark_scores": {
+        "humaneval_calibrated": 0.92
+      },
+      "generation": 2
+    }
+  ],
+  "has_improvement": false,
+  "has_regression": false,
+  "improvements": [],
+  "min_delta": 0.0,
+  "parent_child_deltas": [
+    {
+      "average_delta": 0.0,
+      "benchmark_deltas": {
+        "humaneval_calibrated": 0.0
+      },
+      "benchmark_improvements": {},
+      "benchmark_regressions": {},
+      "benchmark_unchanged": [
+        "humaneval_calibrated"
+      ],
+      "child_average_score": 0.92,
+      "child_generation": 1,
+      "child_id": "72210758-40c8-4bd3-82f5-ac7f9eaf70b0",
+      "is_improvement": false,
+      "parent_average_score": 0.92,
+      "parent_generation": 0,
+      "parent_id": "3eb500d9-343a-4b9f-a962-44fe2f93527c"
+    },
+    {
+      "average_delta": 0.0,
+      "benchmark_deltas": {
+        "humaneval_calibrated": 0.0
+      },
+      "benchmark_improvements": {},
+      "benchmark_regressions": {},
+      "benchmark_unchanged": [
+        "humaneval_calibrated"
+      ],
+      "child_average_score": 0.92,
+      "child_generation": 2,
+      "child_id": "d0d37981-b090-41fa-930b-d7d6a9d5e937",
+      "is_improvement": false,
+      "parent_average_score": 0.92,
+      "parent_generation": 1,
+      "parent_id": "72210758-40c8-4bd3-82f5-ac7f9eaf70b0"
+    }
+  ],
+  "top_agent_id": "3eb500d9-343a-4b9f-a962-44fe2f93527c",
+  "top_score": 0.92,
+  "total_agents": 3,
+  "total_benchmark_improvements": 0,
+  "total_benchmark_regressions": 0,
+  "total_benchmark_unchanged": 2,
+  "valid_agents": 3
+}

--- a/docs/live-runs/model-matrix-2026-06-16/scorecards/kimi-k2-7-code-openrouter-trial-02-scorecard.json
+++ b/docs/live-runs/model-matrix-2026-06-16/scorecards/kimi-k2-7-code-openrouter-trial-02-scorecard.json
@@ -1,0 +1,71 @@
+{
+  "archive_metadata": ".dgm-live-runs/model-matrix-2026-06-16/kimi-k2-7-code-openrouter-trial-02/archive/archive_metadata.json",
+  "best_average_delta": 0.0,
+  "generation_best_scores": [
+    {
+      "agent_id": "173d465b-a3ee-45cc-b0fe-f1c90a6dbf16",
+      "average_score": 0.92,
+      "benchmark_scores": {
+        "humaneval_calibrated": 0.92
+      },
+      "generation": 0
+    },
+    {
+      "agent_id": "9c90fc16-b424-4fa2-aea7-81d8b38cada3",
+      "average_score": 0.92,
+      "benchmark_scores": {
+        "humaneval_calibrated": 0.92
+      },
+      "generation": 1
+    }
+  ],
+  "has_improvement": false,
+  "has_regression": true,
+  "improvements": [],
+  "min_delta": 0.0,
+  "parent_child_deltas": [
+    {
+      "average_delta": -0.020000000000000018,
+      "benchmark_deltas": {
+        "humaneval_calibrated": -0.020000000000000018
+      },
+      "benchmark_improvements": {},
+      "benchmark_regressions": {
+        "humaneval_calibrated": -0.020000000000000018
+      },
+      "benchmark_unchanged": [],
+      "child_average_score": 0.9,
+      "child_generation": 1,
+      "child_id": "db5307b3-d169-4104-843c-835689e46c7b",
+      "is_improvement": false,
+      "parent_average_score": 0.92,
+      "parent_generation": 0,
+      "parent_id": "173d465b-a3ee-45cc-b0fe-f1c90a6dbf16"
+    },
+    {
+      "average_delta": 0.0,
+      "benchmark_deltas": {
+        "humaneval_calibrated": 0.0
+      },
+      "benchmark_improvements": {},
+      "benchmark_regressions": {},
+      "benchmark_unchanged": [
+        "humaneval_calibrated"
+      ],
+      "child_average_score": 0.92,
+      "child_generation": 1,
+      "child_id": "9c90fc16-b424-4fa2-aea7-81d8b38cada3",
+      "is_improvement": false,
+      "parent_average_score": 0.92,
+      "parent_generation": 0,
+      "parent_id": "173d465b-a3ee-45cc-b0fe-f1c90a6dbf16"
+    }
+  ],
+  "top_agent_id": "173d465b-a3ee-45cc-b0fe-f1c90a6dbf16",
+  "top_score": 0.92,
+  "total_agents": 3,
+  "total_benchmark_improvements": 0,
+  "total_benchmark_regressions": 1,
+  "total_benchmark_unchanged": 1,
+  "valid_agents": 3
+}

--- a/docs/live-runs/model-matrix-2026-06-16/scorecards/kimi-k2-7-code-openrouter-trial-03-scorecard.json
+++ b/docs/live-runs/model-matrix-2026-06-16/scorecards/kimi-k2-7-code-openrouter-trial-03-scorecard.json
@@ -1,0 +1,79 @@
+{
+  "archive_metadata": ".dgm-live-runs/model-matrix-2026-06-16/kimi-k2-7-code-openrouter-trial-03/archive/archive_metadata.json",
+  "best_average_delta": 0.0,
+  "generation_best_scores": [
+    {
+      "agent_id": "90e6d024-5cff-4630-b54d-8f65e4d04f00",
+      "average_score": 0.92,
+      "benchmark_scores": {
+        "humaneval_calibrated": 0.92
+      },
+      "generation": 0
+    },
+    {
+      "agent_id": "5acd9175-f616-42b3-9209-b77ae4c205ef",
+      "average_score": 0.92,
+      "benchmark_scores": {
+        "humaneval_calibrated": 0.92
+      },
+      "generation": 1
+    },
+    {
+      "agent_id": "f22a6ca5-f193-4461-8127-066d6f38aa65",
+      "average_score": 0.92,
+      "benchmark_scores": {
+        "humaneval_calibrated": 0.92
+      },
+      "generation": 2
+    }
+  ],
+  "has_improvement": false,
+  "has_regression": false,
+  "improvements": [],
+  "min_delta": 0.0,
+  "parent_child_deltas": [
+    {
+      "average_delta": 0.0,
+      "benchmark_deltas": {
+        "humaneval_calibrated": 0.0
+      },
+      "benchmark_improvements": {},
+      "benchmark_regressions": {},
+      "benchmark_unchanged": [
+        "humaneval_calibrated"
+      ],
+      "child_average_score": 0.92,
+      "child_generation": 1,
+      "child_id": "5acd9175-f616-42b3-9209-b77ae4c205ef",
+      "is_improvement": false,
+      "parent_average_score": 0.92,
+      "parent_generation": 0,
+      "parent_id": "90e6d024-5cff-4630-b54d-8f65e4d04f00"
+    },
+    {
+      "average_delta": 0.0,
+      "benchmark_deltas": {
+        "humaneval_calibrated": 0.0
+      },
+      "benchmark_improvements": {},
+      "benchmark_regressions": {},
+      "benchmark_unchanged": [
+        "humaneval_calibrated"
+      ],
+      "child_average_score": 0.92,
+      "child_generation": 2,
+      "child_id": "f22a6ca5-f193-4461-8127-066d6f38aa65",
+      "is_improvement": false,
+      "parent_average_score": 0.92,
+      "parent_generation": 1,
+      "parent_id": "5acd9175-f616-42b3-9209-b77ae4c205ef"
+    }
+  ],
+  "top_agent_id": "90e6d024-5cff-4630-b54d-8f65e4d04f00",
+  "top_score": 0.92,
+  "total_agents": 3,
+  "total_benchmark_improvements": 0,
+  "total_benchmark_regressions": 0,
+  "total_benchmark_unchanged": 2,
+  "valid_agents": 3
+}

--- a/docs/live-runs/model-matrix-2026-06-16/scorecards/kimi-k2-7-code-openrouter-trial-04-scorecard.json
+++ b/docs/live-runs/model-matrix-2026-06-16/scorecards/kimi-k2-7-code-openrouter-trial-04-scorecard.json
@@ -1,0 +1,79 @@
+{
+  "archive_metadata": ".dgm-live-runs/model-matrix-2026-06-16/kimi-k2-7-code-openrouter-trial-04/archive/archive_metadata.json",
+  "best_average_delta": 0.0,
+  "generation_best_scores": [
+    {
+      "agent_id": "c7e2cbb8-f06f-48d8-a540-22f70e80c848",
+      "average_score": 0.92,
+      "benchmark_scores": {
+        "humaneval_calibrated": 0.92
+      },
+      "generation": 0
+    },
+    {
+      "agent_id": "cd97553c-280c-44d8-8b26-36d002b34ff7",
+      "average_score": 0.92,
+      "benchmark_scores": {
+        "humaneval_calibrated": 0.92
+      },
+      "generation": 1
+    },
+    {
+      "agent_id": "35cd5326-bb34-42ae-b5d7-089c07f4e2d5",
+      "average_score": 0.88,
+      "benchmark_scores": {
+        "humaneval_calibrated": 0.88
+      },
+      "generation": 2
+    }
+  ],
+  "has_improvement": false,
+  "has_regression": true,
+  "improvements": [],
+  "min_delta": 0.0,
+  "parent_child_deltas": [
+    {
+      "average_delta": 0.0,
+      "benchmark_deltas": {
+        "humaneval_calibrated": 0.0
+      },
+      "benchmark_improvements": {},
+      "benchmark_regressions": {},
+      "benchmark_unchanged": [
+        "humaneval_calibrated"
+      ],
+      "child_average_score": 0.92,
+      "child_generation": 1,
+      "child_id": "cd97553c-280c-44d8-8b26-36d002b34ff7",
+      "is_improvement": false,
+      "parent_average_score": 0.92,
+      "parent_generation": 0,
+      "parent_id": "c7e2cbb8-f06f-48d8-a540-22f70e80c848"
+    },
+    {
+      "average_delta": -0.040000000000000036,
+      "benchmark_deltas": {
+        "humaneval_calibrated": -0.040000000000000036
+      },
+      "benchmark_improvements": {},
+      "benchmark_regressions": {
+        "humaneval_calibrated": -0.040000000000000036
+      },
+      "benchmark_unchanged": [],
+      "child_average_score": 0.88,
+      "child_generation": 2,
+      "child_id": "35cd5326-bb34-42ae-b5d7-089c07f4e2d5",
+      "is_improvement": false,
+      "parent_average_score": 0.92,
+      "parent_generation": 1,
+      "parent_id": "cd97553c-280c-44d8-8b26-36d002b34ff7"
+    }
+  ],
+  "top_agent_id": "c7e2cbb8-f06f-48d8-a540-22f70e80c848",
+  "top_score": 0.92,
+  "total_agents": 3,
+  "total_benchmark_improvements": 0,
+  "total_benchmark_regressions": 1,
+  "total_benchmark_unchanged": 1,
+  "valid_agents": 3
+}

--- a/docs/live-runs/model-matrix-2026-06-16/scorecards/kimi-k2-7-code-openrouter-trial-05-scorecard.json
+++ b/docs/live-runs/model-matrix-2026-06-16/scorecards/kimi-k2-7-code-openrouter-trial-05-scorecard.json
@@ -1,0 +1,71 @@
+{
+  "archive_metadata": ".dgm-live-runs/model-matrix-2026-06-16/kimi-k2-7-code-openrouter-trial-05/archive/archive_metadata.json",
+  "best_average_delta": -0.020000000000000018,
+  "generation_best_scores": [
+    {
+      "agent_id": "d7464a56-866b-4121-b3eb-f88bbad45310",
+      "average_score": 0.92,
+      "benchmark_scores": {
+        "humaneval_calibrated": 0.92
+      },
+      "generation": 0
+    },
+    {
+      "agent_id": "fc8f0ba1-c187-40bc-a887-f7235db6f06d",
+      "average_score": 0.9,
+      "benchmark_scores": {
+        "humaneval_calibrated": 0.9
+      },
+      "generation": 1
+    }
+  ],
+  "has_improvement": false,
+  "has_regression": true,
+  "improvements": [],
+  "min_delta": 0.0,
+  "parent_child_deltas": [
+    {
+      "average_delta": -0.92,
+      "benchmark_deltas": {
+        "humaneval_calibrated": -0.92
+      },
+      "benchmark_improvements": {},
+      "benchmark_regressions": {
+        "humaneval_calibrated": -0.92
+      },
+      "benchmark_unchanged": [],
+      "child_average_score": 0.0,
+      "child_generation": 1,
+      "child_id": "4e6c285c-86b0-41af-84ff-8b5bf81008b5",
+      "is_improvement": false,
+      "parent_average_score": 0.92,
+      "parent_generation": 0,
+      "parent_id": "d7464a56-866b-4121-b3eb-f88bbad45310"
+    },
+    {
+      "average_delta": -0.020000000000000018,
+      "benchmark_deltas": {
+        "humaneval_calibrated": -0.020000000000000018
+      },
+      "benchmark_improvements": {},
+      "benchmark_regressions": {
+        "humaneval_calibrated": -0.020000000000000018
+      },
+      "benchmark_unchanged": [],
+      "child_average_score": 0.9,
+      "child_generation": 1,
+      "child_id": "fc8f0ba1-c187-40bc-a887-f7235db6f06d",
+      "is_improvement": false,
+      "parent_average_score": 0.92,
+      "parent_generation": 0,
+      "parent_id": "d7464a56-866b-4121-b3eb-f88bbad45310"
+    }
+  ],
+  "top_agent_id": "d7464a56-866b-4121-b3eb-f88bbad45310",
+  "top_score": 0.92,
+  "total_agents": 3,
+  "total_benchmark_improvements": 0,
+  "total_benchmark_regressions": 2,
+  "total_benchmark_unchanged": 0,
+  "valid_agents": 3
+}

--- a/docs/live-runs/model-matrix-2026-06-16/summary.json
+++ b/docs/live-runs/model-matrix-2026-06-16/summary.json
@@ -1,0 +1,214 @@
+{
+  "audit_count": 10,
+  "audit_dir": ".dgm-sandbox-runs/model-matrix-2026-06-16",
+  "base_live_run_config": "config/live_score_movement.yaml",
+  "benchmark": "humaneval_calibrated",
+  "command": ".venv/bin/python scripts/run_model_matrix.py --execute --allow-network --run-dir .dgm-live-runs/model-matrix-2026-06-16 --audit-dir .dgm-sandbox-runs/model-matrix-2026-06-16 --json",
+  "completed_trials": 10,
+  "estimated_total_cost_usd": 28.1735,
+  "matrix_config": "config/live_model_matrix.yaml",
+  "max_estimated_cost_usd": 30.0,
+  "model_count": 2,
+  "models": [
+    {
+      "api_key_env": "ANTHROPIC_API_KEY",
+      "best_average_deltas": [
+        0.88,
+        0.0,
+        0.0,
+        0.0,
+        0.0
+      ],
+      "estimated_total_cost_usd_per_trial": 4.518,
+      "generations_per_trial": 2,
+      "improvement_trials": [
+        "claude-sonnet-4-6-trial-01"
+      ],
+      "model": "claude-sonnet-4-6",
+      "model_id": "claude-sonnet-4-6",
+      "provider": "anthropic",
+      "regression_trials": [],
+      "success_count": 5,
+      "top_score_max": 0.88,
+      "top_score_mean": 0.88,
+      "top_score_median": 0.88,
+      "top_score_min": 0.88,
+      "top_scores": [
+        0.88,
+        0.88,
+        0.88,
+        0.88,
+        0.88
+      ],
+      "trial_count": 5,
+      "trials": [
+        {
+          "audit": "audits/claude-sonnet-4-6-trial-01-audit.json",
+          "best_average_delta": 0.88,
+          "has_improvement": true,
+          "has_regression": false,
+          "scorecard": "scorecards/claude-sonnet-4-6-trial-01-scorecard.json",
+          "top_score": 0.88,
+          "total_agents": 3,
+          "trial_id": "claude-sonnet-4-6-trial-01",
+          "valid_agents": 3
+        },
+        {
+          "audit": "audits/claude-sonnet-4-6-trial-02-audit.json",
+          "best_average_delta": 0.0,
+          "has_improvement": false,
+          "has_regression": false,
+          "scorecard": "scorecards/claude-sonnet-4-6-trial-02-scorecard.json",
+          "top_score": 0.88,
+          "total_agents": 3,
+          "trial_id": "claude-sonnet-4-6-trial-02",
+          "valid_agents": 3
+        },
+        {
+          "audit": "audits/claude-sonnet-4-6-trial-03-audit.json",
+          "best_average_delta": 0.0,
+          "has_improvement": false,
+          "has_regression": false,
+          "scorecard": "scorecards/claude-sonnet-4-6-trial-03-scorecard.json",
+          "top_score": 0.88,
+          "total_agents": 3,
+          "trial_id": "claude-sonnet-4-6-trial-03",
+          "valid_agents": 3
+        },
+        {
+          "audit": "audits/claude-sonnet-4-6-trial-04-audit.json",
+          "best_average_delta": 0.0,
+          "has_improvement": false,
+          "has_regression": false,
+          "scorecard": "scorecards/claude-sonnet-4-6-trial-04-scorecard.json",
+          "top_score": 0.88,
+          "total_agents": 3,
+          "trial_id": "claude-sonnet-4-6-trial-04",
+          "valid_agents": 3
+        },
+        {
+          "audit": "audits/claude-sonnet-4-6-trial-05-audit.json",
+          "best_average_delta": 0.0,
+          "has_improvement": false,
+          "has_regression": false,
+          "scorecard": "scorecards/claude-sonnet-4-6-trial-05-scorecard.json",
+          "top_score": 0.88,
+          "total_agents": 3,
+          "trial_id": "claude-sonnet-4-6-trial-05",
+          "valid_agents": 3
+        }
+      ]
+    },
+    {
+      "api_key_env": "OPENROUTER_API_KEY",
+      "best_average_deltas": [
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        -0.020000000000000018
+      ],
+      "estimated_total_cost_usd_per_trial": 1.1167,
+      "generations_per_trial": 2,
+      "improvement_trials": [],
+      "model": "moonshotai/kimi-k2.7-code",
+      "model_id": "kimi-k2.7-code-openrouter",
+      "provider": "openai_compatible",
+      "regression_trials": [
+        "kimi-k2-7-code-openrouter-trial-02",
+        "kimi-k2-7-code-openrouter-trial-04",
+        "kimi-k2-7-code-openrouter-trial-05"
+      ],
+      "success_count": 5,
+      "top_score_max": 0.92,
+      "top_score_mean": 0.92,
+      "top_score_median": 0.92,
+      "top_score_min": 0.92,
+      "top_scores": [
+        0.92,
+        0.92,
+        0.92,
+        0.92,
+        0.92
+      ],
+      "trial_count": 5,
+      "trials": [
+        {
+          "audit": "audits/kimi-k2-7-code-openrouter-trial-01-audit.json",
+          "best_average_delta": 0.0,
+          "has_improvement": false,
+          "has_regression": false,
+          "scorecard": "scorecards/kimi-k2-7-code-openrouter-trial-01-scorecard.json",
+          "top_score": 0.92,
+          "total_agents": 3,
+          "trial_id": "kimi-k2-7-code-openrouter-trial-01",
+          "valid_agents": 3
+        },
+        {
+          "audit": "audits/kimi-k2-7-code-openrouter-trial-02-audit.json",
+          "best_average_delta": 0.0,
+          "has_improvement": false,
+          "has_regression": true,
+          "scorecard": "scorecards/kimi-k2-7-code-openrouter-trial-02-scorecard.json",
+          "top_score": 0.92,
+          "total_agents": 3,
+          "trial_id": "kimi-k2-7-code-openrouter-trial-02",
+          "valid_agents": 3
+        },
+        {
+          "audit": "audits/kimi-k2-7-code-openrouter-trial-03-audit.json",
+          "best_average_delta": 0.0,
+          "has_improvement": false,
+          "has_regression": false,
+          "scorecard": "scorecards/kimi-k2-7-code-openrouter-trial-03-scorecard.json",
+          "top_score": 0.92,
+          "total_agents": 3,
+          "trial_id": "kimi-k2-7-code-openrouter-trial-03",
+          "valid_agents": 3
+        },
+        {
+          "audit": "audits/kimi-k2-7-code-openrouter-trial-04-audit.json",
+          "best_average_delta": 0.0,
+          "has_improvement": false,
+          "has_regression": true,
+          "scorecard": "scorecards/kimi-k2-7-code-openrouter-trial-04-scorecard.json",
+          "top_score": 0.92,
+          "total_agents": 3,
+          "trial_id": "kimi-k2-7-code-openrouter-trial-04",
+          "valid_agents": 3
+        },
+        {
+          "audit": "audits/kimi-k2-7-code-openrouter-trial-05-audit.json",
+          "best_average_delta": -0.020000000000000018,
+          "has_improvement": false,
+          "has_regression": true,
+          "scorecard": "scorecards/kimi-k2-7-code-openrouter-trial-05-scorecard.json",
+          "top_score": 0.92,
+          "total_agents": 3,
+          "trial_id": "kimi-k2-7-code-openrouter-trial-05",
+          "valid_agents": 3
+        }
+      ]
+    }
+  ],
+  "openrouter_usage_delta_usd": 0.280637273,
+  "planner_live_calls_performed": 0,
+  "run_date": "2026-06-16",
+  "run_dir": ".dgm-live-runs/model-matrix-2026-06-16",
+  "run_id": "model-matrix-2026-06-16",
+  "scorecard_count": 10,
+  "secret_handling": {
+    "api_key_values_committed": false,
+    "audit_env_names": [
+      "ANTHROPIC_API_KEY",
+      "OPENROUTER_API_KEY"
+    ],
+    "audit_env_values": [
+      "hidden"
+    ]
+  },
+  "status": "executed",
+  "total_request_ceiling": 250,
+  "trial_count": 10,
+  "trials_per_model": 5
+}


### PR DESCRIPTION
## Summary
- add committed live-run evidence for the 2026-06-16 model matrix execution
- include an aggregate summary plus 10 normalized scorecards and 10 redacted sandbox audits
- document the redacted command, cost envelope, OpenRouter usage delta, model results, and scorecard caveats

## Results
- 10/10 live matrix trials completed
- Claude Sonnet 4.6: five trials at top score 0.88, no regression flags
- Kimi K2.7 Code through OpenRouter: five trials at top score 0.92, with regression flags in 3/5 trials
- all sandbox audits record env_values as hidden and include env var names only

## Validation
- .venv/bin/python -m pytest
- .venv/bin/python scripts/verify_demo_path.py
- .venv/bin/python scripts/verify_sandbox_docker.py --require
- .venv/bin/python scripts/run_model_matrix.py --dry-run --json
- secret/path scan over the new docs artifact
