### PR TITLE
[codex] Add no-spend eval matrix gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,10 +53,11 @@ python scripts/verify_demo_path.py
 ```
 
 This checks benchmark loading, the HumanEval-style reference solution, the
-score-movement demo, the committed live-run proof, and the archive-lineage demo
-without API keys or model calls. It also checks that the full-process sandbox
-runner exposes the explicit network, secret pass-through, discard-changes, and
-optional audit-artifact flags used for safer local runs.
+score-movement demo, the no-spend eval-matrix gate, the committed live-run
+proof, and the archive-lineage demo without API keys or model calls. It also
+checks that the full-process sandbox runner exposes the explicit network,
+secret pass-through, discard-changes, and optional audit-artifact flags used for
+safer local runs.
 
 4. **Configure API keys:**
 ```bash

--- a/config/eval_model_matrix.yaml
+++ b/config/eval_model_matrix.yaml
@@ -1,0 +1,38 @@
+# No-spend eval matrix gate for deciding whether a larger live model matrix is
+# worth running. This config uses committed baseline/candidate fixtures only.
+
+purpose: no_spend_eval_model_differentiation
+approval_required: true
+live_calls_performed: 0
+benchmarks_dir: config/benchmarks
+
+gate:
+  min_benchmark_families: 3
+  min_total_eval_cases: 75
+  min_average_delta: 0.35
+  min_delta_per_benchmark: 0.25
+  min_baseline_score: 0.4
+  max_baseline_score: 0.75
+  min_candidate_score: 1.0
+
+benchmarks:
+  - id: humaneval_style
+    family: algorithmic_reasoning
+    baseline_solution: docs/demo/humaneval_style_baseline.py
+    candidate_solution: docs/demo/humaneval_style_improved.py
+    min_eval_cases: 20
+    min_delta: 0.4
+
+  - id: humaneval_headroom
+    family: hidden_case_headroom
+    baseline_solution: docs/demo/humaneval_headroom_baseline.py
+    candidate_solution: docs/demo/humaneval_headroom_improved.py
+    min_eval_cases: 17
+    min_delta: 0.35
+
+  - id: humaneval_calibrated
+    family: calibrated_hidden_cases
+    baseline_solution: docs/demo/humaneval_calibrated_baseline.py
+    candidate_solution: docs/demo/humaneval_calibrated_improved.py
+    min_eval_cases: 50
+    min_delta: 0.3

--- a/config/live_model_matrix.yaml
+++ b/config/live_model_matrix.yaml
@@ -22,6 +22,7 @@ model_matrix:
     audit_dir: .dgm-sandbox-runs/model-matrix
   required_preflight:
     - PATH="$PWD/.venv/bin:$PATH" python scripts/verify_demo_path.py
+    - PATH="$PWD/.venv/bin:$PATH" python scripts/plan_eval_matrix.py --json
     - PATH="$PWD/.venv/bin:$PATH" python scripts/estimate_model_matrix_cost.py --json
     - PATH="$PWD/.venv/bin:$PATH" python scripts/run_model_matrix.py --dry-run --json
   post_run_scorecard_template:

--- a/scripts/estimate_model_matrix_cost.py
+++ b/scripts/estimate_model_matrix_cost.py
@@ -161,6 +161,10 @@ def estimate_model_matrix_cost(
         "Model matrix preflight must include verify_demo_path.py",
     )
     _require(
+        any("scripts/plan_eval_matrix.py" in command for command in preflight),
+        "Model matrix preflight must include the no-spend eval matrix planner",
+    )
+    _require(
         any("scripts/estimate_model_matrix_cost.py" in command for command in preflight),
         "Model matrix preflight must include this estimator",
     )

--- a/scripts/plan_eval_matrix.py
+++ b/scripts/plan_eval_matrix.py
@@ -1,0 +1,267 @@
+#!/usr/bin/env python3
+"""Build a no-network eval matrix gate for future paid model comparisons."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+from pathlib import Path
+from statistics import mean
+from typing import Any
+
+import yaml
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from scripts.compare_benchmark_solutions import compare_solutions
+
+
+class EvalMatrixPlanError(RuntimeError):
+    """Raised when the eval matrix is unsafe or not ready for live spend."""
+
+
+def _require(condition: bool, message: str) -> None:
+    if not condition:
+        raise EvalMatrixPlanError(message)
+
+
+def _load_yaml(path: Path) -> dict[str, Any]:
+    try:
+        data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    except FileNotFoundError as exc:
+        raise EvalMatrixPlanError(f"Missing config: {path}") from exc
+    except yaml.YAMLError as exc:
+        raise EvalMatrixPlanError(f"Invalid YAML in {path}: {exc}") from exc
+    _require(isinstance(data, dict), f"Config must be a mapping: {path}")
+    return data
+
+
+def _project_path(path_text: str | Path, project_root: Path, *, must_be_file: bool) -> Path:
+    path = Path(path_text).expanduser()
+    if not path.is_absolute():
+        path = project_root / path
+    try:
+        relative_path = path.resolve().relative_to(project_root.resolve())
+    except ValueError as exc:
+        raise EvalMatrixPlanError(f"{path_text} must stay inside the project root") from exc
+    path = project_root.resolve() / relative_path
+    if must_be_file:
+        _require(path.is_file(), f"Missing required project file: {relative_path}")
+    return path
+
+
+def _project_relative(path: Path, project_root: Path) -> str:
+    resolved_path = path.resolve()
+    try:
+        return str(resolved_path.relative_to(project_root.resolve()))
+    except ValueError:
+        return str(resolved_path)
+
+
+def _require_no_secret_fields(raw: dict[str, Any], label: str) -> None:
+    forbidden = {"api_key", "secret", "token"}
+    present = forbidden.intersection(raw)
+    _require(not present, f"{label} must not contain secret fields")
+
+
+def _gate_float(gate: dict[str, Any], name: str) -> float:
+    value = float(gate.get(name, 0))
+    _require(value > 0, f"gate.{name} must be greater than zero")
+    return value
+
+
+def _gate_int(gate: dict[str, Any], name: str) -> int:
+    value = int(gate.get(name, 0))
+    _require(value > 0, f"gate.{name} must be greater than zero")
+    return value
+
+
+async def plan_eval_matrix(
+    config_path: Path = PROJECT_ROOT / "config" / "eval_model_matrix.yaml",
+    *,
+    project_root: Path = PROJECT_ROOT,
+) -> dict[str, Any]:
+    """Score local benchmark fixtures and decide whether live matrix spend is justified."""
+    project_root = project_root.resolve()
+    config_path = config_path if config_path.is_absolute() else project_root / config_path
+    config = _load_yaml(config_path)
+
+    _require(
+        config.get("purpose") == "no_spend_eval_model_differentiation",
+        "Eval matrix must declare no_spend_eval_model_differentiation purpose",
+    )
+    _require(config.get("approval_required") is True, "Eval matrix must require approval")
+    _require(config.get("live_calls_performed") == 0, "Eval matrix must perform zero live calls")
+    _require_no_secret_fields(config, "Eval matrix config")
+
+    benchmarks_dir = _project_path(
+        config.get("benchmarks_dir", "config/benchmarks"),
+        project_root,
+        must_be_file=False,
+    )
+    _require(benchmarks_dir.is_dir(), f"Missing benchmarks directory: {benchmarks_dir}")
+
+    gate = config.get("gate", {})
+    _require(isinstance(gate, dict), "gate must be a mapping")
+    min_benchmark_families = _gate_int(gate, "min_benchmark_families")
+    min_total_eval_cases = _gate_int(gate, "min_total_eval_cases")
+    min_average_delta = _gate_float(gate, "min_average_delta")
+    min_delta_per_benchmark = _gate_float(gate, "min_delta_per_benchmark")
+    min_baseline_score = _gate_float(gate, "min_baseline_score")
+    max_baseline_score = _gate_float(gate, "max_baseline_score")
+    min_candidate_score = _gate_float(gate, "min_candidate_score")
+    _require(
+        min_baseline_score < max_baseline_score,
+        "gate.min_baseline_score must be below gate.max_baseline_score",
+    )
+
+    configured_benchmarks = config.get("benchmarks", [])
+    _require(
+        isinstance(configured_benchmarks, list) and configured_benchmarks,
+        "benchmarks must be a non-empty list",
+    )
+
+    benchmark_reports: list[dict[str, Any]] = []
+    for raw in configured_benchmarks:
+        _require(isinstance(raw, dict), "Each benchmark entry must be a mapping")
+        _require(raw.get("id"), "Each benchmark entry must define id")
+        _require(raw.get("family"), f"Benchmark {raw.get('id')} must define family")
+        _require_no_secret_fields(raw, f"Benchmark {raw['id']}")
+
+        baseline_path = _project_path(
+            raw.get("baseline_solution", ""),
+            project_root,
+            must_be_file=True,
+        )
+        candidate_path = _project_path(
+            raw.get("candidate_solution", ""),
+            project_root,
+            must_be_file=True,
+        )
+        min_eval_cases = int(raw.get("min_eval_cases", 0))
+        _require(min_eval_cases > 0, f"Benchmark {raw['id']} must define min_eval_cases")
+        min_delta = float(raw.get("min_delta", min_delta_per_benchmark))
+
+        comparison = await compare_solutions(
+            benchmarks_dir=benchmarks_dir,
+            benchmark_name=str(raw["id"]),
+            baseline_path=baseline_path,
+            candidate_path=candidate_path,
+        )
+        baseline = comparison["baseline"]
+        candidate = comparison["candidate"]
+        delta = comparison["delta"]
+        total = int(candidate["total"])
+        passed_gate = (
+            baseline["score"] >= min_baseline_score
+            and baseline["score"] <= max_baseline_score
+            and candidate["score"] >= min_candidate_score
+            and delta >= min_delta
+            and delta >= min_delta_per_benchmark
+            and total >= min_eval_cases
+        )
+        benchmark_reports.append(
+            {
+                "id": raw["id"],
+                "family": raw["family"],
+                "baseline_solution": _project_relative(baseline_path, project_root),
+                "candidate_solution": _project_relative(candidate_path, project_root),
+                "baseline_score": baseline["score"],
+                "candidate_score": candidate["score"],
+                "delta": delta,
+                "baseline_passed": baseline["passed"],
+                "candidate_passed": candidate["passed"],
+                "total_eval_cases": total,
+                "min_eval_cases": min_eval_cases,
+                "min_delta": min_delta,
+                "passed_gate": passed_gate,
+            }
+        )
+
+    families = sorted({str(item["family"]) for item in benchmark_reports})
+    total_eval_cases = sum(int(item["total_eval_cases"]) for item in benchmark_reports)
+    average_delta = mean(float(item["delta"]) for item in benchmark_reports)
+    all_benchmarks_passed = all(bool(item["passed_gate"]) for item in benchmark_reports)
+    ready_for_live_matrix = (
+        all_benchmarks_passed
+        and len(families) >= min_benchmark_families
+        and total_eval_cases >= min_total_eval_cases
+        and average_delta >= min_average_delta
+    )
+
+    report = {
+        "name": "eval_model_matrix_plan",
+        "status": "ok" if ready_for_live_matrix else "blocked",
+        "config": _project_relative(config_path, project_root),
+        "benchmarks_dir": _project_relative(benchmarks_dir, project_root),
+        "approval_required": True,
+        "live_calls_performed": 0,
+        "benchmark_count": len(benchmark_reports),
+        "benchmark_families": families,
+        "min_benchmark_families": min_benchmark_families,
+        "total_eval_cases": total_eval_cases,
+        "min_total_eval_cases": min_total_eval_cases,
+        "average_delta": average_delta,
+        "min_average_delta": min_average_delta,
+        "all_benchmarks_passed": all_benchmarks_passed,
+        "ready_for_live_matrix": ready_for_live_matrix,
+        "decision": (
+            "prepare_live_matrix_plan"
+            if ready_for_live_matrix
+            else "recalibrate_before_live_spend"
+        ),
+        "benchmarks": benchmark_reports,
+    }
+    _require(ready_for_live_matrix, "Eval matrix is not ready for live model spend")
+    return report
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--config",
+        default=str(PROJECT_ROOT / "config" / "eval_model_matrix.yaml"),
+    )
+    parser.add_argument("--project-root", default=str(PROJECT_ROOT))
+    parser.add_argument("--json", action="store_true", help="Print JSON output.")
+    return parser
+
+
+async def _main_async(args: argparse.Namespace) -> int:
+    try:
+        report = await plan_eval_matrix(
+            Path(args.config),
+            project_root=Path(args.project_root),
+        )
+    except EvalMatrixPlanError as exc:
+        if args.json:
+            print(json.dumps({"status": "failed", "error": str(exc)}, indent=2))
+        else:
+            print(f"[fail] {exc}", file=sys.stderr)
+        return 1
+
+    if args.json:
+        print(json.dumps(report, indent=2, sort_keys=True))
+    else:
+        print(
+            "[ok] eval_model_matrix_plan "
+            f"benchmarks={report['benchmark_count']} "
+            f"families={len(report['benchmark_families'])} "
+            f"cases={report['total_eval_cases']} "
+            f"average_delta={report['average_delta']:.3f} "
+            f"decision={report['decision']}"
+        )
+    return 0
+
+
+def main() -> int:
+    return asyncio.run(_main_async(_build_parser().parse_args()))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/verify_demo_path.py
+++ b/scripts/verify_demo_path.py
@@ -36,6 +36,7 @@ from scripts.run_dgm_in_sandbox import (
     write_run_audit,
 )
 from scripts.verify_live_score_movement_plan import verify_live_score_movement_plan
+from scripts.plan_eval_matrix import plan_eval_matrix
 from scripts.estimate_model_matrix_cost import estimate_model_matrix_cost
 from scripts.run_model_matrix import build_model_matrix_plan
 
@@ -514,6 +515,7 @@ async def verify_demo_path(project_root: Path = PROJECT_ROOT) -> list[dict[str, 
         project_root / "README.md",
         project_root / "requirements.txt",
         project_root / "config" / "dgm_config.yaml",
+        project_root / "config" / "eval_model_matrix.yaml",
         project_root / "config" / "live_model_matrix.yaml",
         project_root / "config" / "live_score_movement.yaml",
         project_root / "config" / "benchmarks" / "humaneval_calibrated.yaml",
@@ -528,6 +530,7 @@ async def verify_demo_path(project_root: Path = PROJECT_ROOT) -> list[dict[str, 
         project_root / "docs" / "demo" / "humaneval_style_baseline.py",
         project_root / "docs" / "demo" / "humaneval_style_improved.py",
         project_root / "docs" / "demo" / "humaneval_score_movement.json",
+        project_root / "scripts" / "plan_eval_matrix.py",
         project_root / "scripts" / "estimate_model_matrix_cost.py",
         project_root / "scripts" / "run_model_matrix.py",
     ]
@@ -544,6 +547,12 @@ async def verify_demo_path(project_root: Path = PROJECT_ROOT) -> list[dict[str, 
     checks.append(
         verify_live_score_movement_plan(
             project_root / "config" / "live_score_movement.yaml",
+            project_root=project_root,
+        )
+    )
+    checks.append(
+        await plan_eval_matrix(
+            project_root / "config" / "eval_model_matrix.yaml",
             project_root=project_root,
         )
     )

--- a/tests/integration/test_demo_path_verifier.py
+++ b/tests/integration/test_demo_path_verifier.py
@@ -21,6 +21,7 @@ async def test_no_network_demo_path_verifier_passes():
     assert "sandbox_runner_cli" in names
     assert "sandbox_discard_changes_contract" in names
     assert "live_score_movement_plan" in names
+    assert "eval_model_matrix_plan" in names
     assert "live_model_matrix_plan" in names
     assert "live_model_matrix_execution_plan" in names
     assert "live_score_movement_attempt_docs" in names
@@ -97,6 +98,23 @@ async def test_no_network_demo_path_verifier_passes():
     assert live_plan_check["request_ceiling"] == 25
     assert live_plan_check["estimated_total_cost_usd"] == pytest.approx(4.518)
     assert live_plan_check["max_estimated_cost_usd"] == 5
+
+    eval_matrix_check = next(
+        check for check in checks if check["name"] == "eval_model_matrix_plan"
+    )
+    assert eval_matrix_check["live_calls_performed"] == 0
+    assert eval_matrix_check["benchmark_count"] == 3
+    assert eval_matrix_check["benchmark_families"] == [
+        "algorithmic_reasoning",
+        "calibrated_hidden_cases",
+        "hidden_case_headroom",
+    ]
+    assert eval_matrix_check["total_eval_cases"] == 87
+    assert eval_matrix_check["average_delta"] == pytest.approx(
+        (0.5 + (7 / 17) + 0.4) / 3
+    )
+    assert eval_matrix_check["ready_for_live_matrix"] is True
+    assert eval_matrix_check["decision"] == "prepare_live_matrix_plan"
 
     matrix_check = next(
         check for check in checks if check["name"] == "live_model_matrix_plan"

--- a/tests/unit/test_estimate_model_matrix_cost.py
+++ b/tests/unit/test_estimate_model_matrix_cost.py
@@ -66,7 +66,7 @@ def test_model_matrix_rejects_live_enabled_config(tmp_path):
 def test_model_matrix_rejects_secret_fields(tmp_path):
     project_root = Path(__file__).resolve().parents[2]
     plan = deepcopy(_load_default_plan(project_root))
-    plan["model_matrix"]["models"][1]["api_key"] = "sk-leaked"
+    plan["model_matrix"]["models"][1]["api_key"] = "placeholder"
     config_path = _write_plan(tmp_path, plan)
 
     with pytest.raises(ModelMatrixPlanError, match="api_key_env"):
@@ -90,6 +90,20 @@ def test_model_matrix_rejects_over_budget(tmp_path):
     config_path = _write_plan(tmp_path, plan)
 
     with pytest.raises(ModelMatrixPlanError, match="budget"):
+        estimate_model_matrix_cost(config_path, project_root=project_root)
+
+
+def test_model_matrix_requires_eval_matrix_preflight(tmp_path):
+    project_root = Path(__file__).resolve().parents[2]
+    plan = deepcopy(_load_default_plan(project_root))
+    plan["model_matrix"]["required_preflight"] = [
+        command
+        for command in plan["model_matrix"]["required_preflight"]
+        if "scripts/plan_eval_matrix.py" not in command
+    ]
+    config_path = _write_plan(tmp_path, plan)
+
+    with pytest.raises(ModelMatrixPlanError, match="eval matrix planner"):
         estimate_model_matrix_cost(config_path, project_root=project_root)
 
 

--- a/tests/unit/test_plan_eval_matrix.py
+++ b/tests/unit/test_plan_eval_matrix.py
@@ -1,0 +1,117 @@
+from copy import deepcopy
+from pathlib import Path
+
+import pytest
+import yaml
+
+from scripts.plan_eval_matrix import (
+    EvalMatrixPlanError,
+    _build_parser,
+    _main_async,
+    plan_eval_matrix,
+)
+
+
+def _load_default_plan(project_root: Path) -> dict:
+    return yaml.safe_load(
+        (project_root / "config" / "eval_model_matrix.yaml").read_text(
+            encoding="utf-8"
+        )
+    )
+
+
+def _write_plan(tmp_path: Path, plan: dict) -> Path:
+    config_path = tmp_path / "eval_model_matrix.yaml"
+    config_path.write_text(yaml.safe_dump(plan, sort_keys=False), encoding="utf-8")
+    return config_path
+
+
+@pytest.mark.asyncio
+async def test_eval_matrix_plan_passes_default_config():
+    project_root = Path(__file__).resolve().parents[2]
+
+    report = await plan_eval_matrix(project_root=project_root)
+
+    assert report["name"] == "eval_model_matrix_plan"
+    assert report["status"] == "ok"
+    assert report["approval_required"] is True
+    assert report["live_calls_performed"] == 0
+    assert report["benchmark_count"] == 3
+    assert report["benchmark_families"] == [
+        "algorithmic_reasoning",
+        "calibrated_hidden_cases",
+        "hidden_case_headroom",
+    ]
+    assert report["total_eval_cases"] == 87
+    assert report["min_total_eval_cases"] == 75
+    assert report["average_delta"] == pytest.approx((0.5 + (7 / 17) + 0.4) / 3)
+    assert report["ready_for_live_matrix"] is True
+    assert report["decision"] == "prepare_live_matrix_plan"
+
+    by_id = {item["id"]: item for item in report["benchmarks"]}
+    assert by_id["humaneval_style"]["baseline_score"] == pytest.approx(0.5)
+    assert by_id["humaneval_style"]["candidate_score"] == 1.0
+    assert by_id["humaneval_style"]["delta"] == pytest.approx(0.5)
+    assert by_id["humaneval_style"]["total_eval_cases"] == 20
+    assert by_id["humaneval_style"]["passed_gate"] is True
+
+    assert by_id["humaneval_headroom"]["baseline_score"] == pytest.approx(10 / 17)
+    assert by_id["humaneval_headroom"]["candidate_score"] == 1.0
+    assert by_id["humaneval_headroom"]["delta"] == pytest.approx(7 / 17)
+    assert by_id["humaneval_headroom"]["total_eval_cases"] == 17
+    assert by_id["humaneval_headroom"]["passed_gate"] is True
+
+    assert by_id["humaneval_calibrated"]["baseline_score"] == pytest.approx(0.6)
+    assert by_id["humaneval_calibrated"]["candidate_score"] == 1.0
+    assert by_id["humaneval_calibrated"]["delta"] == pytest.approx(0.4)
+    assert by_id["humaneval_calibrated"]["total_eval_cases"] == 50
+    assert by_id["humaneval_calibrated"]["passed_gate"] is True
+
+
+@pytest.mark.asyncio
+async def test_eval_matrix_plan_rejects_weak_average_delta(tmp_path):
+    project_root = Path(__file__).resolve().parents[2]
+    plan = deepcopy(_load_default_plan(project_root))
+    plan["gate"]["min_average_delta"] = 0.99
+    config_path = _write_plan(tmp_path, plan)
+
+    with pytest.raises(EvalMatrixPlanError, match="not ready"):
+        await plan_eval_matrix(config_path, project_root=project_root)
+
+
+@pytest.mark.asyncio
+async def test_eval_matrix_plan_rejects_secret_fields(tmp_path):
+    project_root = Path(__file__).resolve().parents[2]
+    plan = deepcopy(_load_default_plan(project_root))
+    plan["benchmarks"][0]["token"] = "placeholder-leaked-token"
+    config_path = _write_plan(tmp_path, plan)
+
+    with pytest.raises(EvalMatrixPlanError, match="secret fields"):
+        await plan_eval_matrix(config_path, project_root=project_root)
+
+
+@pytest.mark.asyncio
+async def test_eval_matrix_plan_cli_json(capsys):
+    args = _build_parser().parse_args(["--json"])
+
+    exit_code = await _main_async(args)
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    assert '"name": "eval_model_matrix_plan"' in captured.out
+    assert '"live_calls_performed": 0' in captured.out
+    assert '"ready_for_live_matrix": true' in captured.out
+
+
+@pytest.mark.asyncio
+async def test_eval_matrix_plan_cli_text(capsys):
+    args = _build_parser().parse_args([])
+
+    exit_code = await _main_async(args)
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    assert "eval_model_matrix_plan" in captured.out
+    assert "benchmarks=3" in captured.out
+    assert "cases=87" in captured.out
+    assert "decision=prepare_live_matrix_plan" in captured.out


### PR DESCRIPTION
## Summary
- add `config/eval_model_matrix.yaml` and `scripts/plan_eval_matrix.py` for a no-network benchmark-family gate before larger paid model matrices
- require the live model matrix preflight to run the eval planner before cost estimation and dry-run materialization
- wire the planner into `scripts/verify_demo_path.py` and cover the pass/fail gates in unit and integration tests

## Why
The last live Claude-vs-Kimi matrix proved multi-provider execution, but it did not prove autonomous improvement readiness. This change makes the next cycle prove local benchmark headroom across multiple eval families before spending more API budget.

## No-spend gate result
- 3 benchmark families
- 87 total eval cases
- average baseline-to-candidate delta: 0.4372549019607843
- decision: `prepare_live_matrix_plan`

## Validation
- `.venv/bin/python -m pytest`
- `.venv/bin/python scripts/verify_demo_path.py`
- `.venv/bin/python scripts/verify_sandbox_docker.py --require`
- `.venv/bin/python scripts/plan_eval_matrix.py --json`
- `.venv/bin/python scripts/run_model_matrix.py --dry-run --json`
- staged secret/path scan
